### PR TITLE
fix: resolve identity schema lookup failure during project bootstrap

### DIFF
--- a/docs/data-sources/identity_schema.md
+++ b/docs/data-sources/identity_schema.md
@@ -15,7 +15,7 @@ This data source retrieves a specific identity schema from the project, allowing
 
 ~> **Note:** Ory may assign hash-based IDs to schemas. Use the `ory_identity_schemas` (plural) data source to discover available schema IDs, or use the `id` output from an `ory_identity_schema` resource.
 
-~> **Tip:** Set `project_id` when only a workspace API key is available (e.g., during project bootstrap before `project_slug` and `project_api_key` exist). When project credentials are configured, the Kratos API is preferred automatically as it returns canonical hash-based IDs with full schema content.
+~> **Tip:** Set `project_id` when only a workspace API key is available (e.g., during project bootstrap before `project_slug` and `project_api_key` exist). The provider will automatically create a temporary API key to reach the Kratos API, which returns all workspace-scoped schemas including those not yet added to the new project. When project credentials are configured at the provider level, the Kratos API is preferred automatically.
 
 ## Example Usage
 

--- a/docs/data-sources/identity_schemas.md
+++ b/docs/data-sources/identity_schemas.md
@@ -13,7 +13,7 @@ This data source retrieves all identity schemas configured for the current proje
 
 -> **Plan:** Available on all Ory Network plans.
 
-~> **Tip:** Set `project_id` to list schemas via the console API (workspace key only). This is useful during project bootstrap when `project_slug` and `project_api_key` are not yet available.
+~> **Tip:** Set `project_id` to list schemas during project bootstrap when `project_slug` and `project_api_key` are not yet available. The provider will automatically create a temporary API key to reach the Kratos API, which returns all workspace-scoped schemas including those not yet added to the new project.
 
 ## Example Usage
 
