### PR TITLE
feat: add oidc_base_redirect_uri to ory_project_config resource

### DIFF
--- a/docs/resources/project_config.md
+++ b/docs/resources/project_config.md
@@ -53,9 +53,10 @@ resource "ory_project_config" "secure" {
   # Authentication Methods
   enable_password              = true
   enable_code                  = true
-  code_mfa_enabled             = true # Enable code as a second factor for MFA
-  enable_oidc                  = true # Required for social providers (Google, GitHub, etc.)
-  enable_oidc_auto_link_policy = true # Allow social providers with auto_link = true to link to existing identities
+  code_mfa_enabled             = true                      # Enable code as a second factor for MFA
+  enable_oidc                  = true                      # Required for social providers (Google, GitHub, etc.)
+  enable_oidc_auto_link_policy = true                      # Allow social providers with auto_link = true to link to existing identities
+  oidc_base_redirect_uri       = "https://iam.example.com" # Custom domain for OIDC callback URLs
   enable_passkey               = true
   enable_profile               = true # Allow users to update profile traits via settings flow
 
@@ -331,7 +332,7 @@ This resource exposes **75+ attributes** across these configuration categories:
 | Session settings | cookie same site, lifespan, whoami-required AAL |
 | CORS | public and admin origins, enabled/disabled |
 | Login flow | login style (unified, identifier_first) |
-| Authentication | passwordless, code, profile, OIDC (social sign-in), OIDC auto-link policy, TOTP, passkey, WebAuthn, lookup secrets |
+| Authentication | passwordless, code, profile, OIDC (social sign-in), OIDC auto-link policy, OIDC base redirect URI, TOTP, passkey, WebAuthn, lookup secrets |
 | Code method | lifespan, max submissions, missing credential fallback |
 | OAuth2/Hydra | token lifespans, access token strategy, PKCE, claims, scope strategy, consent/login URLs |
 | Settings flow | lifespan, privileged session max age, required AAL |
@@ -406,6 +407,7 @@ Some Ory project settings are not yet available through this resource. For setti
 - `oauth2_refresh_token_lifespan` (String) OAuth2 refresh token lifespan (e.g., '720h' for 30 days). Requires Hydra service.
 - `oauth2_scope_strategy` (String) OAuth2 scope matching strategy ('exact', 'wildcard').
 - `oauth2_session_encrypt_at_rest` (Boolean) Encrypt OAuth2 sessions at rest.
+- `oidc_base_redirect_uri` (String) Override the base redirect URI for OIDC callbacks (e.g., "https://iam.example.com"). When set, Ory constructs callback URLs using this base instead of the default project domain. This is useful when your project uses a custom domain for authentication flows. This is also configurable via the ory_social_provider resource's base_redirect_uri attribute.
 - `password_check_haveibeenpwned` (Boolean) Check passwords against HaveIBeenPwned.
 - `password_identifier_similarity` (Boolean) Check password similarity to identifier.
 - `password_max_breaches` (Number) Maximum allowed breaches in HaveIBeenPwned.

--- a/examples/resources/ory_project_config/resource.tf
+++ b/examples/resources/ory_project_config/resource.tf
@@ -30,9 +30,10 @@ resource "ory_project_config" "secure" {
   # Authentication Methods
   enable_password              = true
   enable_code                  = true
-  code_mfa_enabled             = true # Enable code as a second factor for MFA
-  enable_oidc                  = true # Required for social providers (Google, GitHub, etc.)
-  enable_oidc_auto_link_policy = true # Allow social providers with auto_link = true to link to existing identities
+  code_mfa_enabled             = true                      # Enable code as a second factor for MFA
+  enable_oidc                  = true                      # Required for social providers (Google, GitHub, etc.)
+  enable_oidc_auto_link_policy = true                      # Allow social providers with auto_link = true to link to existing identities
+  oidc_base_redirect_uri       = "https://iam.example.com" # Custom domain for OIDC callback URLs
   enable_passkey               = true
   enable_profile               = true # Allow users to update profile traits via settings flow
 

--- a/internal/resources/projectconfig/resource.go
+++ b/internal/resources/projectconfig/resource.go
@@ -93,15 +93,16 @@ type ProjectConfigResourceModel struct {
 	ErrorUIURL        types.String `tfsdk:"error_ui_url"`
 
 	// Auth methods
-	EnablePassword           types.Bool `tfsdk:"enable_password"`
-	EnableCode               types.Bool `tfsdk:"enable_code"`
-	CodeMFAEnabled           types.Bool `tfsdk:"code_mfa_enabled"`
-	EnableOIDC               types.Bool `tfsdk:"enable_oidc"`
-	EnableOIDCAutoLinkPolicy types.Bool `tfsdk:"enable_oidc_auto_link_policy"`
-	EnableTOTP               types.Bool `tfsdk:"enable_totp"`
-	EnableWebAuthn           types.Bool `tfsdk:"enable_webauthn"`
-	EnablePasskey            types.Bool `tfsdk:"enable_passkey"`
-	EnableLookupSecret       types.Bool `tfsdk:"enable_lookup_secret"`
+	EnablePassword           types.Bool   `tfsdk:"enable_password"`
+	EnableCode               types.Bool   `tfsdk:"enable_code"`
+	CodeMFAEnabled           types.Bool   `tfsdk:"code_mfa_enabled"`
+	EnableOIDC               types.Bool   `tfsdk:"enable_oidc"`
+	EnableOIDCAutoLinkPolicy types.Bool   `tfsdk:"enable_oidc_auto_link_policy"`
+	OIDCBaseRedirectURI      types.String `tfsdk:"oidc_base_redirect_uri"`
+	EnableTOTP               types.Bool   `tfsdk:"enable_totp"`
+	EnableWebAuthn           types.Bool   `tfsdk:"enable_webauthn"`
+	EnablePasskey            types.Bool   `tfsdk:"enable_passkey"`
+	EnableLookupSecret       types.Bool   `tfsdk:"enable_lookup_secret"`
 
 	// Password policy
 	PasswordMinLength            types.Int64 `tfsdk:"password_min_length"`
@@ -505,6 +506,13 @@ func (r *ProjectConfigResource) Schema(ctx context.Context, req resource.SchemaR
 			"enable_oidc_auto_link_policy": schema.BoolAttribute{
 				Description: "Enable the OIDC auto-link policy. When true, social sign-in providers with auto_link enabled (on ory_social_provider) can automatically link to existing identities that share the same identifier (e.g., email).",
 				Optional:    true,
+			},
+			"oidc_base_redirect_uri": schema.StringAttribute{
+				Description: "Override the base redirect URI for OIDC callbacks (e.g., \"https://iam.example.com\"). " +
+					"When set, Ory constructs callback URLs using this base instead of the default project domain. " +
+					"This is useful when your project uses a custom domain for authentication flows. " +
+					"This is also configurable via the ory_social_provider resource's base_redirect_uri attribute.",
+				Optional: true,
 			},
 			"enable_totp": schema.BoolAttribute{
 				Description: "Enable TOTP (Time-based One-Time Password).",
@@ -1085,6 +1093,22 @@ func (r *ProjectConfigResource) buildPatches(ctx context.Context, plan *ProjectC
 				Op:    "replace",
 				Path:  m.path,
 				Value: m.field.ValueBool(),
+			})
+		}
+	}
+
+	// OIDC base redirect URI
+	if !plan.OIDCBaseRedirectURI.IsNull() && !plan.OIDCBaseRedirectURI.IsUnknown() {
+		if plan.OIDCBaseRedirectURI.ValueString() == "" {
+			patches = append(patches, ory.JsonPatch{
+				Op:   "remove",
+				Path: "/services/identity/config/selfservice/methods/oidc/config/base_redirect_uri",
+			})
+		} else {
+			patches = append(patches, ory.JsonPatch{
+				Op:    "add",
+				Path:  "/services/identity/config/selfservice/methods/oidc/config/base_redirect_uri",
+				Value: plan.OIDCBaseRedirectURI.ValueString(),
 			})
 		}
 	}
@@ -1721,6 +1745,19 @@ func (r *ProjectConfigResource) readProjectConfig(ctx context.Context, project *
 				if v, ok := getNestedBool(identityConfig, keys...); ok {
 					*field = types.BoolValue(v)
 				}
+			}
+		}
+
+		// OIDC base redirect URI
+		if !state.OIDCBaseRedirectURI.IsNull() {
+			if state.OIDCBaseRedirectURI.ValueString() != "" {
+				if v, ok := getNestedString(identityConfig, "selfservice", "methods", "oidc", "config", "base_redirect_uri"); ok {
+					state.OIDCBaseRedirectURI = types.StringValue(v)
+				}
+			} else if v, ok := getNestedString(identityConfig, "selfservice", "methods", "oidc", "config", "base_redirect_uri"); ok && v != "" {
+				tflog.Warn(ctx, "API returned non-empty oidc base_redirect_uri after remove patch; preserving empty state value", map[string]interface{}{
+					"api_value": v,
+				})
 			}
 		}
 

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -240,6 +240,36 @@ func TestAccProjectConfigResource_oidcAutoLinkPolicy(t *testing.T) {
 	})
 }
 
