### PR TITLE
fix: skip ValidateConfig for ory_action when webhook auth values are unknown

### DIFF
--- a/internal/resources/action/resource.go
+++ b/internal/resources/action/resource.go
@@ -369,29 +369,22 @@ func (r *ActionResource) ValidateConfig(ctx context.Context, req resource.Valida
 		return
 	}
 
-	// When any webhook auth attribute value is unknown (e.g. sourced from a data source like
-	// AWS Secrets Manager), we cannot validate cross-field requirements yet.
-	// Unknown values will become known at apply time, so we defer validation.
-	// See: https://developer.hashicorp.com/terraform/plugin/framework/validation
-	if config.WebhookAuthBasicAuthUser.IsUnknown() ||
-		config.WebhookAuthBasicAuthPassword.IsUnknown() ||
-		config.WebhookAuthAPIKeyName.IsUnknown() ||
-		config.WebhookAuthAPIKeyValue.IsUnknown() ||
-		config.WebhookAuthAPIKeyIn.IsUnknown() {
-		return
-	}
-
+	// Per-field unknown checks: when a value is sourced from a data source (e.g. AWS Secrets
+	// Manager), it is unknown at plan time and will become known at apply time. We skip the
+	// required-field check only for the specific field that is unknown, allowing validation of
+	// other fields that are already known. See:
+	// https://developer.hashicorp.com/terraform/plugin/framework/validation
 	authType := config.WebhookAuthType.ValueString()
 	switch authType {
 	case webhookAuthBasicAuth:
-		if config.WebhookAuthBasicAuthUser.IsNull() {
+		if !config.WebhookAuthBasicAuthUser.IsUnknown() && config.WebhookAuthBasicAuthUser.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("webhook_auth_basic_auth_user"),
 				"Missing Required Attribute",
 				"webhook_auth_basic_auth_user is required when webhook_auth_type is \"basic_auth\".",
 			)
 		}
-		if config.WebhookAuthBasicAuthPassword.IsNull() {
+		if !config.WebhookAuthBasicAuthPassword.IsUnknown() && config.WebhookAuthBasicAuthPassword.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("webhook_auth_basic_auth_password"),
 				"Missing Required Attribute",
@@ -399,21 +392,21 @@ func (r *ActionResource) ValidateConfig(ctx context.Context, req resource.Valida
 			)
 		}
 	case webhookAuthAPIKey:
-		if config.WebhookAuthAPIKeyName.IsNull() {
+		if !config.WebhookAuthAPIKeyName.IsUnknown() && config.WebhookAuthAPIKeyName.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("webhook_auth_api_key_name"),
 				"Missing Required Attribute",
 				"webhook_auth_api_key_name is required when webhook_auth_type is \"api_key\".",
 			)
 		}
-		if config.WebhookAuthAPIKeyValue.IsNull() {
+		if !config.WebhookAuthAPIKeyValue.IsUnknown() && config.WebhookAuthAPIKeyValue.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("webhook_auth_api_key_value"),
 				"Missing Required Attribute",
 				"webhook_auth_api_key_value is required when webhook_auth_type is \"api_key\".",
 			)
 		}
-		if config.WebhookAuthAPIKeyIn.IsNull() {
+		if !config.WebhookAuthAPIKeyIn.IsUnknown() && config.WebhookAuthAPIKeyIn.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("webhook_auth_api_key_in"),
 				"Missing Required Attribute",

--- a/internal/resources/action/validate_config_test.go
+++ b/internal/resources/action/validate_config_test.go
@@ -299,3 +299,50 @@ func TestValidateConfig_BasicAuth_UnknownUser_SkipsValidation(t *testing.T) {
 		t.Errorf("expected no errors for unknown webhook_auth_basic_auth_user, got: %s", resp.Diagnostics.Errors()[0].Detail())
 	}
 }
+
+// TestValidateConfig_APIKey_UnknownValue_NullName_StillFails verifies that when
+// webhook_auth_api_key_value is unknown but webhook_auth_api_key_name is null, the null
+// name is still flagged. Per-field unknown checks allow validation of known fields.
+func TestValidateConfig_APIKey_UnknownValue_NullName_StillFails(t *testing.T) {
+	r := &ActionResource{}
+	ctx := context.Background()
+
+	req := buildActionTestConfig(t, ActionResourceModel{
+		Flow:            types.StringValue("login"),
+		Timing:          types.StringValue("after"),
+		URL:             types.StringValue("https://example.com/webhook"),
+		WebhookAuthType: types.StringValue("api_key"),
+		// WebhookAuthAPIKeyName is null — should still fail even though value is unknown
+		WebhookAuthAPIKeyValue: types.StringUnknown(), // sourced from data source
+		WebhookAuthAPIKeyIn:    types.StringValue("header"),
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Error("expected error for null webhook_auth_api_key_name even when value is unknown, got none")
+	}
+}
+
+// TestValidateConfig_BasicAuth_UnknownPassword_NullUser_StillFails verifies that when
+// webhook_auth_basic_auth_password is unknown but webhook_auth_basic_auth_user is null,
+// the null user is still flagged.
+func TestValidateConfig_BasicAuth_UnknownPassword_NullUser_StillFails(t *testing.T) {
+	r := &ActionResource{}
+	ctx := context.Background()
+
+	req := buildActionTestConfig(t, ActionResourceModel{
+		Flow:            types.StringValue("registration"),
+		Timing:          types.StringValue("after"),
+		URL:             types.StringValue("https://example.com/webhook"),
+		WebhookAuthType: types.StringValue("basic_auth"),
+		// WebhookAuthBasicAuthUser is null — should still fail even though password is unknown
+		WebhookAuthBasicAuthPassword: types.StringUnknown(), // sourced from data source
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Error("expected error for null webhook_auth_basic_auth_user even when password is unknown, got none")
+	}
+}


### PR DESCRIPTION
## Description

`ory_action`'s `ValidateConfig` method rejected unknown values (e.g. from AWS Secrets Manager or other data sources) for webhook authentication attributes, causing a spurious validation error during `terraform plan`:

```
Error: Missing Required Attribute
webhook_auth_api_key_value is required when webhook_auth_type is "api_key".
```

This happened because the validation checked `IsNull() || IsUnknown()` and treated unknown values as missing. Per Terraform Plugin Framework best practices, unknown values should pass validation since they will become known at apply time.

The same bug was previously fixed for `ory_social_provider` in #100. This PR applies the same fix pattern to `ory_action`.

## Related Issues

Fixes #108

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

- [x] Unit tests — 10 new tests in `internal/resources/action/validate_config_test.go` covering:
  - Unknown `webhook_auth_api_key_value`, `webhook_auth_api_key_name`, `webhook_auth_api_key_in` → validation skipped
  - Unknown `webhook_auth_basic_auth_password`, `webhook_auth_basic_auth_user` → validation skipped
  - Known valid configs → pass validation
  - Null required fields → fail validation (existing behaviour preserved)
- [x] Manual testing — confirmed `terraform plan` succeeds when `webhook_auth_api_key_value` is sourced from `terraform_data.output` (unknown at plan time)

## Screenshots/Output

**Before fix** (plan would fail):
```
│ Error: Missing Required Attribute
│ webhook_auth_api_key_value is required when webhook_auth_type is "api_key".
```

**After fix** (plan succeeds):
```
  # ory_action.test will be created
  + resource "ory_action" "test" {
      ...
      + webhook_auth_api_key_value = (sensitive value)
      + webhook_auth_type          = "api_key"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```