### PR TITLE
ci: increase goreleaser job timeout to 30 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
     name: GoReleaser
     needs: acceptance-tests
     runs-on: ubuntu-slim
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
The GoReleaser job timed out during the v0.0.1 release because building binaries for all OS/arch targets exceeded the default 15-minute limit.

This adds an explicit `timeout-minutes: 30` to the `goreleaser` job.