+func TestAccProjectConfigResource_oidcBaseRedirectURI(t *testing.T) {
+	acctest.RequireSocialProviderTests(t)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/oidc_base_redirect_uri.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_project_config.test", "id"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "enable_oidc", "true"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "oidc_base_redirect_uri", "https://iam.example.com"),
+				),
+			},
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/oidc_base_redirect_uri_updated.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "oidc_base_redirect_uri", "https://auth.example.com"),
+				),
+			},
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/oidc_base_redirect_uri_removed.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "oidc_base_redirect_uri", ""),
+				),
+			},
+		},
+	})
+}
+
 func TestAccProjectConfigResource_accountExperience(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccPreCheck(t) },

--- a/internal/resources/projectconfig/testdata/oidc_base_redirect_uri.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/oidc_base_redirect_uri.tf.tmpl
@@ -1,0 +1,4 @@
+resource "ory_project_config" "test" {
+  enable_oidc            = true
+  oidc_base_redirect_uri = "https://iam.example.com"
+}

--- a/internal/resources/projectconfig/testdata/oidc_base_redirect_uri_removed.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/oidc_base_redirect_uri_removed.tf.tmpl
@@ -1,0 +1,4 @@
+resource "ory_project_config" "test" {
+  enable_oidc            = true
+  oidc_base_redirect_uri = ""
+}

