### PR TITLE
feat: add ory_saml_provider resource for Ory Polis SAML config

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"8c870312-7b9e-4c2f-8f76-db0819a93bba","pid":93110,"acquiredAt":1776822671388}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"8c870312-7b9e-4c2f-8f76-db0819a93bba","pid":93110,"acquiredAt":1776822671388}

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,7 +128,7 @@ terraform plan
 |----------|---------------------|
 | `ory_project`, `ory_workspace` | `workspace_api_key`, `workspace_id` |
 | `ory_organization` | `workspace_api_key`, `project_id` |
-| `ory_project_config`, `ory_action`, `ory_social_provider`, `ory_email_template` | `workspace_api_key`, `project_id` |
+| `ory_project_config`, `ory_action`, `ory_social_provider`, `ory_saml_provider`, `ory_email_template` | `workspace_api_key`, `project_id` |
 | `ory_identity_schema`, `ory_project_api_key` | `workspace_api_key`, `project_id` |
 | `ory_identity`, `ory_oauth2_client`, `ory_relationship` | `project_api_key`, `project_slug` |
 | `ory_json_web_key_set` | `project_api_key`, `project_slug` |

--- a/docs/resources/saml_provider.md
+++ b/docs/resources/saml_provider.md
@@ -84,6 +84,8 @@ The `raw_idp_metadata_xml` attribute accepts the IDP's SAML 2.0 metadata XML. Or
 - **`base64://<base64-encoded XML>`** — for inline metadata (typical when the IDP exports a static XML file).
 - **`https://...`** or **`http://...`** — for metadata hosted by the IDP (some providers expose a metadata URL).
 
+-> **Security:** Prefer `https://` in production. Plain `http://` is accepted by the API but leaves the metadata (and therefore the signing certificate trust root) vulnerable to tampering — use it only in controlled development or test environments.
+
 The metadata must include at least one signing `<KeyDescriptor>` and one `<SingleSignOnService>` binding, or Ory will reject the configuration with a validation error.
 
 ~> **Note:** The API transforms inline metadata to a hosted GCS URL on read. The provider preserves the original `base64://` value in state when you configured it that way, so Terraform won't show spurious drift.

