### PR TITLE
fix(ci): install Terraform CLI for acceptance tests

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -92,6 +92,11 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4
+        with:
+          terraform_wrapper: false
+
       - name: Run Acceptance Tests
         env:
           TF_ACC: "1"


### PR DESCRIPTION
## Description

The `hc-install` library (pulled in transitively by `terraform-plugin-testing`) verifies Terraform CLI downloads against HashiCorp's embedded PGP key. That key expired on 2026-04-19, so every acceptance-test CI run now fails during bootstrap with:

```
cannot run Terraform provider tests: failed to find or install Terraform CLI from [...]: unable to verify checksums signature: openpgp: key expired
```

Pre-installing Terraform via `hashicorp/setup-terraform` makes `hc-install`'s `LookPath` source find the binary on `PATH`, so the signature-verified release download path is never taken. This mirrors the setup already used in `.github/workflows/lint.yml`.


## Related Issues

Unblocks #182 and any future acceptance-test CI runs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [ ] Unit tests
- [x] Acceptance tests
- [x] Manual testing

- Reproduced the `openpgp: key expired` failure locally by running an acceptance test with `terraform` removed from `PATH`.
- Verified the acceptance test (`TestAccIdentityResource_basic`) passes once `terraform` is on `PATH`, which is exactly what `hashicorp/setup-terraform` provides in CI.
- `make format`, `make lint`, and `make sec` all pass with 0 issues.

## Screenshots/Output

Before (CI, PR #182):

```
cannot run Terraform provider tests: failed to find or install Terraform CLI from [...]: unable to verify checksums signature: openpgp: key expired
FAIL    github.com/ory/terraform-provider-ory/internal/resources/action    0.766s
FAIL    github.com/ory/terraform-provider-ory/internal/resources/customdomain    0.401s
...
```

After (local reproduction with fix applied):

```
=== RUN   TestAccIdentityResource_basic
    acctest.go:132: Using pre-created test project: ***
--- PASS: TestAccIdentityResource_basic (10.25s)
PASS
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to configure Terraform before running acceptance tests, ensuring proper test execution environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->