### PR TITLE
fix: add explicit permissions to workflows missing GITHUB_TOKEN restrictions

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -6,6 +6,9 @@ on:
     # https://crontab.guru/#0_8,11,14,17_*_*_*
     - cron: '0 8,11,14,17 * * *'
 
+permissions:
+  contents: read
+
 concurrency:
   group: renovate-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -53,6 +53,9 @@ on:
       ORY_CUSTOM_DOMAIN_COOKIE_DOMAIN:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   acceptance-test:
     name: Acceptance Tests


### PR DESCRIPTION
## Description

Add explicit `permissions: contents: read` blocks to the two workflows flagged by CodeQL for missing workflow permissions (CWE-275):

- `.github/workflows/renovate.yaml` — [Code scanning alert #1](https://github.com/ory/terraform-provider-ory/security/code-scanning/1)
- `.github/workflows/run-acceptance-tests.yml` — [Code scanning alert #2](https://github.com/ory/terraform-provider-ory/security/code-scanning/2)

Without explicit permissions, these workflows inherit the repository/organization default token permissions, which may be broader than necessary. This change restricts the `GITHUB_TOKEN` to read-only `contents` access, following the principle of least privilege.

## Related Issues

Fixes https://github.com/ory/terraform-provider-ory/security/code-scanning/1
Fixes https://github.com/ory/terraform-provider-ory/security/code-scanning/2

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [ ] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

- [ ] Unit tests
- [ ] Acceptance tests
- [x] Manual testing

Verified that all other workflow files in the repository already have explicit `permissions` blocks. These two were the only ones missing them.

## Screenshots/Output

N/A - workflow YAML changes only.