--- a/docs/resources/saml_provider.md
+++ b/docs/resources/saml_provider.md
@@ -1,0 +1,169 @@
+---
+page_title: "ory_saml_provider Resource - ory"
+subcategory: ""
+description: |-
+  Manages an Ory Network SAML identity provider (Ory Polis).
+---
+
+# ory_saml_provider (Resource)
+
+Manages an Ory Network SAML identity provider. Ory Network uses [Ory Polis](https://www.ory.sh/polis) as its SAML backend, which lets you connect enterprise SSO identity providers (Okta, Azure AD, OneLogin, JumpCloud, etc.) to your project.
+
+SAML providers are configured as part of the project's SAML authentication method. Each provider is identified by a unique `provider_id` that is used in the ACS callback URL.
+
+-> **Plan:** SAML single sign-on requires a plan with B2B or Enterprise features. Check your Ory Network plan before using this resource.
+
+## How SAML sign-in works
+
+When a user initiates a SAML login:
+
+1. The user is redirected to your Ory project's SAML endpoint.
+2. Ory (via Polis) redirects the user to the configured IDP (based on `provider_id`).
+3. After successful authentication, the IDP returns a signed SAML assertion to Ory's ACS URL.
+4. Ory validates the assertion against the certificate in `raw_idp_metadata_xml`, applies the `mapper_url` Jsonnet mapping, and creates or updates the identity.
+
+The IDP metadata you configure here is what Ory uses to validate assertions — it must contain an `<IDPSSODescriptor>` with at least one signing `<KeyDescriptor>`.
+
+## Example Usage
+
+```terraform
+# SAML identity provider (Ory Polis)
+resource "ory_saml_provider" "corporate" {
+  provider_id          = "corporate"
+  label                = "Sign in with Corporate SSO"
+  raw_idp_metadata_xml = "base64://${base64encode(file("${path.module}/corporate-idp-metadata.xml"))}"
+}
+
+# SAML provider with a hosted metadata URL
+resource "ory_saml_provider" "hosted" {
+  provider_id          = "okta"
+  label                = "Okta SSO"
+  raw_idp_metadata_xml = "https://example.okta.com/app/metadata"
+}
+
+# SAML provider scoped to an organization (B2B)
+resource "ory_saml_provider" "acme" {
+  provider_id          = "acme"
+  label                = "Acme SSO"
+  raw_idp_metadata_xml = "base64://${base64encode(var.acme_idp_metadata)}"
+  organization_id      = ory_organization.acme.id
+}
+
+# SAML provider with a custom mapper and audience override
+resource "ory_saml_provider" "custom" {
+  provider_id                  = "custom"
+  label                        = "Custom Workplace"
+  raw_idp_metadata_xml         = "base64://${base64encode(var.custom_idp_metadata)}"
+  mapper_url                   = "base64://${base64encode(file("${path.module}/saml-mapper.jsonnet"))}"
+  audience_override_base_url   = "https://iam.example.com"
+  proxy_saml_audience_override = "https://sp.example.com/saml"
+}
+
+resource "ory_organization" "acme" {
+  label   = "Acme"
+  domains = ["acme.example.com"]
+}
+
+variable "acme_idp_metadata" {
+  description = "SAML IDP metadata XML for the Acme organization"
+  type        = string
+  sensitive   = false
+}
+
+variable "custom_idp_metadata" {
+  description = "SAML IDP metadata XML for the Custom workplace"
+  type        = string
+  sensitive   = false
+}
+```
+
+## IDP Metadata
+
+The `raw_idp_metadata_xml` attribute accepts the IDP's SAML 2.0 metadata XML. Ory requires one of:
+
+- **`base64://<base64-encoded XML>`** — for inline metadata (typical when the IDP exports a static XML file).
+- **`https://...`** or **`http://...`** — for metadata hosted by the IDP (some providers expose a metadata URL).
+
+The metadata must include at least one signing `<KeyDescriptor>` and one `<SingleSignOnService>` binding, or Ory will reject the configuration with a validation error.
+
+~> **Note:** The API transforms inline metadata to a hosted GCS URL on read. The provider preserves the original `base64://` value in state when you configured it that way, so Terraform won't show spurious drift.
+
+## Mapper URL
+
+The `mapper_url` attribute controls how SAML attributes are mapped to Ory identity traits. It accepts:
+
+- A URL pointing to a hosted Jsonnet file
+- A base64-encoded Jsonnet template prefixed with `base64://`
+
+If not set, the provider uses a default mapper that extracts the email claim.
+
+```jsonnet
+local claims = std.extVar('claims');
+{
+  identity: {
+    traits: {
+      email: claims.email,
+    },
+  },
+}
+```
+
+## Organization Scoping (B2B)
+
+Set `organization_id` to associate a SAML provider with a specific organization. This is how Ory routes a user's login based on their email domain to the correct IDP. When combined with an `ory_organization` resource that owns the user's domain, Ory automatically starts a SAML flow against this provider.
+
+```hcl
+resource "ory_organization" "acme" {
+  label   = "Acme"
+  domains = ["acme.example.com"]
+}
+
+resource "ory_saml_provider" "acme_sso" {
+  provider_id          = "acme"
+  label                = "Acme SSO"
+  raw_idp_metadata_xml = "base64://${base64encode(var.acme_idp_metadata)}"
+  organization_id      = ory_organization.acme.id
+}
+```
+
+## Audience Overrides
+
+- **`audience_override_base_url`** — Overrides the base URL used when computing the SAML SP audience (EntityID). Use when Ory is reached through a custom domain and you need the EntityID to match that domain instead of the default `*.projects.oryapis.com` hostname.
+- **`proxy_saml_audience_override`** — Replaces the SP audience (EntityID) entirely. Use when the IDP trust was established against a pre-existing audience that you cannot change on the IDP side.
+
+## Important Behaviors
+
+- **`provider_id` cannot be changed** after creation. Changing it forces a new resource.
+- **`raw_idp_metadata_xml` is required** and is validated by Ory on every update. An invalid cert or missing binding will reject the patch.
+- **Deleting the last provider** resets the entire SAML configuration (`enabled = false`, empty providers). This mirrors the behavior of the `ory_social_provider` resource.
+
+## Import
+
+Import using the provider ID:
+
+```shell
+terraform import ory_saml_provider.corporate corporate
+```
+
+The `provider_id` is the unique identifier you chose when creating the provider. After import, the `raw_idp_metadata_xml` attribute will be populated with the hosted URL form (the API's transformed value). If you originally configured metadata inline with `base64://...`, update your configuration to use the new hosted URL, or re-apply with your original `base64://` value to re-upload the inline XML.
+
+<!-- schema generated by tfplugindocs -->
+## Schema
+
+### Required
+
+- `provider_id` (String) Unique identifier for the SAML provider (used in ACS callback URLs).
+- `raw_idp_metadata_xml` (String) SAML IDP metadata XML. Accepts a URL (http/https) or a base64-encoded XML prefixed with `base64://`. This is required by the SAML identity provider to establish trust.
+
+### Optional
+
+- `audience_override_base_url` (String) Override the base URL used when computing the SAML SP audience (EntityID). Useful when running Ory behind a custom domain.
+- `label` (String) Human-readable label for the provider, displayed on the login button (e.g., "Sign in with Corporate SSO").
+- `mapper_url` (String) Jsonnet mapper URL for mapping SAML attributes to identity traits. Accepts a URL (http/https) or a base64-encoded Jsonnet template prefixed with `base64://`. If not set, a default mapper that extracts email from claims will be used.
+- `organization_id` (String) Organization ID to associate this SAML provider with (for B2B SSO).
+- `project_id` (String) Project ID. If not set, uses provider's project_id.
+- `proxy_saml_audience_override` (String) Customer-controlled override of the SAML Audience (EntityID) sent to the identity provider.
+
+### Read-Only
+
+- `id` (String) Resource ID (same as provider_id).

--- a/examples/resources/ory_saml_provider/resource.tf
+++ b/examples/resources/ory_saml_provider/resource.tf
@@ -1,0 +1,48 @@
+# SAML identity provider (Ory Polis)
+resource "ory_saml_provider" "corporate" {
+  provider_id          = "corporate"
+  label                = "Sign in with Corporate SSO"
+  raw_idp_metadata_xml = "base64://${base64encode(file("${path.module}/corporate-idp-metadata.xml"))}"
+}
+
+# SAML provider with a hosted metadata URL
+resource "ory_saml_provider" "hosted" {
+  provider_id          = "okta"
+  label                = "Okta SSO"
+  raw_idp_metadata_xml = "https://example.okta.com/app/metadata"
+}
+
+# SAML provider scoped to an organization (B2B)
+resource "ory_saml_provider" "acme" {
+  provider_id          = "acme"
+  label                = "Acme SSO"
+  raw_idp_metadata_xml = "base64://${base64encode(var.acme_idp_metadata)}"
+  organization_id      = ory_organization.acme.id
+}
+
+# SAML provider with a custom mapper and audience override
+resource "ory_saml_provider" "custom" {
+  provider_id                  = "custom"
+  label                        = "Custom Workplace"
+  raw_idp_metadata_xml         = "base64://${base64encode(var.custom_idp_metadata)}"
+  mapper_url                   = "base64://${base64encode(file("${path.module}/saml-mapper.jsonnet"))}"
+  audience_override_base_url   = "https://iam.example.com"
+  proxy_saml_audience_override = "https://sp.example.com/saml"
+}
+
+resource "ory_organization" "acme" {
+  label   = "Acme"
+  domains = ["acme.example.com"]
+}
+
+variable "acme_idp_metadata" {
+  description = "SAML IDP metadata XML for the Acme organization"
+  type        = string
+  sensitive   = false
+}
+
+variable "custom_idp_metadata" {
+  description = "SAML IDP metadata XML for the Custom workplace"
+  type        = string
+  sensitive   = false
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ory/terraform-provider-ory/internal/resources/projectapikey"
 	"github.com/ory/terraform-provider-ory/internal/resources/projectconfig"
 	"github.com/ory/terraform-provider-ory/internal/resources/relationship"
+	"github.com/ory/terraform-provider-ory/internal/resources/samlprovider"
 	"github.com/ory/terraform-provider-ory/internal/resources/socialprovider"
 	"github.com/ory/terraform-provider-ory/internal/resources/trustedjwtissuer"
 	"github.com/ory/terraform-provider-ory/internal/resources/workspace"
@@ -149,7 +150,7 @@ export TF_VAR_ory_project_key="ory_pat_..."
 |----------|---------------------|
 | ` + "`ory_project`" + `, ` + "`ory_workspace`" + ` | ` + "`workspace_api_key`" + `, ` + "`workspace_id`" + ` |
 | ` + "`ory_organization`" + ` | ` + "`workspace_api_key`" + `, ` + "`project_id`" + ` |
-| ` + "`ory_project_config`" + `, ` + "`ory_action`" + `, ` + "`ory_social_provider`" + `, ` + "`ory_email_template`" + ` | ` + "`workspace_api_key`" + `, ` + "`project_id`" + ` |
+| ` + "`ory_project_config`" + `, ` + "`ory_action`" + `, ` + "`ory_social_provider`" + `, ` + "`ory_saml_provider`" + `, ` + "`ory_email_template`" + ` | ` + "`workspace_api_key`" + `, ` + "`project_id`" + ` |
 | ` + "`ory_identity`" + `, ` + "`ory_oauth2_client`" + `, ` + "`ory_relationship`" + ` | ` + "`project_api_key`" + `, ` + "`project_slug`" + ` |
 
 ## Import Requirements
@@ -287,6 +288,7 @@ func (p *OryProvider) Resources(ctx context.Context) []func() resource.Resource 
 		action.NewResource,
 		identityschema.NewResource,
 		socialprovider.NewResource,
+		samlprovider.NewResource,
 		emailtemplate.NewResource,
 		projectapikey.NewResource,
 		jwk.NewResource,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -236,7 +236,7 @@ Or via environment variables:
   export ORY_PROJECT_API_KEY="ory_pat_..."
 
 Which API key do you need?
-  - Workspace API Key (ory_wak_...): For ory_project, ory_workspace, ory_organization, ory_project_config, ory_action
+  - Workspace API Key (ory_wak_...): For ory_project, ory_workspace, ory_organization, ory_project_config, ory_action, ory_social_provider, ory_saml_provider, ory_email_template
   - Project API Key (ory_pat_...): For ory_identity, ory_oauth2_client, ory_relationship
 
 For more information: https://www.ory.sh/docs/guides/api-keys`,

--- a/internal/resources/samlprovider/helpers.go
+++ b/internal/resources/samlprovider/helpers.go
@@ -1,7 +1,25 @@
 package samlprovider
 
-import "regexp"
+import (
+	"errors"
+	"regexp"
+
+	ory "github.com/ory/client-go"
+)
 
 // mapperURLRegex matches the URL prefixes Ory accepts for SAML mapper and IDP
 // metadata values. The Ory API rejects any other prefix with a 400 error.
 var mapperURLRegex = regexp.MustCompile(`^(base64://|https?://)`)
+
+// apiErrorDetail extracts the API response body from an Ory client-go error.
+// GenericOpenAPIError.Error() returns only the HTTP status — the JSON body
+// (which carries the actual server-side reason) is on .Body().
+func apiErrorDetail(err error) string {
+	var openAPIErr *ory.GenericOpenAPIError
+	if errors.As(err, &openAPIErr) {
+		if body := string(openAPIErr.Body()); body != "" {
+			return err.Error() + ": " + body
+		}
+	}
+	return err.Error()
+}

--- a/internal/resources/samlprovider/helpers.go
+++ b/internal/resources/samlprovider/helpers.go
@@ -1,0 +1,7 @@
+package samlprovider
+
+import "regexp"
+
+// mapperURLRegex matches the URL prefixes Ory accepts for SAML mapper and IDP
+// metadata values. The Ory API rejects any other prefix with a 400 error.
+var mapperURLRegex = regexp.MustCompile(`^(base64://|https?://)`)

--- a/internal/resources/samlprovider/resource.go
+++ b/internal/resources/samlprovider/resource.go
@@ -1,0 +1,571 @@
+package samlprovider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	ory "github.com/ory/client-go"
+
+	"github.com/ory/terraform-provider-ory/internal/client"
+	"github.com/ory/terraform-provider-ory/internal/helpers"
+)
+
+var (
+	_ resource.Resource                   = &SAMLProviderResource{}
+	_ resource.ResourceWithConfigure      = &SAMLProviderResource{}
+	_ resource.ResourceWithImportState    = &SAMLProviderResource{}
+	_ resource.ResourceWithValidateConfig = &SAMLProviderResource{}
+)
+
+// projectMutexes serializes Create, Update, and Delete operations per project.
+// The Ory API stores SAML providers as an array in the project config. All
+// mutations use a read-modify-write pattern (read providers → build patch →
+// PatchProject). Without serialization, concurrent operations read the same
+// stale state and the last write wins, silently discarding the others.
+// See: https://github.com/ory/terraform-provider-ory/issues/165
+var projectMutexes sync.Map // map[projectID]*sync.Mutex
+
+func projectMutex(projectID string) *sync.Mutex {
+	v, _ := projectMutexes.LoadOrStore(projectID, &sync.Mutex{})
+	return v.(*sync.Mutex)
+}
+
+func NewResource() resource.Resource {
+	return &SAMLProviderResource{}
+}
+
+type SAMLProviderResource struct {
+	client *client.OryClient
+}
+
+type SAMLProviderResourceModel struct {
+	ID                        types.String `tfsdk:"id"`
+	ProjectID                 types.String `tfsdk:"project_id"`
+	ProviderID                types.String `tfsdk:"provider_id"`
+	Label                     types.String `tfsdk:"label"`
+	MapperURL                 types.String `tfsdk:"mapper_url"`
+	RawIDPMetadataXML         types.String `tfsdk:"raw_idp_metadata_xml"`
+	OrganizationID            types.String `tfsdk:"organization_id"`
+	AudienceOverrideBaseURL   types.String `tfsdk:"audience_override_base_url"`
+	ProxySAMLAudienceOverride types.String `tfsdk:"proxy_saml_audience_override"`
+}
+
+func (r *SAMLProviderResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_saml_provider"
+}
+
+func (r *SAMLProviderResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages an Ory Network SAML identity provider (Ory Polis).",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "Resource ID (same as provider_id).",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"project_id": schema.StringAttribute{
+				Description: "Project ID. If not set, uses provider's project_id.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"provider_id": schema.StringAttribute{
+				Description: "Unique identifier for the SAML provider (used in ACS callback URLs).",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"label": schema.StringAttribute{
+				Description: "Human-readable label for the provider, displayed on the login button (e.g., \"Sign in with Corporate SSO\").",
+				Optional:    true,
+			},
+			"mapper_url": schema.StringAttribute{
+				Description: "Jsonnet mapper URL for mapping SAML attributes to identity traits. Accepts a URL (http/https) or a base64-encoded Jsonnet template prefixed with `base64://`. If not set, a default mapper that extracts email from claims will be used.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(mapperURLRegex, "must start with base64://, http://, or https://"),
+				},
+			},
+			"raw_idp_metadata_xml": schema.StringAttribute{
+				Description: "SAML IDP metadata XML. Accepts a URL (http/https) or a base64-encoded XML prefixed with `base64://`. This is required by the SAML identity provider to establish trust.",
+				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(mapperURLRegex, "must start with base64://, http://, or https://"),
+				},
+			},
+			"organization_id": schema.StringAttribute{
+				Description: "Organization ID to associate this SAML provider with (for B2B SSO).",
+				Optional:    true,
+			},
+			"audience_override_base_url": schema.StringAttribute{
+				Description: "Override the base URL used when computing the SAML SP audience (EntityID). Useful when running Ory behind a custom domain.",
+				Optional:    true,
+			},
+			"proxy_saml_audience_override": schema.StringAttribute{
+				Description: "Customer-controlled override of the SAML Audience (EntityID) sent to the identity provider.",
+				Optional:    true,
+			},
+		},
+	}
+}
+
+func (r *SAMLProviderResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	oryClient, ok := req.ProviderData.(*client.OryClient)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *client.OryClient, got: %T", req.ProviderData))
+		return
+	}
+	r.client = oryClient
+}
+
+func (r *SAMLProviderResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config SAMLProviderResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !config.ProviderID.IsNull() && !config.ProviderID.IsUnknown() && config.ProviderID.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(path.Root("provider_id"), "Invalid Attribute Value", "provider_id must not be an empty string.")
+	}
+	if !config.RawIDPMetadataXML.IsNull() && !config.RawIDPMetadataXML.IsUnknown() && config.RawIDPMetadataXML.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(path.Root("raw_idp_metadata_xml"), "Invalid Attribute Value", "raw_idp_metadata_xml must not be an empty string.")
+	}
+}
+
+// defaultMapperURL returns the default Jsonnet mapper. Ory's SAML backend
+// (Polis/Jackson) surfaces claims under the same `claims` variable used by
+// OIDC mappers, so this matches the social_provider default.
+const defaultMapperURL = "base64://bG9jYWwgY2xhaW1zID0gc3RkLmV4dFZhcignY2xhaW1zJyk7CnsKICBpZGVudGl0eTogewogICAgdHJhaXRzOiB7CiAgICAgIGVtYWlsOiBjbGFpbXMuZW1haWwsCiAgICB9LAogIH0sCn0="
+
+func (r *SAMLProviderResource) buildProviderConfig(plan *SAMLProviderResourceModel) map[string]interface{} {
+	config := map[string]interface{}{
+		"id":                   plan.ProviderID.ValueString(),
+		"raw_idp_metadata_xml": plan.RawIDPMetadataXML.ValueString(),
+	}
+
+	if !plan.Label.IsNull() && !plan.Label.IsUnknown() {
+		config["label"] = plan.Label.ValueString()
+	}
+	if !plan.MapperURL.IsNull() && !plan.MapperURL.IsUnknown() && plan.MapperURL.ValueString() != "" {
+		config["mapper_url"] = plan.MapperURL.ValueString()
+	} else {
+		config["mapper_url"] = defaultMapperURL
+	}
+	if !plan.OrganizationID.IsNull() && !plan.OrganizationID.IsUnknown() && plan.OrganizationID.ValueString() != "" {
+		config["organization_id"] = plan.OrganizationID.ValueString()
+	}
+	if !plan.AudienceOverrideBaseURL.IsNull() && !plan.AudienceOverrideBaseURL.IsUnknown() && plan.AudienceOverrideBaseURL.ValueString() != "" {
+		config["audience_override_base_url"] = plan.AudienceOverrideBaseURL.ValueString()
+	}
+	if !plan.ProxySAMLAudienceOverride.IsNull() && !plan.ProxySAMLAudienceOverride.IsUnknown() && plan.ProxySAMLAudienceOverride.ValueString() != "" {
+		config["proxy_saml_audience_override"] = plan.ProxySAMLAudienceOverride.ValueString()
+	}
+
+	return config
+}
+
+// extractSAMLConfigFromProject navigates to the SAML method config map.
+func extractSAMLConfigFromProject(project *ory.Project) map[string]interface{} {
+	if project.Services.Identity == nil {
+		return nil
+	}
+	configMap := project.Services.Identity.Config
+	if configMap == nil {
+		return nil
+	}
+	selfservice, ok := configMap["selfservice"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	methods, ok := selfservice["methods"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	saml, ok := methods["saml"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	samlConfig, ok := saml["config"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return samlConfig
+}
+
+func extractProvidersFromProject(project *ory.Project) []map[string]interface{} {
+	samlConfig := extractSAMLConfigFromProject(project)
+	if samlConfig == nil {
+		return []map[string]interface{}{}
+	}
+	providers, ok := samlConfig["providers"].([]interface{})
+	if !ok {
+		return []map[string]interface{}{}
+	}
+	result := make([]map[string]interface{}, 0, len(providers))
+	for _, p := range providers {
+		if pm, ok := p.(map[string]interface{}); ok {
+			result = append(result, pm)
+		}
+	}
+	return result
+}
+
+// copyProviders returns a deep copy of the provider slice via a JSON
+// round-trip so callers cannot accidentally mutate the cached project state.
+func copyProviders(providers []map[string]interface{}) []map[string]interface{} {
+	b, err := json.Marshal(providers)
+	if err != nil {
+		return providers
+	}
+	var cp []map[string]interface{}
+	if err := json.Unmarshal(b, &cp); err != nil {
+		return providers
+	}
+	return cp
+}
+
+func (r *SAMLProviderResource) getProviders(ctx context.Context, projectID string) ([]map[string]interface{}, error) {
+	if cached := r.client.GetCachedProject(projectID); cached != nil {
+		return copyProviders(extractProvidersFromProject(cached)), nil
+	}
+	project, err := r.client.GetProject(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get project %s: %w", projectID, err)
+	}
+	return extractProvidersFromProject(project), nil
+}
+
+func (r *SAMLProviderResource) findProviderIndex(providers []map[string]interface{}, providerID string) int {
+	for i, p := range providers {
+		if p["id"] == providerID {
+			return i
+		}
+	}
+	return -1
+}
+
+func (r *SAMLProviderResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan SAMLProviderResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	projectID := plan.ProjectID.ValueString()
+	if projectID == "" {
+		projectID = r.client.ProjectID()
+	}
+
+	providerConfig := r.buildProviderConfig(&plan)
+
+	mu := projectMutex(projectID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	providers, err := r.getProviders(ctx, projectID)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Getting SAML Providers", err.Error())
+		return
+	}
+
+	var patches []ory.JsonPatch
+	existingIndex := r.findProviderIndex(providers, plan.ProviderID.ValueString())
+
+	switch {
+	case existingIndex >= 0:
+		// Replace existing
+		patches = append(patches, ory.JsonPatch{
+			Op:    "replace",
+			Path:  fmt.Sprintf("/services/identity/config/selfservice/methods/saml/config/providers/%d", existingIndex),
+			Value: providerConfig,
+		})
+	case len(providers) == 0:
+		// Initialize the full SAML method configuration when adding the first provider
+		patches = append(patches, ory.JsonPatch{
+			Op:   "replace",
+			Path: "/services/identity/config/selfservice/methods/saml",
+			Value: map[string]interface{}{
+				"enabled": true,
+				"config": map[string]interface{}{
+					"providers": []interface{}{providerConfig},
+				},
+			},
+		})
+	default:
+		patches = append(patches, ory.JsonPatch{
+			Op:    "add",
+			Path:  "/services/identity/config/selfservice/methods/saml/config/providers/-",
+			Value: providerConfig,
+		})
+	}
+
+	result, err := r.client.PatchProject(ctx, projectID, patches)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Creating SAML Provider", err.Error())
+		return
+	}
+
+	project := result.GetProject()
+	updatedProviders := extractProvidersFromProject(&project)
+	if r.findProviderIndex(updatedProviders, plan.ProviderID.ValueString()) < 0 {
+		resp.Diagnostics.AddError("Error Verifying SAML Provider",
+			fmt.Sprintf("Provider %q was not found in the PatchProject response", plan.ProviderID.ValueString()))
+		return
+	}
+
+	plan.ID = plan.ProviderID
+	plan.ProjectID = types.StringValue(projectID)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *SAMLProviderResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state SAMLProviderResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	projectID := state.ProjectID.ValueString()
+	if projectID == "" {
+		projectID = r.client.ProjectID()
+	}
+	if projectID == "" {
+		resp.Diagnostics.AddError(
+			"Missing Project ID",
+			"Could not determine project ID. Set project_id in the resource or configure ORY_PROJECT_ID environment variable.",
+		)
+		return
+	}
+
+	providerID := state.ProviderID.ValueString()
+	if providerID == "" {
+		resp.Diagnostics.AddError(
+			"Missing Provider ID",
+			"provider_id is empty in state. This is a bug - please report it.",
+		)
+		return
+	}
+
+	var providers []map[string]interface{}
+	index := -1
+
+	if cached := r.client.GetCachedProject(projectID); cached != nil {
+		providers = extractProvidersFromProject(cached)
+		index = r.findProviderIndex(providers, providerID)
+	}
+
+	if index < 0 {
+		for attempt := 0; attempt < helpers.ReadRetryMaxAttempts; attempt++ {
+			project, err := r.client.GetProject(ctx, projectID)
+			if err != nil {
+				resp.Diagnostics.AddError("Error Reading SAML Provider",
+					fmt.Sprintf("Failed to get providers for project %s: %v", projectID, err))
+				return
+			}
+			providers = extractProvidersFromProject(project)
+			index = r.findProviderIndex(providers, providerID)
+			if index >= 0 {
+				break
+			}
+			if attempt < helpers.ReadRetryMaxAttempts-1 {
+				select {
+				case <-ctx.Done():
+					resp.State.RemoveResource(ctx)
+					return
+				case <-time.After(time.Duration(1<<attempt) * time.Second):
+				}
+			}
+		}
+	}
+
+	if index < 0 {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	provider := providers[index]
+
+	if label, ok := provider["label"].(string); ok && label != "" {
+		state.Label = types.StringValue(label)
+	} else {
+		state.Label = types.StringNull()
+	}
+
+	// The API transforms base64:// mapper URLs into hosted GCS URLs on read.
+	// Only update state if the user explicitly configured it — mirrors social_provider.
+	if !state.MapperURL.IsNull() && !state.MapperURL.IsUnknown() {
+		if mapper, ok := provider["mapper_url"].(string); ok && mapper != "" {
+			state.MapperURL = types.StringValue(mapper)
+		}
+	}
+
+	// raw_idp_metadata_xml also gets transformed to a GCS URL on read.
+	// Only refresh state from the API when the user supplied a URL; otherwise
+	// (user supplied base64://) keep their original value to avoid spurious diffs.
+	if !state.RawIDPMetadataXML.IsNull() && !state.RawIDPMetadataXML.IsUnknown() {
+		userValue := state.RawIDPMetadataXML.ValueString()
+		if !strings.HasPrefix(userValue, "base64://") {
+			if xml, ok := provider["raw_idp_metadata_xml"].(string); ok && xml != "" {
+				state.RawIDPMetadataXML = types.StringValue(xml)
+			}
+		}
+	}
+
+	if orgID, ok := provider["organization_id"].(string); ok && orgID != "" {
+		state.OrganizationID = types.StringValue(orgID)
+	} else {
+		state.OrganizationID = types.StringNull()
+	}
+
+	if audience, ok := provider["audience_override_base_url"].(string); ok && audience != "" {
+		state.AudienceOverrideBaseURL = types.StringValue(audience)
+	} else {
+		state.AudienceOverrideBaseURL = types.StringNull()
+	}
+
+	if override, ok := provider["proxy_saml_audience_override"].(string); ok && override != "" {
+		state.ProxySAMLAudienceOverride = types.StringValue(override)
+	} else {
+		state.ProxySAMLAudienceOverride = types.StringNull()
+	}
+
+	state.ID = types.StringValue(providerID)
+	state.ProjectID = types.StringValue(projectID)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *SAMLProviderResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan SAMLProviderResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	projectID := plan.ProjectID.ValueString()
+	if projectID == "" {
+		projectID = r.client.ProjectID()
+	}
+
+	providerConfig := r.buildProviderConfig(&plan)
+
+	mu := projectMutex(projectID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	providers, err := r.getProviders(ctx, projectID)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Getting SAML Providers", err.Error())
+		return
+	}
+
+	index := r.findProviderIndex(providers, plan.ProviderID.ValueString())
+	if index < 0 {
+		resp.Diagnostics.AddError("SAML Provider Not Found",
+			fmt.Sprintf("Provider '%s' not found", plan.ProviderID.ValueString()))
+		return
+	}
+
+	patches := []ory.JsonPatch{{
+		Op:    "replace",
+		Path:  fmt.Sprintf("/services/identity/config/selfservice/methods/saml/config/providers/%d", index),
+		Value: providerConfig,
+	}}
+
+	_, err = r.client.PatchProject(ctx, projectID, patches)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Updating SAML Provider", err.Error())
+		return
+	}
+
+	plan.ID = plan.ProviderID
+	plan.ProjectID = types.StringValue(projectID)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *SAMLProviderResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state SAMLProviderResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	projectID := state.ProjectID.ValueString()
+	if projectID == "" {
+		projectID = r.client.ProjectID()
+	}
+
+	mu := projectMutex(projectID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	providers, err := r.getProviders(ctx, projectID)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Getting SAML Providers", err.Error())
+		return
+	}
+
+	index := r.findProviderIndex(providers, state.ProviderID.ValueString())
+	if index < 0 {
+		return
+	}
+
+	var patches []ory.JsonPatch
+
+	// When removing the last provider, reset the SAML method config so we
+	// don't leave an `enabled: true` method with an empty providers array,
+	// which Ory treats as an invalid configuration.
+	if len(providers) == 1 {
+		patches = append(patches, ory.JsonPatch{
+			Op:   "replace",
+			Path: "/services/identity/config/selfservice/methods/saml",
+			Value: map[string]interface{}{
+				"enabled": false,
+				"config": map[string]interface{}{
+					"providers": []interface{}{},
+				},
+			},
+		})
+	} else {
+		patches = append(patches, ory.JsonPatch{
+			Op:   "remove",
+			Path: fmt.Sprintf("/services/identity/config/selfservice/methods/saml/config/providers/%d", index),
+		})
+	}
+
+	_, err = r.client.PatchProject(ctx, projectID, patches)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Deleting SAML Provider", err.Error())
+		return
+	}
+}
+
+func (r *SAMLProviderResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("provider_id"), req.ID)...)
+}

