### PR TITLE
feat: support specifying client_id on oauth2 client creation

### DIFF
--- a/docs/resources/oauth2_client.md
+++ b/docs/resources/oauth2_client.md
@@ -15,6 +15,21 @@ OAuth2 clients are used for machine-to-machine authentication or user-facing OAu
 
 ~> **Important:** The `client_secret` is only returned when the client is first created. Store it securely immediately after creation. It cannot be retrieved later, including after `terraform import`.
 
+## Custom Client ID
+
+By default, a random `client_id` is generated when the client is created. You can specify a custom `client_id` for consistency across environments:
+
+```hcl
+resource "ory_oauth2_client" "api" {
+  client_id   = "my-api-client"
+  client_name = "API Client"
+  grant_types = ["client_credentials"]
+  scope       = "read write"
+}
+```
+
+~> **Note:** Changing the `client_id` after creation forces the resource to be destroyed and recreated. The `client_id` must be unique within the project.
+
 ## Example Usage
 
 ```terraform
@@ -139,6 +154,14 @@ resource "ory_oauth2_client" "cli_tool" {
   response_types             = ["code"]
   token_endpoint_auth_method = "none"
   scope                      = "openid offline_access"
+}
+
+# Client with a custom client_id (useful for consistency across environments)
+resource "ory_oauth2_client" "custom_id" {
+  client_id   = "my-api-client"
+  client_name = "API Client with Custom ID"
+  grant_types = ["client_credentials"]
+  scope       = "api:read api:write"
 }
 
 # Same-apply: Create project and OAuth2 client together
@@ -329,6 +352,7 @@ terraform import ory_oauth2_client.api <client-id>
 - `backchannel_logout_session_required` (Boolean) Whether the client requires a session identifier in back-channel logout notifications.
 - `backchannel_logout_uri` (String) OpenID Connect back-channel logout URI.
 - `client_credentials_grant_access_token_lifespan` (String) Access token lifespan for client credentials grant (e.g., '1h', '30m').
+- `client_id` (String) The OAuth2 client ID. If not specified, a random ID will be generated. Once set, changing this value forces recreation of the resource.
 - `client_uri` (String) URL of the client's homepage.
 - `contacts` (List of String) List of contact email addresses for the client maintainers.
 - `device_authorization_grant_access_token_lifespan` (String) Access token lifespan for device authorization grant (e.g., '1h').
@@ -364,6 +388,5 @@ terraform import ory_oauth2_client.api <client-id>
 
 ### Read-Only
 
-- `client_id` (String) The OAuth2 client ID.
 - `client_secret` (String, Sensitive) The OAuth2 client secret. Only returned on creation.
 - `id` (String) Internal Terraform ID (same as client_id).

--- a/examples/resources/ory_oauth2_client/resource.tf
+++ b/examples/resources/ory_oauth2_client/resource.tf
@@ -121,6 +121,14 @@ resource "ory_oauth2_client" "cli_tool" {
   scope                      = "openid offline_access"
 }
 
+# Client with a custom client_id (useful for consistency across environments)
+resource "ory_oauth2_client" "custom_id" {
+  client_id   = "my-api-client"
+  client_name = "API Client with Custom ID"
+  grant_types = ["client_credentials"]
+  scope       = "api:read api:write"
+}
+
 # Same-apply: Create project and OAuth2 client together
 # Use resource-level credentials when the project doesn't exist yet
 resource "ory_oauth2_client" "same_apply" {

--- a/internal/resources/oauth2client/resource.go
+++ b/internal/resources/oauth2client/resource.go
@@ -115,6 +115,14 @@ resource "ory_oauth2_client" "api" {
   token_endpoint_auth_method  = "client_secret_post"
 }
 
+# With a custom client_id
+resource "ory_oauth2_client" "custom" {
+  client_id                   = "my-api-client"
+  client_name                 = "API Client with Custom ID"
+  grant_types                 = ["client_credentials"]
+  scope                       = "read write"
+}
+
 output "client_id" {
   value = ory_oauth2_client.api.client_id
 }
@@ -149,10 +157,12 @@ func (r *OAuth2ClientResource) Schema(ctx context.Context, req resource.SchemaRe
 				},
 			},
 			"client_id": schema.StringAttribute{
-				Description: "The OAuth2 client ID.",
+				Description: "The OAuth2 client ID. If not specified, a random ID will be generated. Once set, changing this value forces recreation of the resource.",
+				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"client_secret": schema.StringAttribute{
@@ -405,6 +415,10 @@ func (r *OAuth2ClientResource) Create(ctx context.Context, req resource.CreateRe
 	oauthClient := ory.OAuth2Client{
 		ClientName: ory.PtrString(plan.ClientName.ValueString()),
 		Scope:      ory.PtrString(plan.Scope.ValueString()),
+	}
+
+	if !plan.ClientID.IsNull() && !plan.ClientID.IsUnknown() {
+		oauthClient.ClientId = ory.PtrString(plan.ClientID.ValueString())
 	}
 
 	if !plan.GrantTypes.IsNull() && !plan.GrantTypes.IsUnknown() {

--- a/internal/resources/oauth2client/resource_test.go
+++ b/internal/resources/oauth2client/resource_test.go
@@ -3,7 +3,9 @@
 package oauth2client_test
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
@@ -222,6 +224,51 @@ func TestAccOAuth2ClientResource_withResourceCredentials(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"client_secret", "project_slug", "project_api_key"},
+			},
+		},
+	})
+}
+
+func TestAccOAuth2ClientResource_withCustomClientID(t *testing.T) {
+	clientID := fmt.Sprintf("tf-acc-test-%d", time.Now().UnixNano())
+
+	acctest.RunTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create with custom client_id
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_custom_client_id.tf.tmpl", map[string]string{
+					"Name":     "Test Client Custom ID",
+					"ClientID": clientID,
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_oauth2_client.test", "client_id", clientID),
+					resource.TestCheckResourceAttr("ory_oauth2_client.test", "id", clientID),
+					resource.TestCheckResourceAttr("ory_oauth2_client.test", "client_name", "Test Client Custom ID"),
+					resource.TestCheckResourceAttr("ory_oauth2_client.test", "scope", "api:read"),
+					resource.TestCheckResourceAttrSet("ory_oauth2_client.test", "client_secret"),
+				),
+			},
+			// ImportState
+			{
+				ResourceName:            "ory_oauth2_client.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"client_secret"},
+			},
+			// Update (change name/scope, client_id stays the same)
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_custom_client_id_updated.tf.tmpl", map[string]string{
+					"Name":     "Test Client Custom ID Updated",
+					"ClientID": clientID,
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_oauth2_client.test", "client_id", clientID),
+					resource.TestCheckResourceAttr("ory_oauth2_client.test", "id", clientID),
+					resource.TestCheckResourceAttr("ory_oauth2_client.test", "client_name", "Test Client Custom ID Updated"),
+					resource.TestCheckResourceAttr("ory_oauth2_client.test", "scope", "api:read api:write"),
+				),
 			},
 		},
 	})

--- a/internal/resources/oauth2client/testdata/with_custom_client_id.tf.tmpl
+++ b/internal/resources/oauth2client/testdata/with_custom_client_id.tf.tmpl
@@ -1,0 +1,8 @@
+resource "ory_oauth2_client" "test" {
+  client_id   = "[[ .ClientID ]]"
+  client_name = "[[ .Name ]]"
+
+  grant_types    = ["client_credentials"]
+  response_types = ["token"]
+  scope          = "api:read"
+}

--- a/internal/resources/oauth2client/testdata/with_custom_client_id_updated.tf.tmpl
+++ b/internal/resources/oauth2client/testdata/with_custom_client_id_updated.tf.tmpl
@@ -1,0 +1,8 @@
+resource "ory_oauth2_client" "test" {
+  client_id   = "[[ .ClientID ]]"
+  client_name = "[[ .Name ]]"
+
+  grant_types    = ["client_credentials"]
+  response_types = ["token"]
+  scope          = "api:read api:write"
+}

--- a/templates/resources/oauth2_client.md.tmpl
+++ b/templates/resources/oauth2_client.md.tmpl
@@ -15,6 +15,21 @@ OAuth2 clients are used for machine-to-machine authentication or user-facing OAu
 
 ~> **Important:** The `client_secret` is only returned when the client is first created. Store it securely immediately after creation. It cannot be retrieved later, including after `terraform import`.
 
+## Custom Client ID
+
+By default, a random `client_id` is generated when the client is created. You can specify a custom `client_id` for consistency across environments:
+
+```hcl
+resource "ory_oauth2_client" "api" {
+  client_id   = "my-api-client"
+  client_name = "API Client"
+  grant_types = ["client_credentials"]
+  scope       = "read write"
+}
+```
+
+~> **Note:** Changing the `client_id` after creation forces the resource to be destroyed and recreated. The `client_id` must be unique within the project.
+
 ## Example Usage
 
 {{ tffile "examples/resources/ory_oauth2_client/resource.tf" }}


### PR DESCRIPTION
## Description

Support specifying a custom `client_id` when creating OAuth2 client resources, matching the Ory API's existing capability. This allows users to maintain consistent naming conventions across environments (e.g., migrating from self-hosted Hydra to Ory Network).

## Related Issues

Fixes #121

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

### Changes

**Schema** (`internal/resources/oauth2client/resource.go`):
- Changed `client_id` attribute from `Computed` to `Optional+Computed`
- Added `RequiresReplace()` plan modifier (changing client_id forces recreation)

**Create** (`internal/resources/oauth2client/resource.go`):
- Pass user-specified `client_id` to the Ory API on creation

**Tests** (`internal/resources/oauth2client/resource_test.go`):
- Added `TestAccOAuth2ClientResource_withCustomClientID` covering create, import, and update with a custom client_id

**Documentation**:
- Updated `templates/resources/oauth2_client.md.tmpl` with Custom Client ID section
- Added example in `examples/resources/ory_oauth2_client/resource.tf`
- Updated inline schema description

### Acceptance Test Results

All 9 OAuth2 client acceptance tests pass:
```
--- PASS: TestAccOAuth2ClientResource_basic (5.45s)
--- PASS: TestAccOAuth2ClientResource_withAudience (3.14s)
--- PASS: TestAccOAuth2ClientResource_withRedirectURIs (3.28s)
--- PASS: TestAccOAuth2ClientResource_withNewFields (3.54s)
--- PASS: TestAccOAuth2ClientResource_withConsentAndSubjectType (3.63s)
--- PASS: TestAccOAuth2ClientResource_withJWKS (5.23s)
--- PASS: TestAccOAuth2ClientResource_withResourceCredentials (3.55s)
--- PASS: TestAccOAuth2ClientResource_withCustomClientID (5.52s)
--- PASS: TestAccOAuth2ClientResource_withTokenLifespans (3.53s)
```

### Security Scans

All pass clean:
- `make sec` (govulncheck, gosec, gitleaks) - 0 issues
- `make sec-trivy` - 0 findings
- `make licenses` - passed