@@ -23,6 +23,18 @@ data "ory_identity_schemas" "all" {}
 
 output "schemas" {
   value = data.ory_identity_schemas.all.schemas
+}
+
+# List all workspace schemas during project bootstrap.
+# When only a workspace API key is configured (no project_slug/project_api_key),
+# set project_id to discover all workspace-scoped schemas for a new project.
+resource "ory_project" "new" {
+  name        = "my-new-project"
+  environment = "dev"
+}
+
+data "ory_identity_schemas" "for_new_project" {
+  project_id = ory_project.new.id
 }
 ```
 

--- a/examples/data-sources/ory_identity_schemas/data-source.tf
+++ b/examples/data-sources/ory_identity_schemas/data-source.tf
@@ -4,3 +4,15 @@ data "ory_identity_schemas" "all" {}
 output "schemas" {
   value = data.ory_identity_schemas.all.schemas
 }
+
+# List all workspace schemas during project bootstrap.
+# When only a workspace API key is configured (no project_slug/project_api_key),
+# set project_id to discover all workspace-scoped schemas for a new project.
+resource "ory_project" "new" {
+  name        = "my-new-project"
+  environment = "dev"
+}
+
+data "ory_identity_schemas" "for_new_project" {
+  project_id = ory_project.new.id
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -497,30 +497,21 @@ func (c *OryClient) ProjectClientForProject(ctx context.Context, projectID strin
 	return c.WithProjectCredentials(slug, apiKey), nil
 }
 
-// ListIdentitySchemasForProject lists identity schemas using the Kratos API
-// for a specific project ID. This is used during project bootstrap when only
-// a workspace API key is available (no project_slug/project_api_key at the
-// provider level).
-//
-// When a project API key is already configured, it is used directly.
-// Otherwise, a temporary project API key is created via the console API,
-// used for the Kratos call, and then deleted. This allows the data source
-// to return all workspace-scoped schemas even for brand-new projects.
+// ListIdentitySchemasForProject lists schemas via the Kratos API for a given project.
+// During bootstrap (no project credentials), a temporary API key is created via the
+// console API, used for the Kratos call, and then deleted.
 func (c *OryClient) ListIdentitySchemasForProject(ctx context.Context, projectID string) ([]ory.IdentitySchemaContainer, error) {
 	slug, err := c.ResolveProjectSlug(ctx, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("resolving project for schema listing: %w", err)
 	}
 
-	// If a project API key is already configured, use it directly.
-	if c.config.ProjectAPIKey != "" {
+	// Project API keys are project-scoped — only reuse if slug matches.
+	if c.config.ProjectAPIKey != "" && c.config.ProjectSlug == slug {
 		tempClient := c.WithProjectCredentials(slug, c.config.ProjectAPIKey)
 		return tempClient.ListIdentitySchemas(ctx)
 	}
 
-	// Bootstrap path: create a temporary project API key via the console API
-	// (which accepts workspace keys), use it to call the Kratos API, then
-	// clean it up.
 	if c.consoleClient == nil {
 		return nil, fmt.Errorf("workspace_api_key is required to list workspace schemas during project bootstrap")
 	}
@@ -532,9 +523,11 @@ func (c *OryClient) ListIdentitySchemasForProject(ctx context.Context, projectID
 		return nil, fmt.Errorf("creating temporary API key for schema listing: %w", err)
 	}
 
-	// Always clean up the temporary key, even if the schema listing fails.
+	// Use a detached context for cleanup so caller cancellation doesn't skip it.
 	defer func() {
-		_ = c.DeleteProjectAPIKey(ctx, projectID, tempKey.GetId())
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = c.DeleteProjectAPIKey(cleanupCtx, projectID, tempKey.GetId())
 	}()
 
 	tempClient := c.WithProjectCredentials(slug, tempKey.GetValue())

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -497,6 +497,50 @@ func (c *OryClient) ProjectClientForProject(ctx context.Context, projectID strin
 	return c.WithProjectCredentials(slug, apiKey), nil
 }
 
+// ListIdentitySchemasForProject lists identity schemas using the Kratos API
+// for a specific project ID. This is used during project bootstrap when only
+// a workspace API key is available (no project_slug/project_api_key at the
+// provider level).
+//
+// When a project API key is already configured, it is used directly.
+// Otherwise, a temporary project API key is created via the console API,
+// used for the Kratos call, and then deleted. This allows the data source
+// to return all workspace-scoped schemas even for brand-new projects.
+func (c *OryClient) ListIdentitySchemasForProject(ctx context.Context, projectID string) ([]ory.IdentitySchemaContainer, error) {
+	slug, err := c.ResolveProjectSlug(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("resolving project for schema listing: %w", err)
+	}
+
+	// If a project API key is already configured, use it directly.
+	if c.config.ProjectAPIKey != "" {
+		tempClient := c.WithProjectCredentials(slug, c.config.ProjectAPIKey)
+		return tempClient.ListIdentitySchemas(ctx)
+	}
+
+	// Bootstrap path: create a temporary project API key via the console API
+	// (which accepts workspace keys), use it to call the Kratos API, then
+	// clean it up.
+	if c.consoleClient == nil {
+		return nil, fmt.Errorf("workspace_api_key is required to list workspace schemas during project bootstrap")
+	}
+
+	tempKey, err := c.CreateProjectAPIKey(ctx, projectID, ory.CreateProjectApiKeyRequest{
+		Name: "terraform-provider-ory-temp-schema-lookup",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating temporary API key for schema listing: %w", err)
+	}
+
+	// Always clean up the temporary key, even if the schema listing fails.
+	defer func() {
+		_ = c.DeleteProjectAPIKey(ctx, projectID, tempKey.GetId())
+	}()
+
+	tempClient := c.WithProjectCredentials(slug, tempKey.GetValue())
+	return tempClient.ListIdentitySchemas(ctx)
+}
+
 // WithProjectCredentials returns a new OryClient that uses the given project
 // credentials. The returned client shares the console client with the parent
 // but has its own isolated project client (lazily initialized).

--- a/internal/datasources/identityschema/datasource.go
+++ b/internal/datasources/identityschema/datasource.go
@@ -140,8 +140,13 @@ func (d *IdentitySchemaDataSource) Read(ctx context.Context, req datasource.Read
 	// config, which only contains schemas explicitly added to that project and
 	// may return empty schema bodies when the API has transformed schema URLs
 	// from base64:// to https://.
+	//
+	// During project bootstrap (workspace key only, no project_slug/project_api_key),
+	// we can still reach the Kratos API by resolving the project slug from the
+	// project_id and using the workspace API key as the bearer token.
 	canUseKratosAPI := d.client.HasProjectClient()
 	canUseConsoleAPI := d.client.HasConsoleClient() && projectID != ""
+	canBootstrapKratosAPI := !canUseKratosAPI && canUseConsoleAPI
 
 	if !canUseKratosAPI && !canUseConsoleAPI {
 		resp.Diagnostics.AddError("Missing Project ID",
@@ -174,7 +179,25 @@ func (d *IdentitySchemaDataSource) Read(ctx context.Context, req datasource.Read
 			}
 		}
 
-		// Strategy 2: Try console API (works for any project, fallback for Kratos failures).
+		// Strategy 2: Bootstrap Kratos API via project_id (workspace key only).
+		// Resolves the project slug from project_id and uses the workspace API key
+		// to call the Kratos API, which returns all workspace-scoped schemas.
+		if canBootstrapKratosAPI && found == nil {
+			schemas, err := d.client.ListIdentitySchemasForProject(ctx, projectID)
+			if err == nil {
+				allSchemas = schemas
+				for i := range schemas {
+					if schemas[i].GetId() == targetID {
+						found = &schemas[i]
+						break
+					}
+				}
+			}
+			// If bootstrap Kratos failed, fall through to console API below.
+		}
+
+		// Strategy 3: Try console API (reads from project config — limited to schemas
+		// already added to this project).
 		if canUseConsoleAPI && found == nil {
 			schemas, err := d.client.ListIdentitySchemasViaProject(ctx, projectID)
 			if err != nil {

--- a/internal/datasources/identityschema/datasource.go
+++ b/internal/datasources/identityschema/datasource.go
@@ -129,21 +129,8 @@ func (d *IdentitySchemaDataSource) Read(ctx context.Context, req datasource.Read
 	// Resolve project_id: use config value if known, fall back to provider.
 	projectID := d.resolveProjectID(data.ProjectID)
 
-	// Determine which APIs are available for this lookup.
-	//
-	// Identity schemas are workspace-scoped: any project in the workspace can
-	// access all schemas. The Kratos API (ListIdentitySchemas) returns canonical
-	// hash-based IDs with full schema content and works regardless of which
-	// project_id is specified, so we always prefer it when available.
-	//
-	// The console API (ListIdentitySchemasViaProject) reads from the project
-	// config, which only contains schemas explicitly added to that project and
-	// may return empty schema bodies when the API has transformed schema URLs
-	// from base64:// to https://.
-	//
-	// During project bootstrap (workspace key only, no project_slug/project_api_key),
-	// we can still reach the Kratos API by resolving the project slug from the
-	// project_id and using the workspace API key as the bearer token.
+	// Prefer Kratos API (canonical IDs, full content); fall back to console API.
+	// Bootstrap path (workspace key only): use ListIdentitySchemasForProject.
 	canUseKratosAPI := d.client.HasProjectClient()
 	canUseConsoleAPI := d.client.HasConsoleClient() && projectID != ""
 	canBootstrapKratosAPI := !canUseKratosAPI && canUseConsoleAPI
@@ -159,7 +146,7 @@ func (d *IdentitySchemaDataSource) Read(ctx context.Context, req datasource.Read
 	var found *ory.IdentitySchemaContainer
 
 	for attempt := 0; attempt < helpers.ReadRetryMaxAttempts; attempt++ {
-		// Strategy 1: Try Kratos API (preferred — canonical hash IDs + full content).
+		// Strategy 1: Kratos API (preferred — canonical IDs, full content).
 		if canUseKratosAPI && found == nil {
 			schemas, err := d.client.ListIdentitySchemas(ctx)
 			if err != nil {
@@ -167,7 +154,6 @@ func (d *IdentitySchemaDataSource) Read(ctx context.Context, req datasource.Read
 					resp.Diagnostics.AddError("Error Listing Identity Schemas", err.Error())
 					return
 				}
-				// Kratos API failed but console API is available — continue to fallback.
 			} else {
 				allSchemas = schemas
 				for i := range schemas {
@@ -179,9 +165,7 @@ func (d *IdentitySchemaDataSource) Read(ctx context.Context, req datasource.Read
 			}
 		}
 
-		// Strategy 2: Bootstrap Kratos API via project_id (workspace key only).
-		// Resolves the project slug from project_id and uses the workspace API key
-		// to call the Kratos API, which returns all workspace-scoped schemas.
+		// Strategy 2: bootstrap — create a temp key to reach the Kratos API.
 		if canBootstrapKratosAPI && found == nil {
 			schemas, err := d.client.ListIdentitySchemasForProject(ctx, projectID)
 			if err == nil {
@@ -193,11 +177,9 @@ func (d *IdentitySchemaDataSource) Read(ctx context.Context, req datasource.Read
 					}
 				}
 			}
-			// If bootstrap Kratos failed, fall through to console API below.
 		}
 
-		// Strategy 3: Try console API (reads from project config — limited to schemas
-		// already added to this project).
+		// Strategy 3: console API (project config only, limited schema set).
 		if canUseConsoleAPI && found == nil {
 			schemas, err := d.client.ListIdentitySchemasViaProject(ctx, projectID)
 			if err != nil {
@@ -205,7 +187,6 @@ func (d *IdentitySchemaDataSource) Read(ctx context.Context, req datasource.Read
 					resp.Diagnostics.AddError("Error Listing Identity Schemas", err.Error())
 					return
 				}
-				// Console API failed but we already have Kratos results — schema just isn't there.
 			} else {
 				if len(allSchemas) == 0 {
 					allSchemas = schemas

--- a/internal/datasources/identityschema/datasource_test.go
+++ b/internal/datasources/identityschema/datasource_test.go
@@ -74,6 +74,45 @@ func TestAccIdentitySchemaDataSource_viaProjectID(t *testing.T) {
 	})
 }
 
+// TestAccIdentitySchemaDataSource_bootstrapProject tests the bootstrap scenario
+// where a brand-new project is created and an existing workspace-level schema is
+// looked up via project_id. This exercises the code path that creates a temporary
+// API key to call the Kratos API when no project credentials are configured.
+func TestAccIdentitySchemaDataSource_bootstrapProject(t *testing.T) {
+	suffix := time.Now().UnixNano()
+	schemaID := fmt.Sprintf("tf-test-ds-bootstrap-%d", suffix)
+	projectName := fmt.Sprintf("%s-bootstrap-%d", acctest.TestProjectPrefix, suffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.AccPreCheck(t)
+			acctest.RequireSchemaTests(t)
+			acctest.RequireProjectTests(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/bootstrap_project.tf.tmpl", map[string]string{
+					"SchemaID":    schemaID,
+					"AppURL":      testutil.ExampleAppURL,
+					"ProjectName": projectName,
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// The data source found the schema via the bootstrap project
+					resource.TestCheckResourceAttrPair(
+						"data.ory_identity_schema.via_bootstrap", "id",
+						"ory_identity_schema.seed", "id",
+					),
+					// Schema content is not empty
+					resource.TestCheckResourceAttrSet("data.ory_identity_schema.via_bootstrap", "schema"),
+					// project_id is set on the data source
+					resource.TestCheckResourceAttrSet("data.ory_identity_schema.via_bootstrap", "project_id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIdentitySchemaDataSource_viaProjectIDContentMatch(t *testing.T) {
 	suffix := time.Now().UnixNano()
 	schemaID := fmt.Sprintf("tf-test-ds-content-%d", suffix)

--- a/internal/datasources/identityschema/testdata/bootstrap_project.tf.tmpl
+++ b/internal/datasources/identityschema/testdata/bootstrap_project.tf.tmpl
@@ -1,0 +1,46 @@
+# First create a schema in the shared test project so it exists in the workspace.
+resource "ory_identity_schema" "seed" {
+  schema_id = "[[ .SchemaID ]]"
+  schema    = jsonencode({
+    "$id": "[[ .AppURL ]]/test-bootstrap-schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Bootstrap Test Schema",
+    "type": "object",
+    "properties": {
+      "traits": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email",
+            "ory.sh/kratos": {
+              "credentials": {
+                "password": {"identifier": true}
+              },
+              "verification": {"via": "email"},
+              "recovery": {"via": "email"}
+            }
+          }
+        },
+        "required": ["email"]
+      }
+    }
+  })
+}
+
+# Create a brand-new project (simulates bootstrap scenario).
+resource "ory_project" "bootstrap" {
+  name        = "[[ .ProjectName ]]"
+  environment = "dev"
+}
+
+# Look up the schema via the new project's project_id.
+# This exercises the bootstrap path: no project_slug/project_api_key at the
+# provider level for this project, only the workspace key + project_id.
+data "ory_identity_schema" "via_bootstrap" {
+  id         = ory_identity_schema.seed.id
+  project_id = ory_project.bootstrap.id
+
+  depends_on = [ory_identity_schema.seed]
+}

--- a/internal/datasources/identityschemas/datasource.go
+++ b/internal/datasources/identityschemas/datasource.go
@@ -90,9 +90,7 @@ func (d *IdentitySchemasDataSource) Read(ctx context.Context, req datasource.Rea
 	// Resolve project_id: use config value if known, fall back to provider.
 	projectID := d.resolveProjectID(data.ProjectID)
 
-	// Determine which APIs are available for this lookup.
-	// Identity schemas are workspace-scoped — see identityschema (singular)
-	// data source for detailed rationale on API selection.
+	// Prefer Kratos API (canonical IDs, full content); fall back to console API.
 	canUseKratosAPI := d.client.HasProjectClient()
 	canUseConsoleAPI := d.client.HasConsoleClient() && projectID != ""
 	canBootstrapKratosAPI := !canUseKratosAPI && canUseConsoleAPI
@@ -107,19 +105,14 @@ func (d *IdentitySchemasDataSource) Read(ctx context.Context, req datasource.Rea
 	var schemas []ory.IdentitySchemaContainer
 	var err error
 	for attempt := 0; attempt < helpers.ReadRetryMaxAttempts; attempt++ {
-		// Prefer Kratos API (canonical IDs + full content) when available.
 		if canUseKratosAPI {
 			schemas, err = d.client.ListIdentitySchemas(ctx)
 			if err != nil && canUseConsoleAPI {
-				// Kratos API failed — try console API as fallback.
 				schemas, err = d.client.ListIdentitySchemasViaProject(ctx, projectID)
 			}
 		} else if canBootstrapKratosAPI {
-			// Bootstrap path: resolve slug from project_id, create a temp API key,
-			// and call the Kratos API to get all workspace-scoped schemas.
 			schemas, err = d.client.ListIdentitySchemasForProject(ctx, projectID)
 			if err != nil {
-				// If bootstrap Kratos failed, fall back to console API (project config only).
 				schemas, err = d.client.ListIdentitySchemasViaProject(ctx, projectID)
 			}
 		} else {

--- a/internal/datasources/identityschemas/datasource.go
+++ b/internal/datasources/identityschemas/datasource.go
@@ -95,6 +95,7 @@ func (d *IdentitySchemasDataSource) Read(ctx context.Context, req datasource.Rea
 	// data source for detailed rationale on API selection.
 	canUseKratosAPI := d.client.HasProjectClient()
 	canUseConsoleAPI := d.client.HasConsoleClient() && projectID != ""
+	canBootstrapKratosAPI := !canUseKratosAPI && canUseConsoleAPI
 
 	if !canUseKratosAPI && !canUseConsoleAPI {
 		resp.Diagnostics.AddError("Missing Project ID",
@@ -107,11 +108,18 @@ func (d *IdentitySchemasDataSource) Read(ctx context.Context, req datasource.Rea
 	var err error
 	for attempt := 0; attempt < helpers.ReadRetryMaxAttempts; attempt++ {
 		// Prefer Kratos API (canonical IDs + full content) when available.
-		// Fall back to console API if Kratos fails and console is available.
 		if canUseKratosAPI {
 			schemas, err = d.client.ListIdentitySchemas(ctx)
 			if err != nil && canUseConsoleAPI {
 				// Kratos API failed — try console API as fallback.
+				schemas, err = d.client.ListIdentitySchemasViaProject(ctx, projectID)
+			}
+		} else if canBootstrapKratosAPI {
+			// Bootstrap path: resolve slug from project_id, create a temp API key,
+			// and call the Kratos API to get all workspace-scoped schemas.
+			schemas, err = d.client.ListIdentitySchemasForProject(ctx, projectID)
+			if err != nil {
+				// If bootstrap Kratos failed, fall back to console API (project config only).
 				schemas, err = d.client.ListIdentitySchemasViaProject(ctx, projectID)
 			}
 		} else {

--- a/internal/datasources/identityschemas/datasource_test.go
+++ b/internal/datasources/identityschemas/datasource_test.go
@@ -13,6 +13,14 @@ import (
 	"github.com/ory/terraform-provider-ory/internal/testutil"
 )
 
+// checkSchemasNonEmpty returns an error if the schemas list is empty.
+func checkSchemasNonEmpty(value string) error {
+	if value == "0" {
+		return fmt.Errorf("expected at least one schema to be returned, got 0")
+	}
+	return nil
+}
+
 func TestAccIdentitySchemasDataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccPreCheck(t) },
@@ -52,8 +60,12 @@ func TestAccIdentitySchemasDataSource_bootstrapProject(t *testing.T) {
 					"ProjectName": projectName,
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					// The data source returns schemas (should include workspace-scoped ones)
-					resource.TestCheckResourceAttrSet("data.ory_identity_schemas.via_bootstrap", "schemas.#"),
+					// The bootstrap path must return at least one schema — new projects
+					// would have none if the temp-key Kratos path is broken.
+					resource.TestCheckResourceAttrWith(
+						"data.ory_identity_schemas.via_bootstrap", "schemas.#",
+						checkSchemasNonEmpty,
+					),
 					// project_id is set
 					resource.TestCheckResourceAttrSet("data.ory_identity_schemas.via_bootstrap", "project_id"),
 				),

--- a/internal/datasources/identityschemas/datasource_test.go
+++ b/internal/datasources/identityschemas/datasource_test.go
@@ -28,6 +28,40 @@ func TestAccIdentitySchemasDataSource_basic(t *testing.T) {
 	})
 }
 
+// TestAccIdentitySchemasDataSource_bootstrapProject tests the bootstrap scenario
+// where a brand-new project is created and workspace-level schemas are listed
+// via project_id. This exercises the code path that creates a temporary API key
+// to call the Kratos API when no project credentials are configured.
+func TestAccIdentitySchemasDataSource_bootstrapProject(t *testing.T) {
+	suffix := time.Now().UnixNano()
+	schemaID := fmt.Sprintf("tf-test-ds-list-bootstrap-%d", suffix)
+	projectName := fmt.Sprintf("%s-bootstrap-list-%d", acctest.TestProjectPrefix, suffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.AccPreCheck(t)
+			acctest.RequireSchemaTests(t)
+			acctest.RequireProjectTests(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/bootstrap_project.tf.tmpl", map[string]string{
+					"SchemaID":    schemaID,
+					"AppURL":      testutil.ExampleAppURL,
+					"ProjectName": projectName,
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// The data source returns schemas (should include workspace-scoped ones)
+					resource.TestCheckResourceAttrSet("data.ory_identity_schemas.via_bootstrap", "schemas.#"),
+					// project_id is set
+					resource.TestCheckResourceAttrSet("data.ory_identity_schemas.via_bootstrap", "project_id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIdentitySchemasDataSource_viaProjectID(t *testing.T) {
 	suffix := time.Now().UnixNano()
 	schemaID := fmt.Sprintf("tf-test-ds-list-%d", suffix)

--- a/internal/datasources/identityschemas/testdata/bootstrap_project.tf.tmpl
+++ b/internal/datasources/identityschemas/testdata/bootstrap_project.tf.tmpl
@@ -1,0 +1,45 @@
+# Create a schema in the shared test project so the workspace has custom schemas.
+resource "ory_identity_schema" "seed" {
+  schema_id = "[[ .SchemaID ]]"
+  schema    = jsonencode({
+    "$id": "[[ .AppURL ]]/test-bootstrap-list-schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Bootstrap List Test Schema",
+    "type": "object",
+    "properties": {
+      "traits": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email",
+            "ory.sh/kratos": {
+              "credentials": {
+                "password": {"identifier": true}
+              },
+              "verification": {"via": "email"},
+              "recovery": {"via": "email"}
+            }
+          }
+        },
+        "required": ["email"]
+      }
+    }
+  })
+}
+
+# Create a brand-new project (simulates bootstrap scenario).
+resource "ory_project" "bootstrap" {
+  name        = "[[ .ProjectName ]]"
+  environment = "dev"
+}
+
+# List all schemas via the new project's project_id.
+# This exercises the bootstrap path where the provider uses a temporary API key
+# to reach the Kratos API and return all workspace-scoped schemas.
+data "ory_identity_schemas" "via_bootstrap" {
+  project_id = ory_project.bootstrap.id
+
+  depends_on = [ory_identity_schema.seed]
+}

--- a/templates/data-sources/identity_schema.md.tmpl
+++ b/templates/data-sources/identity_schema.md.tmpl
@@ -15,7 +15,7 @@ This data source retrieves a specific identity schema from the project, allowing
 
 ~> **Note:** Ory may assign hash-based IDs to schemas. Use the `ory_identity_schemas` (plural) data source to discover available schema IDs, or use the `id` output from an `ory_identity_schema` resource.
 
-~> **Tip:** Set `project_id` when only a workspace API key is available (e.g., during project bootstrap before `project_slug` and `project_api_key` exist). When project credentials are configured, the Kratos API is preferred automatically as it returns canonical hash-based IDs with full schema content.
+~> **Tip:** Set `project_id` when only a workspace API key is available (e.g., during project bootstrap before `project_slug` and `project_api_key` exist). The provider will automatically create a temporary API key to reach the Kratos API, which returns all workspace-scoped schemas including those not yet added to the new project. When project credentials are configured at the provider level, the Kratos API is preferred automatically.
 
 ## Example Usage
 

--- a/templates/data-sources/identity_schemas.md.tmpl
+++ b/templates/data-sources/identity_schemas.md.tmpl
@@ -13,7 +13,7 @@ This data source retrieves all identity schemas configured for the current proje
 
 -> **Plan:** Available on all Ory Network plans.
 
-~> **Tip:** Set `project_id` to list schemas via the console API (workspace key only). This is useful during project bootstrap when `project_slug` and `project_api_key` are not yet available.
+~> **Tip:** Set `project_id` to list schemas during project bootstrap when `project_slug` and `project_api_key` are not yet available. The provider will automatically create a temporary API key to reach the Kratos API, which returns all workspace-scoped schemas including those not yet added to the new project.
 
 ## Example Usage
 


### PR DESCRIPTION
## Description

When creating a brand-new project via Terraform and immediately looking up workspace-scoped identity schemas by hash ID, the `ory_identity_schema` and `ory_identity_schemas` data sources fail to find the schema. This happens because during project bootstrap only a workspace API key is available (no `project_slug`/`project_api_key`), and the console API's `GetProject` endpoint only returns schemas explicitly added to the project config. New projects only have `preset://username`.