--- a/internal/resources/samlprovider/resource.go
+++ b/internal/resources/samlprovider/resource.go
@@ -166,7 +166,7 @@ func (r *SAMLProviderResource) buildProviderConfig(plan *SAMLProviderResourceMod
 		"raw_idp_metadata_xml": plan.RawIDPMetadataXML.ValueString(),
 	}
 
-	if !plan.Label.IsNull() && !plan.Label.IsUnknown() {
+	if !plan.Label.IsNull() && !plan.Label.IsUnknown() && plan.Label.ValueString() != "" {
 		config["label"] = plan.Label.ValueString()
 	}
 	if !plan.MapperURL.IsNull() && !plan.MapperURL.IsUnknown() && plan.MapperURL.ValueString() != "" {
@@ -303,9 +303,12 @@ func (r *SAMLProviderResource) Create(ctx context.Context, req resource.CreateRe
 			Value: providerConfig,
 		})
 	case len(providers) == 0:
-		// Initialize the full SAML method configuration when adding the first provider
+		// Initialize the full SAML method configuration when adding the first provider.
+		// Using `add` (not `replace`) mirrors ory_social_provider's first-provider flow
+		// so the JSON Patch semantics are identical whether or not the saml method stub
+		// already exists in the project config.
 		patches = append(patches, ory.JsonPatch{
-			Op:   "replace",
+			Op:   "add",
 			Path: "/services/identity/config/selfservice/methods/saml",
 			Value: map[string]interface{}{
 				"enabled": true,
@@ -324,7 +327,7 @@ func (r *SAMLProviderResource) Create(ctx context.Context, req resource.CreateRe
 
 	result, err := r.client.PatchProject(ctx, projectID, patches)
 	if err != nil {
-		resp.Diagnostics.AddError("Error Creating SAML Provider", err.Error())
+		resp.Diagnostics.AddError("Error Creating SAML Provider", apiErrorDetail(err))
 		return
 	}
 
@@ -431,14 +434,15 @@ func (r *SAMLProviderResource) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	// raw_idp_metadata_xml also gets transformed to a GCS URL on read.
-	// Only refresh state from the API when the user supplied a URL; otherwise
-	// (user supplied base64://) keep their original value to avoid spurious diffs.
-	if !state.RawIDPMetadataXML.IsNull() && !state.RawIDPMetadataXML.IsUnknown() {
-		userValue := state.RawIDPMetadataXML.ValueString()
-		if !strings.HasPrefix(userValue, "base64://") {
-			if xml, ok := provider["raw_idp_metadata_xml"].(string); ok && xml != "" {
-				state.RawIDPMetadataXML = types.StringValue(xml)
-			}
+	// When the user supplied base64://..., keep their original value to avoid
+	// spurious diffs. When the state is null/unknown (e.g., during import) or
+	// was originally a URL, refresh from the API so a required attribute is
+	// always populated.
+	userSuppliedBase64 := !state.RawIDPMetadataXML.IsNull() && !state.RawIDPMetadataXML.IsUnknown() &&
+		strings.HasPrefix(state.RawIDPMetadataXML.ValueString(), "base64://")
+	if !userSuppliedBase64 {
+		if xml, ok := provider["raw_idp_metadata_xml"].(string); ok && xml != "" {
+			state.RawIDPMetadataXML = types.StringValue(xml)
 		}
 	}
 
@@ -505,7 +509,7 @@ func (r *SAMLProviderResource) Update(ctx context.Context, req resource.UpdateRe
 
 	_, err = r.client.PatchProject(ctx, projectID, patches)
 	if err != nil {
-		resp.Diagnostics.AddError("Error Updating SAML Provider", err.Error())
+		resp.Diagnostics.AddError("Error Updating SAML Provider", apiErrorDetail(err))
 		return
 	}
 
@@ -567,7 +571,7 @@ func (r *SAMLProviderResource) Delete(ctx context.Context, req resource.DeleteRe
 
 	_, err = r.client.PatchProject(ctx, projectID, patches)
 	if err != nil {
-		resp.Diagnostics.AddError("Error Deleting SAML Provider", err.Error())
+		resp.Diagnostics.AddError("Error Deleting SAML Provider", apiErrorDetail(err))
 		return
 	}
 }

--- a/internal/resources/samlprovider/resource.go
+++ b/internal/resources/samlprovider/resource.go
@@ -394,7 +394,10 @@ func (r *SAMLProviderResource) Read(ctx context.Context, req resource.ReadReques
 			if attempt < helpers.ReadRetryMaxAttempts-1 {
 				select {
 				case <-ctx.Done():
-					resp.State.RemoveResource(ctx)
+					resp.Diagnostics.AddError(
+						"Error Reading SAML Provider",
+						fmt.Sprintf("read canceled while retrying project %s: %v", projectID, ctx.Err()),
+					)
 					return
 				case <-time.After(time.Duration(1<<attempt) * time.Second):
 				}
@@ -416,10 +419,14 @@ func (r *SAMLProviderResource) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	// The API transforms base64:// mapper URLs into hosted GCS URLs on read.
-	// Only update state if the user explicitly configured it — mirrors social_provider.
+	// When the user supplied base64://..., preserve their original value to avoid
+	// spurious drift — only refresh state when the user originally configured a URL.
 	if !state.MapperURL.IsNull() && !state.MapperURL.IsUnknown() {
-		if mapper, ok := provider["mapper_url"].(string); ok && mapper != "" {
-			state.MapperURL = types.StringValue(mapper)
+		userValue := state.MapperURL.ValueString()
+		if !strings.HasPrefix(userValue, "base64://") {
+			if mapper, ok := provider["mapper_url"].(string); ok && mapper != "" {
+				state.MapperURL = types.StringValue(mapper)
+			}
 		}
 	}
 

--- a/internal/resources/samlprovider/resource.go
+++ b/internal/resources/samlprovider/resource.go
@@ -147,12 +147,26 @@ func (r *SAMLProviderResource) ValidateConfig(ctx context.Context, req resource.
 		return
 	}
 
-	if !config.ProviderID.IsNull() && !config.ProviderID.IsUnknown() && config.ProviderID.ValueString() == "" {
-		resp.Diagnostics.AddAttributeError(path.Root("provider_id"), "Invalid Attribute Value", "provider_id must not be an empty string.")
+	// Reject empty strings so the plan doesn't silently diverge. Read collapses
+	// empty API responses to null, but Create/Update would otherwise send "" for
+	// required fields and drop it for optional ones — the resulting drift would
+	// never converge across applies.
+	rejectEmpty := func(attr string, v types.String) {
+		if !v.IsNull() && !v.IsUnknown() && v.ValueString() == "" {
+			resp.Diagnostics.AddAttributeError(
+				path.Root(attr),
+				"Invalid Attribute Value",
+				fmt.Sprintf("%s must not be an empty string.", attr),
+			)
+		}
 	}
-	if !config.RawIDPMetadataXML.IsNull() && !config.RawIDPMetadataXML.IsUnknown() && config.RawIDPMetadataXML.ValueString() == "" {
-		resp.Diagnostics.AddAttributeError(path.Root("raw_idp_metadata_xml"), "Invalid Attribute Value", "raw_idp_metadata_xml must not be an empty string.")
-	}
+
+	rejectEmpty("provider_id", config.ProviderID)
+	rejectEmpty("raw_idp_metadata_xml", config.RawIDPMetadataXML)
+	rejectEmpty("label", config.Label)
+	rejectEmpty("organization_id", config.OrganizationID)
+	rejectEmpty("audience_override_base_url", config.AudienceOverrideBaseURL)
+	rejectEmpty("proxy_saml_audience_override", config.ProxySAMLAudienceOverride)
 }
 
 // defaultMapperURL returns the default Jsonnet mapper. Ory's SAML backend

--- a/internal/resources/samlprovider/resource_test.go
+++ b/internal/resources/samlprovider/resource_test.go
@@ -1,0 +1,136 @@
+//go:build acceptance
+
+package samlprovider_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/ory/terraform-provider-ory/internal/acctest"
+)
+
+// buildTestMetadataXML generates a minimal SAML 2.0 IDP metadata XML document
+// containing a fresh self-signed signing certificate, encoded as base64://.
+// Ory validates the metadata structure on PATCH, so a complete KeyDescriptor
+// is required even for tests.
+func buildTestMetadataXML(t *testing.T) string {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate test signing key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "idp.example.com"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create test certificate: %v", err)
+	}
+	certB64 := base64.StdEncoding.EncodeToString(certDER)
+
+	metadata := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://idp.example.com">
+  <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" WantAuthnRequestsSigned="false">
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>%s</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.example.com/sso"/>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.example.com/sso"/>
+  </IDPSSODescriptor>
+</EntityDescriptor>`, certB64)
+
+	// base64-encode the entire XML so the API accepts it as a `base64://` value.
+	return "base64://" + base64.StdEncoding.EncodeToString([]byte(metadata))
+}
+
+func TestAccSAMLProviderResource_basic(t *testing.T) {
+	metadata := buildTestMetadataXML(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/basic.tf.tmpl", map[string]string{
+					"MetadataXML": metadata,
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_saml_provider.test", "id"),
+					resource.TestCheckResourceAttr("ory_saml_provider.test", "provider_id", "test-saml"),
+					resource.TestCheckResourceAttr("ory_saml_provider.test", "label", "Test SAML"),
+				),
+			},
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/updated.tf.tmpl", map[string]string{
+					"MetadataXML": metadata,
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_saml_provider.test", "label", "Test SAML Updated"),
+					resource.TestCheckResourceAttr("ory_saml_provider.test", "audience_override_base_url", "https://audience.example.com"),
+					resource.TestCheckResourceAttr("ory_saml_provider.test", "proxy_saml_audience_override", "https://audience-override.example.com"),
+				),
+			},
+			{
+				ResourceName:      "ory_saml_provider.test",
+				ImportState:       true,
+				ImportStateId:     "test-saml",
+				ImportStateVerify: true,
+				// raw_idp_metadata_xml is transformed to a GCS URL on read. When the user
+				// configured a base64:// value, we preserve it in state on refresh, but
+				// import starts from a blank state — the API's transformed URL is what
+				// import sees, and that's a legitimate value (also accepted by PATCH).
+				ImportStateVerifyIgnore: []string{"raw_idp_metadata_xml"},
+			},
+		},
+	})
+}
+
+// TestAccSAMLProviderResource_concurrentCreate verifies that multiple SAML
+// providers created in a single apply (no depends_on) all persist correctly.
+// This is the same read-modify-write race guarded against in social_provider
+// (see https://github.com/ory/terraform-provider-ory/issues/165).
+func TestAccSAMLProviderResource_concurrentCreate(t *testing.T) {
+	metadata := buildTestMetadataXML(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/concurrent_create.tf.tmpl", map[string]string{
+					"MetadataXML": metadata,
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_saml_provider.concurrent_one", "provider_id", "test-concurrent-saml-one"),
+					resource.TestCheckResourceAttr("ory_saml_provider.concurrent_two", "provider_id", "test-concurrent-saml-two"),
+					resource.TestCheckResourceAttr("ory_saml_provider.concurrent_three", "provider_id", "test-concurrent-saml-three"),
+				),
+			},
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/concurrent_create.tf.tmpl", map[string]string{
+					"MetadataXML": metadata,
+				}),
+				PlanOnly: true,
+			},
+		},
+	})
+}

