### PR TITLE
feat: add code_mfa_enabled support to ory_project_config

### DIFF
--- a/docs/resources/project_config.md
+++ b/docs/resources/project_config.md
@@ -51,10 +51,11 @@ resource "ory_project_config" "secure" {
   password_max_breaches          = 0
 
   # Authentication Methods
-  enable_password = true
-  enable_code     = true
-  enable_oidc     = true # Required for social providers (Google, GitHub, etc.)
-  enable_passkey  = true
+  enable_password  = true
+  enable_code      = true
+  code_mfa_enabled = true # Enable code as a second factor for MFA
+  enable_oidc      = true # Required for social providers (Google, GitHub, etc.)
+  enable_passkey   = true
 
   # Flow Controls
   enable_registration = true
@@ -340,6 +341,7 @@ Some Ory project settings are not yet available through this resource. For setti
 - `account_experience_name` (String) Application name shown in the hosted login UI.
 - `account_experience_stylesheet` (String) Custom CSS stylesheet for the hosted login UI.
 - `allowed_return_urls` (List of String) List of allowed return URLs.
+- `code_mfa_enabled` (Boolean) Enable the code method as a second factor for MFA. When enabled, users can use one-time codes as a second authentication factor.
 - `cors_admin_enabled` (Boolean) Enable CORS for the admin API.
 - `cors_admin_origins` (List of String) Allowed CORS origins for the admin API.
 - `cors_enabled` (Boolean) Enable CORS for the public API.

--- a/examples/resources/ory_project_config/resource.tf
+++ b/examples/resources/ory_project_config/resource.tf
@@ -28,10 +28,11 @@ resource "ory_project_config" "secure" {
   password_max_breaches          = 0
 
   # Authentication Methods
-  enable_password = true
-  enable_code     = true
-  enable_oidc     = true # Required for social providers (Google, GitHub, etc.)
-  enable_passkey  = true
+  enable_password  = true
+  enable_code      = true
+  code_mfa_enabled = true # Enable code as a second factor for MFA
+  enable_oidc      = true # Required for social providers (Google, GitHub, etc.)
+  enable_passkey   = true
 
   # Flow Controls
   enable_registration = true

--- a/internal/resources/projectconfig/resource.go
+++ b/internal/resources/projectconfig/resource.go
@@ -95,6 +95,7 @@ type ProjectConfigResourceModel struct {
 	// Auth methods
 	EnablePassword     types.Bool `tfsdk:"enable_password"`
 	EnableCode         types.Bool `tfsdk:"enable_code"`
+	CodeMFAEnabled     types.Bool `tfsdk:"code_mfa_enabled"`
 	EnableOIDC         types.Bool `tfsdk:"enable_oidc"`
 	EnableTOTP         types.Bool `tfsdk:"enable_totp"`
 	EnableWebAuthn     types.Bool `tfsdk:"enable_webauthn"`
@@ -474,6 +475,11 @@ func (r *ProjectConfigResource) Schema(ctx context.Context, req resource.SchemaR
 			"enable_code": schema.BoolAttribute{
 				Description: "Enable code-based authentication.",
 				Optional:    true,
+			},
+			"code_mfa_enabled": schema.BoolAttribute{
+				Description: "Enable the code method as a second factor for MFA. " +
+					"When enabled, users can use one-time codes as a second authentication factor.",
+				Optional: true,
 			},
 			"enable_oidc": schema.BoolAttribute{
 				Description: "Enable OIDC (OpenID Connect) social sign-in. Must be enabled for social providers (e.g. Google, GitHub) to work.",
@@ -997,6 +1003,7 @@ func (r *ProjectConfigResource) buildPatches(ctx context.Context, plan *ProjectC
 	methodMappings := map[*types.Bool]string{
 		&plan.EnablePassword:     "/services/identity/config/selfservice/methods/password/enabled",
 		&plan.EnableCode:         "/services/identity/config/selfservice/methods/code/enabled",
+		&plan.CodeMFAEnabled:     "/services/identity/config/selfservice/methods/code/mfa_enabled",
 		&plan.EnableOIDC:         "/services/identity/config/selfservice/methods/oidc/enabled",
 		&plan.EnableTOTP:         "/services/identity/config/selfservice/methods/totp/enabled",
 		&plan.EnableWebAuthn:     "/services/identity/config/selfservice/methods/webauthn/enabled",
@@ -1576,6 +1583,7 @@ func (r *ProjectConfigResource) readProjectConfig(ctx context.Context, project *
 		methodReadMappings := map[*types.Bool][]string{
 			&state.EnablePassword:     {"selfservice", "methods", "password", "enabled"},
 			&state.EnableCode:         {"selfservice", "methods", "code", "enabled"},
+			&state.CodeMFAEnabled:     {"selfservice", "methods", "code", "mfa_enabled"},
 			&state.EnableOIDC:         {"selfservice", "methods", "oidc", "enabled"},
 			&state.EnableTOTP:         {"selfservice", "methods", "totp", "enabled"},
 			&state.EnableWebAuthn:     {"selfservice", "methods", "webauthn", "enabled"},

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -159,6 +159,48 @@ func TestAccProjectConfigResource_mfaPolicy(t *testing.T) {
 	})
 }
 
+func TestAccProjectConfigResource_codeMFA(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create with code MFA enabled
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/code_mfa.tf.tmpl", map[string]string{"CodeMFAEnabled": "true"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_project_config.test", "id"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "enable_code", "true"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "code_mfa_enabled", "true"),
+				),
+			},
+			// ImportState
+			{
+				ResourceName:      "ory_project_config.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"enable_code", "code_mfa_enabled",
+					"cors_enabled", "password_min_length",
+					"smtp_connection_uri",
+				},
+			},
+			// Update to disabled
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/code_mfa.tf.tmpl", map[string]string{"CodeMFAEnabled": "false"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "enable_code", "true"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "code_mfa_enabled", "false"),
+				),
+			},
+			// Verify no perpetual diff
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/code_mfa.tf.tmpl", map[string]string{"CodeMFAEnabled": "false"}),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccProjectConfigResource_oidc(t *testing.T) {
 	acctest.RequireSocialProviderTests(t)
 	resource.Test(t, resource.TestCase{

--- a/internal/resources/projectconfig/testdata/code_mfa.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/code_mfa.tf.tmpl
@@ -1,0 +1,4 @@
+resource "ory_project_config" "test" {
+  enable_code     = true
+  code_mfa_enabled = [[ .CodeMFAEnabled ]]
+}


### PR DESCRIPTION
## Description

Add the missing `code_mfa_enabled` attribute to the `ory_project_config` resource, allowing users to configure the code method as a second factor for MFA via Terraform.

## Related Issues

Fixes #122

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

### Changes

- **Model**: Added `CodeMFAEnabled` field (`tfsdk:"code_mfa_enabled"`)
- **Schema**: Added `code_mfa_enabled` boolean attribute with description
- **Write (buildPatches)**: Maps to API path `/services/identity/config/selfservice/methods/code/mfa_enabled`
- **Read (readProjectConfig)**: Reads from `selfservice.methods.code.mfa_enabled`
- **Tests**: Added `TestAccProjectConfigResource_codeMFA` with create, import, update, and no-diff verification steps
- **Examples**: Updated `ory_project_config` example to show `code_mfa_enabled` usage
- **Docs**: Auto-regenerated via `make format`

### Acceptance Test Results

```
=== RUN   TestAccProjectConfigResource_codeMFA
--- PASS: TestAccProjectConfigResource_codeMFA (10.03s)
```

## Usage

```hcl
resource "ory_project_config" "main" {
  enable_code      = true
  code_mfa_enabled = true
}
```