### PR TITLE
feat: add enable_oidc attribute to ory_project_config

### DIFF
--- a/docs/resources/project_config.md
+++ b/docs/resources/project_config.md
@@ -53,6 +53,7 @@ resource "ory_project_config" "secure" {
   # Authentication Methods
   enable_password = true
   enable_code     = true
+  enable_oidc     = true # Required for social providers (Google, GitHub, etc.)
   enable_passkey  = true
 
   # Flow Controls
@@ -257,7 +258,7 @@ This resource exposes **60+ attributes** across 11 configuration categories:
 | Password settings | min length, identifier similarity, max breaches, haveibeenpwned |
 | Session settings | cookie same site, lifespan, whoami-required AAL |
 | CORS | public and admin origins, enabled/disabled |
-| Authentication | passwordless, code, TOTP, passkey, WebAuthn, lookup secrets |
+| Authentication | passwordless, code, OIDC (social sign-in), TOTP, passkey, WebAuthn, lookup secrets |
 | Recovery / Verification | enabled, methods, notify unknown recipients |
 | Account enumeration | mitigation enabled |
 | Keto | namespace configuration |
@@ -291,6 +292,7 @@ Some Ory project settings are not yet available through this resource. For setti
 - `default_return_url` (String) Default URL to redirect after flows.
 - `enable_code` (Boolean) Enable code-based authentication.
 - `enable_lookup_secret` (Boolean) Enable backup/recovery codes.
+- `enable_oidc` (Boolean) Enable OIDC (OpenID Connect) social sign-in. Must be enabled for social providers (e.g. Google, GitHub) to work.
 - `enable_passkey` (Boolean) Enable Passkey authentication.
 - `enable_password` (Boolean) Enable password authentication.
 - `enable_recovery` (Boolean) Enable password recovery flow.

--- a/examples/resources/ory_project_config/resource.tf
+++ b/examples/resources/ory_project_config/resource.tf
@@ -30,6 +30,7 @@ resource "ory_project_config" "secure" {
   # Authentication Methods
   enable_password = true
   enable_code     = true
+  enable_oidc     = true # Required for social providers (Google, GitHub, etc.)
   enable_passkey  = true
 
   # Flow Controls

--- a/internal/resources/projectconfig/resource.go
+++ b/internal/resources/projectconfig/resource.go
@@ -77,6 +77,7 @@ type ProjectConfigResourceModel struct {
 	// Auth methods
 	EnablePassword     types.Bool `tfsdk:"enable_password"`
 	EnableCode         types.Bool `tfsdk:"enable_code"`
+	EnableOIDC         types.Bool `tfsdk:"enable_oidc"`
 	EnableTOTP         types.Bool `tfsdk:"enable_totp"`
 	EnableWebAuthn     types.Bool `tfsdk:"enable_webauthn"`
 	EnablePasskey      types.Bool `tfsdk:"enable_passkey"`
@@ -374,6 +375,10 @@ func (r *ProjectConfigResource) Schema(ctx context.Context, req resource.SchemaR
 			},
 			"enable_code": schema.BoolAttribute{
 				Description: "Enable code-based authentication.",
+				Optional:    true,
+			},
+			"enable_oidc": schema.BoolAttribute{
+				Description: "Enable OIDC (OpenID Connect) social sign-in. Must be enabled for social providers (e.g. Google, GitHub) to work.",
 				Optional:    true,
 			},
 			"enable_totp": schema.BoolAttribute{
@@ -807,6 +812,7 @@ func (r *ProjectConfigResource) buildPatches(ctx context.Context, plan *ProjectC
 	methodMappings := map[*types.Bool]string{
 		&plan.EnablePassword:     "/services/identity/config/selfservice/methods/password/enabled",
 		&plan.EnableCode:         "/services/identity/config/selfservice/methods/code/enabled",
+		&plan.EnableOIDC:         "/services/identity/config/selfservice/methods/oidc/enabled",
 		&plan.EnableTOTP:         "/services/identity/config/selfservice/methods/totp/enabled",
 		&plan.EnableWebAuthn:     "/services/identity/config/selfservice/methods/webauthn/enabled",
 		&plan.EnablePasskey:      "/services/identity/config/selfservice/methods/passkey/enabled",
@@ -1343,6 +1349,7 @@ func (r *ProjectConfigResource) readProjectConfig(ctx context.Context, project *
 		methodReadMappings := map[*types.Bool][]string{
 			&state.EnablePassword:     {"selfservice", "methods", "password", "enabled"},
 			&state.EnableCode:         {"selfservice", "methods", "code", "enabled"},
+			&state.EnableOIDC:         {"selfservice", "methods", "oidc", "enabled"},
 			&state.EnableTOTP:         {"selfservice", "methods", "totp", "enabled"},
 			&state.EnableWebAuthn:     {"selfservice", "methods", "webauthn", "enabled"},
 			&state.EnablePasskey:      {"selfservice", "methods", "passkey", "enabled"},

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -58,6 +58,23 @@ func TestAccProjectConfigResource_mfaPolicy(t *testing.T) {
 	})
 }
 
+func TestAccProjectConfigResource_oidc(t *testing.T) {
+	acctest.RequireSocialProviderTests(t)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/oidc.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_project_config.test", "id"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "enable_oidc", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccProjectConfigResource_accountExperience(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccPreCheck(t) },

--- a/internal/resources/projectconfig/testdata/oidc.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/oidc.tf.tmpl
@@ -1,0 +1,3 @@
+resource "ory_project_config" "test" {
+  enable_oidc = true
+}

--- a/templates/resources/project_config.md.tmpl
+++ b/templates/resources/project_config.md.tmpl
@@ -90,7 +90,7 @@ This resource exposes **60+ attributes** across 11 configuration categories:
 | Password settings | min length, identifier similarity, max breaches, haveibeenpwned |
 | Session settings | cookie same site, lifespan, whoami-required AAL |
 | CORS | public and admin origins, enabled/disabled |
-| Authentication | passwordless, code, TOTP, passkey, WebAuthn, lookup secrets |
+| Authentication | passwordless, code, OIDC (social sign-in), TOTP, passkey, WebAuthn, lookup secrets |
 | Recovery / Verification | enabled, methods, notify unknown recipients |
 | Account enumeration | mitigation enabled |
 | Keto | namespace configuration |


### PR DESCRIPTION
## Description

Add `enable_oidc` boolean attribute to the `ory_project_config` resource, mapping to `/services/identity/config/selfservice/methods/oidc/enabled`. Without this setting, social providers configured via `ory_social_provider` do not take effect because the OIDC authentication method remains disabled.

## Related Issues

Fixes #59

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

### Acceptance Tests

- `TestAccProjectConfigResource_oidc` — verifies create/read with `enable_oidc = true`
- All existing `TestAccProjectConfigResource_*` tests continue to pass

### Manual Testing

Verified with a local Terraform configuration against a staging project:

1. `terraform plan` — shows `enable_oidc = true` in the plan
2. `terraform apply` — successfully enables OIDC via the Ory API
3. `terraform plan` (again) — shows "No changes" (drift detection works)
4. Updated to `enable_oidc = false` — successfully disables OIDC
5. `terraform destroy` — clean removal from state

## Screenshots/Output

```
# terraform plan
  + resource "ory_project_config" "main" {
      + enable_oidc         = true
      + id                  = (known after apply)
      + project_id          = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

# terraform apply
ory_project_config.main: Creating...
ory_project_config.main: Creation complete after 2s

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```