--- a/internal/resources/samlprovider/testdata/basic.tf.tmpl
+++ b/internal/resources/samlprovider/testdata/basic.tf.tmpl
@@ -1,0 +1,5 @@
+resource "ory_saml_provider" "test" {
+  provider_id          = "test-saml"
+  label                = "Test SAML"
+  raw_idp_metadata_xml = "[[ .MetadataXML ]]"
+}

--- a/internal/resources/samlprovider/testdata/concurrent_create.tf.tmpl
+++ b/internal/resources/samlprovider/testdata/concurrent_create.tf.tmpl
@@ -1,0 +1,17 @@
+resource "ory_saml_provider" "concurrent_one" {
+  provider_id          = "test-concurrent-saml-one"
+  label                = "Concurrent One"
+  raw_idp_metadata_xml = "[[ .MetadataXML ]]"
+}
+
+resource "ory_saml_provider" "concurrent_two" {
+  provider_id          = "test-concurrent-saml-two"
+  label                = "Concurrent Two"
+  raw_idp_metadata_xml = "[[ .MetadataXML ]]"
+}
+
+resource "ory_saml_provider" "concurrent_three" {
+  provider_id          = "test-concurrent-saml-three"
+  label                = "Concurrent Three"
+  raw_idp_metadata_xml = "[[ .MetadataXML ]]"
+}