This adds a bootstrap path (`ListIdentitySchemasForProject`) that:
1. Resolves the project slug from `project_id` via the console API
2. Creates a temporary project API key via the console API (which accepts workspace keys)
3. Uses the temp key to call the Kratos API (which returns all workspace-scoped schemas)
4. Cleans up the temporary key via `defer` (even on error)

This fixes the gap in #117 where `project_id` support only worked when project credentials were already configured at the provider level.

## Related Issues

Fixes #138

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

- [ ] Unit tests
- [x] Acceptance tests
- [x] Manual testing

### Changes

**`internal/client/client.go`**
- Added `ListIdentitySchemasForProject()` method that handles the bootstrap path
- Added `WithProjectCredentials()` for creating isolated child clients with different credentials

**`internal/datasources/identityschema/datasource.go`**
- Added Strategy 2 (bootstrap Kratos API) between existing Strategy 1 (direct Kratos) and Strategy 3 (console API)
- Uses `canBootstrapKratosAPI` flag when provider has no project credentials but has console access

**`internal/datasources/identityschemas/datasource.go`**
- Same bootstrap path added for the plural data source

**Acceptance tests**
- `TestAccIdentitySchemaDataSource_bootstrapProject` - creates a new project, seeds a schema, looks it up via the bootstrap path
- `TestAccIdentitySchemasDataSource_bootstrapProject` - same for the plural data source

**Documentation**
- Updated templates and examples to document the bootstrap scenario and temporary API key behavior

### Manual test scenario

```hcl
resource "ory_project" "new" {
  name        = "my-new-project"
  environment = "dev"
}

data "ory_identity_schema" "existing" {
  id         = "d4581d88...full-hash-id"
  project_id = ory_project.new.id
}

resource "ory_identity_schema" "default" {
  schema_id   = "customer"
  project_id  = ory_project.new.id
  schema      = data.ory_identity_schema.existing.schema
  set_default = true
}
```

This config now works with only `ORY_WORKSPACE_API_KEY` configured (no `project_slug`/`project_api_key` needed).