--- a/internal/resources/projectconfig/testdata/oidc_base_redirect_uri_updated.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/oidc_base_redirect_uri_updated.tf.tmpl
@@ -1,0 +1,4 @@
+resource "ory_project_config" "test" {
+  enable_oidc            = true
+  oidc_base_redirect_uri = "https://auth.example.com"
+}

--- a/templates/resources/project_config.md.tmpl
+++ b/templates/resources/project_config.md.tmpl
@@ -104,7 +104,7 @@ This resource exposes **75+ attributes** across these configuration categories:
 | Session settings | cookie same site, lifespan, whoami-required AAL |
 | CORS | public and admin origins, enabled/disabled |
 | Login flow | login style (unified, identifier_first) |
-| Authentication | passwordless, code, profile, OIDC (social sign-in), OIDC auto-link policy, TOTP, passkey, WebAuthn, lookup secrets |
+| Authentication | passwordless, code, profile, OIDC (social sign-in), OIDC auto-link policy, OIDC base redirect URI, TOTP, passkey, WebAuthn, lookup secrets |
 | Code method | lifespan, max submissions, missing credential fallback |
 | OAuth2/Hydra | token lifespans, access token strategy, PKCE, claims, scope strategy, consent/login URLs |
 | Settings flow | lifespan, privileged session max age, required AAL |


### PR DESCRIPTION
## Description

Add the OIDC base redirect URI as a project-level config attribute (`oidc_base_redirect_uri`) on the `ory_project_config` resource. This allows users to manage the global OIDC callback base URL directly from project config, matching the "Base Redirect URI" field visible in the Ory Console OIDC config screen.

Previously, this setting was only configurable via `ory_social_provider.base_redirect_uri`, which was confusing because it is a global OIDC config setting (not per-provider). The attribute remains available on `ory_social_provider` for backward compatibility.

## Related Issues

Fixes #171

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

Acceptance test covers create, update, and removal of the `oidc_base_redirect_uri` attribute:

```
=== RUN   TestAccProjectConfigResource_oidcBaseRedirectURI
--- PASS: TestAccProjectConfigResource_oidcBaseRedirectURI (6.28s)
```

API behavior verified manually:
- `add` patch sets `base_redirect_uri` at `/services/identity/config/selfservice/methods/oidc/config/base_redirect_uri`
- `remove` patch clears it
- Setting empty string (`""`) triggers removal

Pre-commit checks:
- `make build` - pass
- `make format` - 0 lint issues
- `make test-short` - all unit tests pass
- `make sec` - govulncheck, gosec, gitleaks all clean