--- a/internal/resources/samlprovider/testdata/updated.tf.tmpl
+++ b/internal/resources/samlprovider/testdata/updated.tf.tmpl
@@ -1,0 +1,7 @@
+resource "ory_saml_provider" "test" {
+  provider_id                  = "test-saml"
+  label                        = "Test SAML Updated"
+  raw_idp_metadata_xml         = "[[ .MetadataXML ]]"
+  audience_override_base_url   = "https://audience.example.com"
+  proxy_saml_audience_override = "https://audience-override.example.com"
+}

--- a/internal/resources/samlprovider/validate_config_test.go
+++ b/internal/resources/samlprovider/validate_config_test.go
@@ -1,0 +1,109 @@
+package samlprovider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func tfStringValue(v types.String) tftypes.Value {
+	if v.IsNull() {
+		return tftypes.NewValue(tftypes.String, nil)
+	}
+	return tftypes.NewValue(tftypes.String, v.ValueString())
+}
+
+func buildTestConfig(t *testing.T, model SAMLProviderResourceModel) resource.ValidateConfigRequest {
+	t.Helper()
+
+	r := &SAMLProviderResource{}
+	ctx := context.Background()
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+
+	vals := map[string]tftypes.Value{
+		"id":                           tftypes.NewValue(tftypes.String, nil),
+		"project_id":                   tftypes.NewValue(tftypes.String, nil),
+		"provider_id":                  tfStringValue(model.ProviderID),
+		"label":                        tfStringValue(model.Label),
+		"mapper_url":                   tfStringValue(model.MapperURL),
+		"raw_idp_metadata_xml":         tfStringValue(model.RawIDPMetadataXML),
+		"organization_id":              tfStringValue(model.OrganizationID),
+		"audience_override_base_url":   tfStringValue(model.AudienceOverrideBaseURL),
+		"proxy_saml_audience_override": tfStringValue(model.ProxySAMLAudienceOverride),
+	}
+
+	objType := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"id":                           tftypes.String,
+			"project_id":                   tftypes.String,
+			"provider_id":                  tftypes.String,
+			"label":                        tftypes.String,
+			"mapper_url":                   tftypes.String,
+			"raw_idp_metadata_xml":         tftypes.String,
+			"organization_id":              tftypes.String,
+			"audience_override_base_url":   tftypes.String,
+			"proxy_saml_audience_override": tftypes.String,
+		},
+	}
+
+	return resource.ValidateConfigRequest{
+		Config: tfsdk.Config{
+			Raw:    tftypes.NewValue(objType, vals),
+			Schema: schemaResp.Schema,
+		},
+	}
+}
+
+func TestValidateConfig_EmptyProviderID(t *testing.T) {
+	model := SAMLProviderResourceModel{
+		ProviderID:        types.StringValue(""),
+		RawIDPMetadataXML: types.StringValue("base64://abc"),
+	}
+	req := buildTestConfig(t, model)
+
+	r := &SAMLProviderResource{}
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(context.Background(), req, &resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected validation error for empty provider_id, got none")
+	}
+}
+
+func TestValidateConfig_EmptyMetadata(t *testing.T) {
+	model := SAMLProviderResourceModel{
+		ProviderID:        types.StringValue("saml"),
+		RawIDPMetadataXML: types.StringValue(""),
+	}
+	req := buildTestConfig(t, model)
+
+	r := &SAMLProviderResource{}
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(context.Background(), req, &resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected validation error for empty raw_idp_metadata_xml, got none")
+	}
+}
+
+func TestValidateConfig_Valid(t *testing.T) {
+	model := SAMLProviderResourceModel{
+		ProviderID:        types.StringValue("saml"),
+		RawIDPMetadataXML: types.StringValue("base64://abc"),
+	}
+	req := buildTestConfig(t, model)
+
+	r := &SAMLProviderResource{}
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(context.Background(), req, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected validation error: %v", resp.Diagnostics)
+	}
+}

--- a/internal/resources/samlprovider/validate_config_test.go
+++ b/internal/resources/samlprovider/validate_config_test.go
@@ -107,3 +107,39 @@ func TestValidateConfig_Valid(t *testing.T) {
 		t.Fatalf("unexpected validation error: %v", resp.Diagnostics)
 	}
 }
+
+func TestValidateConfig_EmptyOptionalFields(t *testing.T) {
+	cases := map[string]SAMLProviderResourceModel{
+		"label": {
+			ProviderID:        types.StringValue("saml"),
+			RawIDPMetadataXML: types.StringValue("base64://abc"),
+			Label:             types.StringValue(""),
+		},
+		"organization_id": {
+			ProviderID:        types.StringValue("saml"),
+			RawIDPMetadataXML: types.StringValue("base64://abc"),
+			OrganizationID:    types.StringValue(""),
+		},
+		"audience_override_base_url": {
+			ProviderID:              types.StringValue("saml"),
+			RawIDPMetadataXML:       types.StringValue("base64://abc"),
+			AudienceOverrideBaseURL: types.StringValue(""),
+		},
+		"proxy_saml_audience_override": {
+			ProviderID:                types.StringValue("saml"),
+			RawIDPMetadataXML:         types.StringValue("base64://abc"),
+			ProxySAMLAudienceOverride: types.StringValue(""),
+		},
+	}
+	for name, model := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := buildTestConfig(t, model)
+			r := &SAMLProviderResource{}
+			var resp resource.ValidateConfigResponse
+			r.ValidateConfig(context.Background(), req, &resp)
+			if !resp.Diagnostics.HasError() {
+				t.Fatalf("expected validation error for empty %s, got none", name)
+			}
+		})
+	}
+}

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -128,7 +128,7 @@ terraform plan
 |----------|---------------------|
 | `ory_project`, `ory_workspace` | `workspace_api_key`, `workspace_id` |
 | `ory_organization` | `workspace_api_key`, `project_id` |
-| `ory_project_config`, `ory_action`, `ory_social_provider`, `ory_email_template` | `workspace_api_key`, `project_id` |
+| `ory_project_config`, `ory_action`, `ory_social_provider`, `ory_saml_provider`, `ory_email_template` | `workspace_api_key`, `project_id` |
 | `ory_identity_schema`, `ory_project_api_key` | `workspace_api_key`, `project_id` |
 | `ory_identity`, `ory_oauth2_client`, `ory_relationship` | `project_api_key`, `project_slug` |
 | `ory_json_web_key_set` | `project_api_key`, `project_slug` |

--- a/templates/resources/saml_provider.md.tmpl
+++ b/templates/resources/saml_provider.md.tmpl
@@ -35,6 +35,8 @@ The `raw_idp_metadata_xml` attribute accepts the IDP's SAML 2.0 metadata XML. Or
 - **`base64://<base64-encoded XML>`** — for inline metadata (typical when the IDP exports a static XML file).
 - **`https://...`** or **`http://...`** — for metadata hosted by the IDP (some providers expose a metadata URL).
 
+-> **Security:** Prefer `https://` in production. Plain `http://` is accepted by the API but leaves the metadata (and therefore the signing certificate trust root) vulnerable to tampering — use it only in controlled development or test environments.
+
 The metadata must include at least one signing `<KeyDescriptor>` and one `<SingleSignOnService>` binding, or Ory will reject the configuration with a validation error.
 
 ~> **Note:** The API transforms inline metadata to a hosted GCS URL on read. The provider preserves the original `base64://` value in state when you configured it that way, so Terraform won't show spurious drift.

--- a/templates/resources/saml_provider.md.tmpl
+++ b/templates/resources/saml_provider.md.tmpl
@@ -1,0 +1,101 @@
+---
+page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
+subcategory: ""
+description: |-
+  Manages an Ory Network SAML identity provider (Ory Polis).
+---
+
+# {{.Name}} ({{.Type}})
+
+Manages an Ory Network SAML identity provider. Ory Network uses [Ory Polis](https://www.ory.sh/polis) as its SAML backend, which lets you connect enterprise SSO identity providers (Okta, Azure AD, OneLogin, JumpCloud, etc.) to your project.
+
+SAML providers are configured as part of the project's SAML authentication method. Each provider is identified by a unique `provider_id` that is used in the ACS callback URL.
+
+-> **Plan:** SAML single sign-on requires a plan with B2B or Enterprise features. Check your Ory Network plan before using this resource.
+
+## How SAML sign-in works
+
+When a user initiates a SAML login:
+
+1. The user is redirected to your Ory project's SAML endpoint.
+2. Ory (via Polis) redirects the user to the configured IDP (based on `provider_id`).
+3. After successful authentication, the IDP returns a signed SAML assertion to Ory's ACS URL.
+4. Ory validates the assertion against the certificate in `raw_idp_metadata_xml`, applies the `mapper_url` Jsonnet mapping, and creates or updates the identity.
+
+The IDP metadata you configure here is what Ory uses to validate assertions — it must contain an `<IDPSSODescriptor>` with at least one signing `<KeyDescriptor>`.
+
+## Example Usage
+
+{{ tffile "examples/resources/ory_saml_provider/resource.tf" }}
+
+## IDP Metadata
+
+The `raw_idp_metadata_xml` attribute accepts the IDP's SAML 2.0 metadata XML. Ory requires one of:
+
+- **`base64://<base64-encoded XML>`** — for inline metadata (typical when the IDP exports a static XML file).
+- **`https://...`** or **`http://...`** — for metadata hosted by the IDP (some providers expose a metadata URL).
+
+The metadata must include at least one signing `<KeyDescriptor>` and one `<SingleSignOnService>` binding, or Ory will reject the configuration with a validation error.
+
+~> **Note:** The API transforms inline metadata to a hosted GCS URL on read. The provider preserves the original `base64://` value in state when you configured it that way, so Terraform won't show spurious drift.
+
+## Mapper URL
+
+The `mapper_url` attribute controls how SAML attributes are mapped to Ory identity traits. It accepts:
+
+- A URL pointing to a hosted Jsonnet file
+- A base64-encoded Jsonnet template prefixed with `base64://`
+
+If not set, the provider uses a default mapper that extracts the email claim.
+
+```jsonnet
+local claims = std.extVar('claims');
+{
+  identity: {
+    traits: {
+      email: claims.email,
+    },
+  },
+}
+```
+
+## Organization Scoping (B2B)
+
+Set `organization_id` to associate a SAML provider with a specific organization. This is how Ory routes a user's login based on their email domain to the correct IDP. When combined with an `ory_organization` resource that owns the user's domain, Ory automatically starts a SAML flow against this provider.
+
+```hcl
+resource "ory_organization" "acme" {
+  label   = "Acme"
+  domains = ["acme.example.com"]
+}
+
+resource "ory_saml_provider" "acme_sso" {
+  provider_id          = "acme"
+  label                = "Acme SSO"
+  raw_idp_metadata_xml = "base64://${base64encode(var.acme_idp_metadata)}"
+  organization_id      = ory_organization.acme.id
+}
+```
+
+## Audience Overrides
+
+- **`audience_override_base_url`** — Overrides the base URL used when computing the SAML SP audience (EntityID). Use when Ory is reached through a custom domain and you need the EntityID to match that domain instead of the default `*.projects.oryapis.com` hostname.
+- **`proxy_saml_audience_override`** — Replaces the SP audience (EntityID) entirely. Use when the IDP trust was established against a pre-existing audience that you cannot change on the IDP side.
+
+## Important Behaviors
+
+- **`provider_id` cannot be changed** after creation. Changing it forces a new resource.
+- **`raw_idp_metadata_xml` is required** and is validated by Ory on every update. An invalid cert or missing binding will reject the patch.
+- **Deleting the last provider** resets the entire SAML configuration (`enabled = false`, empty providers). This mirrors the behavior of the `ory_social_provider` resource.
+
+## Import
+
+Import using the provider ID:
+
+```shell
+terraform import ory_saml_provider.corporate corporate
+```
+
+The `provider_id` is the unique identifier you chose when creating the provider. After import, the `raw_idp_metadata_xml` attribute will be populated with the hosted URL form (the API's transformed value). If you originally configured metadata inline with `base64://...`, update your configuration to use the new hosted URL, or re-apply with your original `base64://` value to re-upload the inline XML.
+
+{{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
## Description

Adds a new `ory_saml_provider` resource that manages SAML identity providers configured through Ory Polis (Ory Network's SAML backend). The resource targets `/services/identity/config/selfservice/methods/saml/config/providers` in the project config and supports full CRUD plus import.

SAML provider config was previously only reachable by hand-editing the project via `ory_project_config` JSON patches — and is explicitly excluded from the `project_config` codegen because the providers array needs the same per-provider lifecycle that `ory_social_provider` uses.

The implementation mirrors `ory_social_provider`:

- Per-project `sync.Mutex` serializes create/update/delete to prevent the read-modify-write race from #165.
- Cached `PatchProject` response is preferred over `GetProject` to dodge API eventual consistency.
- When adding the first provider, the entire SAML method block is initialized (`enabled: true`, fresh providers array).
- Deleting the last provider resets the method back to `enabled: false`, empty providers — same pattern as social_provider, to avoid leaving the method in an invalid empty-but-enabled state.
- `raw_idp_metadata_xml` and `mapper_url` accept `base64://`, `http://`, or `https://` per Ory's validation. The API transforms `base64://` values to hosted GCS URLs on read, so state preserves the user's original value where possible (same approach as `ory_social_provider.mapper_url`).

## Related Issues

Fixes #186

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests — `TestValidateConfig_*` (empty provider_id, empty metadata, valid case) exercise the ValidateConfig hook without hitting the API.
- [x] Acceptance tests — `TestAccSAMLProviderResource_basic` covers create, update (label + audience overrides), import (with `ImportStateVerify`). `TestAccSAMLProviderResource_concurrentCreate` creates three SAML providers in a single apply with no `depends_on` to verify the mutex prevents last-write-wins data loss.
- [x] Manual testing — ran all acceptance tests against the staging project and verified the SAML config comes back to `{enabled: false, providers: []}` after teardown.

```
=== RUN   TestAccSAMLProviderResource_basic
--- PASS: TestAccSAMLProviderResource_basic (7.88s)
=== RUN   TestAccSAMLProviderResource_concurrentCreate
--- PASS: TestAccSAMLProviderResource_concurrentCreate (12.28s)
```

## Screenshots/Output

Generated resource docs (`docs/resources/saml_provider.md`) include a usage example, an explanation of the Polis-backed SAML flow, IDP metadata/mapper guidance, B2B organization scoping, and audience-override notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New SAML provider resource for managing SAML identity providers with org scoping, mapper support, and audience override options.

* **Documentation**
  * Added comprehensive docs and templates covering SAML metadata requirements, accepted formats, lifecycle behavior, and updated credential requirements.

* **Examples**
  * Added Terraform examples demonstrating multiple metadata sources and organization-scoped setups.

* **Tests**
  * Added unit and acceptance tests for validation, lifecycle, import, and concurrent-creation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->