### PR TITLE
feat(codegen): auto-apply discovered attributes and open draft PR

### DIFF
--- a/.github/workflows/regenerate-config.yml
+++ b/.github/workflows/regenerate-config.yml
@@ -75,10 +75,33 @@ jobs:
             echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Auto-apply unmapped properties from pinned spec
+        id: apply
+        run: |
+          set -o pipefail
+          if ! go run ./internal/codegen/cmd/generate/ \
+            -mappings ./internal/codegen/mappings.yaml \
+            -spec ./internal/codegen/openapi.yaml \
+            -discover-apply \
+            -out ./internal/resources/projectconfig/ 2>&1 | tee /tmp/apply-output.txt; then
+            exit 1
+          fi
+          COUNT=$(grep -oP 'discover-apply: \K\d+' /tmp/apply-output.txt | tail -n1 || true)
+          echo "count=${COUNT:-0}" >> "$GITHUB_OUTPUT"
+          if [ "${COUNT:-0}" -gt 0 ]; then
+            # Regenerate _gen.go files to reflect the newly-appended entries.
+            go run ./internal/codegen/cmd/generate/ \
+              -mappings ./internal/codegen/mappings.yaml \
+              -spec ./internal/codegen/openapi.yaml \
+              -out ./internal/resources/projectconfig/
+            gofmt -s -w ./internal/codegen/cmd/generate/ ./internal/resources/projectconfig/
+          fi
+
       - name: Check for generated file changes
         id: diff
         run: |
-          git diff --exit-code --quiet internal/resources/projectconfig/ || echo "changed=true" >> "$GITHUB_OUTPUT"
+          git diff --exit-code --quiet internal/codegen/mappings.yaml internal/resources/projectconfig/ \
+            || echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Build and test
         if: steps.diff.outputs.changed == 'true'
@@ -89,29 +112,63 @@ jobs:
       - name: Prepare PR body
         if: steps.diff.outputs.changed == 'true'
         run: |
+          APPLIED="${{ steps.apply.outputs.count }}"
           {
             echo "## Summary"
             echo "- Auto-regenerated project_config schema, patches, and read tables from the latest OpenAPI spec"
+            if [ "${APPLIED:-0}" -gt 0 ]; then
+              echo "- Auto-discovered **${APPLIED} new attribute(s)** from the spec and appended entries to \`mappings.yaml\` + \`ProjectConfigResourceModel\`"
+            fi
             echo "- Build and unit tests verified"
             echo ""
+            if [ "${APPLIED:-0}" -gt 0 ]; then
+              echo "## Review checklist for auto-discovered attributes"
+              echo "- [ ] Verify attribute names follow the existing naming convention"
+              echo "- [ ] Review truncated descriptions (some may need rewording)"
+              echo "- [ ] Confirm types (bool/string/int64/list_string/map_string) are correct"
+              echo "- [ ] Decide if any new attribute should be \`sensitive\` or \`skip_empty_read\`"
+              echo "- [ ] Add acceptance test coverage if applicable"
+              echo ""
+            fi
             echo "## Codegen Output"
             echo '```'
             cat /tmp/codegen-output.txt
             echo '```'
+            if [ "${APPLIED:-0}" -gt 0 ]; then
+              echo ""
+              echo "## Discover-Apply Output"
+              echo '```'
+              cat /tmp/apply-output.txt
+              echo '```'
+            fi
           } > /tmp/pr-body.md
+
+      - name: Compute PR title
+        id: pr_meta
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          APPLIED="${{ steps.apply.outputs.count }}"
+          if [ "${APPLIED:-0}" -gt 0 ]; then
+            echo "title=feat: auto-discover ${APPLIED} new project_config attribute(s) + regenerate" >> "$GITHUB_OUTPUT"
+            echo "draft=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "title=feat: regenerate project_config from latest OpenAPI spec" >> "$GITHUB_OUTPUT"
+            echo "draft=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create PR for generated file changes
         if: steps.diff.outputs.changed == 'true' && (github.event_name != 'workflow_dispatch' || github.event.inputs.create_pr == 'true')
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
-          commit-message: "feat: regenerate project_config from latest OpenAPI spec"
-          title: "feat: regenerate project_config from latest OpenAPI spec"
+          commit-message: ${{ steps.pr_meta.outputs.title }}
+          title: ${{ steps.pr_meta.outputs.title }}
           body-path: /tmp/pr-body.md
           branch: chore/regenerate-project-config
           delete-branch: true
+          draft: ${{ steps.pr_meta.outputs.draft == 'true' }}
 
-      - name: Create issue for unmapped properties
-        if: steps.unmapped.outputs.found == 'true'
+      - name: Create issue for master-ahead-of-pinned drift
+        if: steps.unmapped.outputs.found == 'true' && steps.apply.outputs.count == '0'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
@@ -127,22 +184,22 @@ jobs:
               labels: 'codegen-drift',
             });
 
+            const body = `The daily OpenAPI spec check found **${count} new properties** in the \`normalizedProjectRevision\` schema (master branch of ory/client-go) that are not yet mapped in the Terraform provider. These are not yet in the pinned client-go version, so auto-discovery could not append them.\n\n\`\`\`\n${output}\n\`\`\`\n\n## Next steps\n\n- Wait for Renovate to bump client-go to a version that includes these properties. On merge, the regenerate workflow will auto-append them to \`mappings.yaml\` and open a draft PR.\n- Or, bump client-go manually and run \`make discover\` locally.\n\nSee [CONTRIBUTING.md](CONTRIBUTING.md#project-config-codegen) for details.`;
+
             if (issues.data.length > 0) {
-              // Update existing issue
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issues.data[0].number,
-                body: `Daily spec check found ${count} unmapped properties.\n\n\`\`\`\n${output}\n\`\`\`\n\nRun \`make discover\` to generate YAML entries for these properties.`,
+                body: `Daily spec check found ${count} unmapped master-only properties.\n\n\`\`\`\n${output}\n\`\`\``,
               });
             } else {
-              // Create new issue
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: `feat: ${count} new API properties detected in OpenAPI spec`,
+                title: `feat: ${count} new API properties detected in master OpenAPI spec`,
                 labels: ['codegen-drift'],
-                body: `The daily OpenAPI spec check found **${count} new properties** in the \`normalizedProjectRevision\` schema that are not yet mapped in the Terraform provider.\n\n\`\`\`\n${output}\n\`\`\`\n\n## How to add them\n\n1. Run \`make discover\` to generate YAML entries and Go struct fields\n2. Add the entries to \`internal/codegen/mappings.yaml\`\n3. Add the struct fields to \`ProjectConfigResourceModel\` in \`resource.go\`\n4. Run \`make generate && make format\`\n\nSee [CONTRIBUTING.md](CONTRIBUTING.md#project-config-codegen) for details.`,
+                body: body,
               });
             }
 
@@ -157,15 +214,17 @@ jobs:
               cat /tmp/codegen-output.txt
               echo '```'
             fi
+            if [ "${{ steps.apply.outputs.count }}" != "" ] && [ "${{ steps.apply.outputs.count }}" != "0" ]; then
+              echo ""
+              echo "**${{ steps.apply.outputs.count }} new attributes auto-appended** from pinned spec"
+            fi
             if [ "${{ steps.diff.outputs.changed }}" == "true" ]; then
-              echo "Generated files have changes -- PR created"
+              echo "Generated files have changes -- PR ${{ steps.pr_meta.outputs.draft == 'true' && 'draft ' || '' }}created"
             else
               echo "No changes detected in generated files"
             fi
-            if [ "${{ steps.unmapped.outputs.found }}" == "true" ]; then
+            if [ "${{ steps.unmapped.outputs.found }}" == "true" ] && [ "${{ steps.apply.outputs.count }}" == "0" ]; then
               echo ""
-              echo "**${{ steps.unmapped.outputs.count }} unmapped properties detected** -- issue created/updated"
-            else
-              echo "All spec properties are mapped"
+              echo "**${{ steps.unmapped.outputs.count }} unmapped master-only properties detected** -- issue created/updated"
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/internal/codegen/cmd/generate/generate_test.go
+++ b/internal/codegen/cmd/generate/generate_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestGovernsToPatchPath(t *testing.T) {
 	tests := []struct {
@@ -77,5 +82,92 @@ func TestDeriveTerraformName(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("deriveTerraformName(%q): got %q, want %q", tt.openapi, got, tt.want)
 		}
+	}
+}
+
+func TestAppendToMappingsFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mappings.yaml")
+	original := "attributes:\n  - name: foo\n    go_field: Foo\n    type: bool\n"
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := appendToMappingsFile(path, "\n  - name: bar\n    go_field: Bar\n"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	got, err := os.ReadFile(path) //nolint:gosec // test file
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	want := "attributes:\n  - name: foo\n    go_field: Foo\n    type: bool\n\n  - name: bar\n    go_field: Bar\n"
+	if string(got) != want {
+		t.Errorf("unexpected content:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func TestAppendToMappingsFileHandlesMissingTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mappings.yaml")
+	if err := os.WriteFile(path, []byte("attributes:\n  - name: foo"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := appendToMappingsFile(path, "\n  - name: bar\n"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	got, err := os.ReadFile(path) //nolint:gosec // test file
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.HasPrefix(string(got), "attributes:\n  - name: foo\n\n") {
+		t.Errorf("expected single-newline separator, got %q", got)
+	}
+}
+
+func TestInsertStructFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resource.go")
+	src := `package foo
+
+type ProjectConfigResourceModel struct {
+	ID types.String ` + "`tfsdk:\"id\"`" + `
+}
+
+func other() {}
+`
+	if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	fields := []string{
+		"\tNewField1 types.Bool `tfsdk:\"new_field_1\"`",
+		"\tNewField2 types.String `tfsdk:\"new_field_2\"`",
+	}
+	if err := insertStructFields(path, "ProjectConfigResourceModel", fields); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	got, err := os.ReadFile(path) //nolint:gosec // test file
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	content := string(got)
+	if !strings.Contains(content, "\tID types.String `tfsdk:\"id\"`\n") {
+		t.Errorf("original field missing: %s", content)
+	}
+	if !strings.Contains(content, "NewField1 types.Bool") || !strings.Contains(content, "NewField2 types.String") {
+		t.Errorf("inserted fields missing: %s", content)
+	}
+	if !strings.Contains(content, "\n}\n\nfunc other()") {
+		t.Errorf("closing brace or trailing content broken: %s", content)
+	}
+}
+
+func TestInsertStructFieldsErrorsOnMissingStruct(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resource.go")
+	if err := os.WriteFile(path, []byte("package foo\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	err := insertStructFields(path, "ProjectConfigResourceModel", []string{"\tX types.Bool"})
+	if err == nil {
+		t.Fatal("expected error for missing struct, got nil")
 	}
 }

--- a/internal/codegen/cmd/generate/main.go
+++ b/internal/codegen/cmd/generate/main.go
@@ -256,6 +256,8 @@ func main() {
 	outDir := flag.String("out", ".", "output directory for generated files")
 	specPath := flag.String("spec", "", "path to OpenAPI spec (JSON or YAML) for governs-based path derivation and validation")
 	discover := flag.Bool("discover", false, "output YAML entries for unmapped spec properties (requires --spec)")
+	discoverApply := flag.Bool("discover-apply", false, "append YAML entries to mappings file and Go struct fields to resource.go for unmapped spec properties (requires --spec)")
+	resourceFile := flag.String("resource-file", "", "path to resource.go for -discover-apply struct field insertion (default: <out>/resource.go)")
 	strict := flag.Bool("strict", false, "fail if any spec properties are unmapped (use in CI to detect drift)")
 	flag.Parse()
 
@@ -288,13 +290,26 @@ func main() {
 			return
 		}
 
+		if *discoverApply {
+			resourcePath := *resourceFile
+			if resourcePath == "" {
+				resourcePath = filepath.Join(*outDir, "resource.go")
+			}
+			count, err := applyDiscoveredEntries(m, specProps, cleanMappingsPath, resourcePath)
+			if err != nil {
+				log.Fatalf("discover-apply: %v", err)
+			}
+			fmt.Printf("discover-apply: %d new attributes appended\n", count)
+			return
+		}
+
 		// Report unmapped spec properties (candidates for new entries)
 		unmappedCount := reportUnmapped(m, specProps)
 		if *strict && unmappedCount > 0 {
 			log.Fatalf("STRICT MODE: %d unmapped spec properties found. Run 'make discover' to generate YAML entries.", unmappedCount)
 		}
-	} else if *discover {
-		log.Fatal("--discover requires --spec")
+	} else if *discover || *discoverApply {
+		log.Fatal("--discover / --discover-apply requires --spec")
 	} else if *strict {
 		log.Fatal("--strict requires --spec")
 	}
@@ -604,6 +619,144 @@ func discoverNewEntries(m Mappings, specProps map[string]SpecProperty) {
 		fmt.Println(f)
 	}
 	fmt.Printf("\n// Total: %d new attributes\n", len(unmapped))
+}
+
+// collectUnmappedProperties returns the spec properties that have a governs path
+// and a supported type but are not yet present in mappings. Shared by
+// discoverNewEntries and applyDiscoveredEntries so both produce the same set.
+func collectUnmappedProperties(m Mappings, specProps map[string]SpecProperty) []SpecProperty {
+	mapped := make(map[string]bool)
+	mappedPaths := make(map[string]bool)
+	for _, a := range m.Attributes {
+		if a.OpenAPIProperty != "" {
+			mapped[a.OpenAPIProperty] = true
+		}
+		if a.PatchPath != "" {
+			mappedPaths[a.PatchPath] = true
+		}
+	}
+	excluded := excludedProperties()
+
+	var unmapped []SpecProperty
+	for _, sp := range specProps {
+		if excluded[sp.Name] || mapped[sp.Name] {
+			continue
+		}
+		if sp.GovernsPath != "" && mappedPaths[sp.GovernsPath] {
+			continue
+		}
+		if sp.GovernsPath != "" && discoverTypeToTFType(sp.Type, sp.ItemType, sp.AdditionalPropertiesType) != "" {
+			unmapped = append(unmapped, sp)
+		}
+	}
+	sortSpecProperties(unmapped)
+	return unmapped
+}
+
+// applyDiscoveredEntries appends YAML entries for unmapped properties to
+// mappingsPath and inserts matching Go struct fields into resourcePath's
+// ProjectConfigResourceModel struct. Returns the number of entries added.
+func applyDiscoveredEntries(m Mappings, specProps map[string]SpecProperty, mappingsPath, resourcePath string) (int, error) {
+	unmapped := collectUnmappedProperties(m, specProps)
+	if len(unmapped) == 0 {
+		return 0, nil
+	}
+
+	var yamlBuf strings.Builder
+	yamlBuf.WriteString("\n  # --- Auto-discovered entries (review names/descriptions before merging) ---\n")
+	goFields := make([]string, 0, len(unmapped))
+	for _, sp := range unmapped {
+		tfName := deriveTerraformName(sp.Name)
+		goField := toGoFieldName(tfName)
+		tfType := discoverTypeToTFType(sp.Type, sp.ItemType, sp.AdditionalPropertiesType)
+		desc := cleanDescription(sp.Description)
+
+		fmt.Fprintf(&yamlBuf, "  - name: %s\n", tfName)
+		fmt.Fprintf(&yamlBuf, "    go_field: %s\n", goField)
+		fmt.Fprintf(&yamlBuf, "    type: %s\n", tfType)
+		fmt.Fprintf(&yamlBuf, "    openapi_property: %s\n", sp.Name)
+		fmt.Fprintf(&yamlBuf, "    description: %q\n", desc)
+		yamlBuf.WriteString("\n")
+
+		goType := "types.String"
+		switch tfType {
+		case typeBool:
+			goType = "types.Bool"
+		case typeInt64:
+			goType = "types.Int64"
+		case typeListString:
+			goType = "types.List"
+		case typeMapString:
+			goType = "types.Map"
+		}
+		goFields = append(goFields, fmt.Sprintf("\t%s %s `tfsdk:\"%s\"`", goField, goType, tfName))
+	}
+
+	if err := appendToMappingsFile(mappingsPath, yamlBuf.String()); err != nil {
+		return 0, fmt.Errorf("appending to mappings: %w", err)
+	}
+	if err := insertStructFields(resourcePath, "ProjectConfigResourceModel", goFields); err != nil {
+		return 0, fmt.Errorf("inserting struct fields: %w", err)
+	}
+	return len(unmapped), nil
+}
+
+// appendToMappingsFile appends text to the mappings file, ensuring the file
+// ends with a single newline before the appended content.
+func appendToMappingsFile(path, content string) error {
+	cleanPath := filepath.Clean(path)
+	data, err := os.ReadFile(cleanPath) //nolint:gosec // path from trusted CLI flag
+	if err != nil {
+		return err
+	}
+	// Ensure the existing file ends with exactly one newline before our block.
+	trimmed := strings.TrimRight(string(data), "\n") + "\n"
+	// #nosec G703 -- path from trusted CLI flag, not user input
+	return os.WriteFile(cleanPath, []byte(trimmed+content), 0o600)
+}
+
+// insertStructFields inserts the given field lines immediately before the
+// closing brace of the named top-level struct. The struct is expected to be
+// declared at column 0 with `type <name> struct {` and closed with a `}` at
+// column 0.
+func insertStructFields(path, structName string, fields []string) error {
+	cleanPath := filepath.Clean(path)
+	data, err := os.ReadFile(cleanPath) //nolint:gosec // path from trusted CLI flag
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(data), "\n")
+
+	startPrefix := fmt.Sprintf("type %s struct {", structName)
+	startIdx := -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, startPrefix) {
+			startIdx = i
+			break
+		}
+	}
+	if startIdx < 0 {
+		return fmt.Errorf("struct %q not found in %s", structName, path)
+	}
+	closeIdx := -1
+	for i := startIdx + 1; i < len(lines); i++ {
+		if lines[i] == "}" {
+			closeIdx = i
+			break
+		}
+	}
+	if closeIdx < 0 {
+		return fmt.Errorf("closing brace of struct %q not found in %s", structName, path)
+	}
+
+	insertion := append([]string{"", "\t// Auto-discovered (review naming before release)"}, fields...)
+	newLines := make([]string, 0, len(lines)+len(insertion))
+	newLines = append(newLines, lines[:closeIdx]...)
+	newLines = append(newLines, insertion...)
+	newLines = append(newLines, lines[closeIdx:]...)
+
+	// #nosec G703 -- path from trusted CLI flag, not user input
+	return os.WriteFile(cleanPath, []byte(strings.Join(newLines, "\n")), 0o600)
 }
 
 // sortSpecProperties sorts spec properties by name for deterministic output.


### PR DESCRIPTION
## Description

When Renovate bumps `github.com/ory/client-go` to a version that introduces new `normalizedProjectRevision` properties, the existing regenerate workflow only filed an issue telling a maintainer to run `make discover` and hand-edit two files. This PR extends the workflow to do that work automatically and open a draft PR that is ready to review.

**Before:** issue #183 filed, maintainer does the edits manually.
**After:** `mappings.yaml` and `ProjectConfigResourceModel` are appended automatically, `_gen.go` files are regenerated, and a draft PR is opened with a review checklist.

The auto-discovery runs against the **pinned** spec (the version already resolved into `go.sum`), so generated code is guaranteed to compile against the Go client types that exist at HEAD. The master-spec strict check remains as a fallback and now only creates an issue when master is ahead of pinned (i.e., for drift that auto-discovery cannot safely apply yet).

## Related Issues

Closes #183

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## What Changed

### `internal/codegen/cmd/generate/main.go`

- New flag `-discover-apply` (and optional `-resource-file`): reads mappings + spec, appends YAML entries for any unmapped governed properties to `mappings.yaml`, and inserts matching Go struct fields into `ProjectConfigResourceModel` in `resource.go`. Prints `discover-apply: N new attributes appended` and exits 0 (so a zero-finding run is a no-op).
- Refactored the unmapped-property selection into `collectUnmappedProperties` so `-discover` (print-only) and `-discover-apply` (mutating) produce the same set.
- File edits are delimited:
  - `appendToMappingsFile` normalizes the trailing newline, then appends a commented block `# --- Auto-discovered entries (review names/descriptions before merging) ---` followed by the entries.
  - `insertStructFields` finds the top-level `type ProjectConfigResourceModel struct {` line and inserts before the first column-0 `}` that follows it, with a `// Auto-discovered (review naming before release)` marker.

### `.github/workflows/regenerate-config.yml`

- New step `Auto-apply unmapped properties from pinned spec` runs `-discover-apply`, then re-runs codegen when anything was appended so the `_gen.go` files reflect the new entries.
- `Check for generated file changes` now also watches `internal/codegen/mappings.yaml`.
- PR title and draft flag are computed dynamically: when auto-discovery appends entries, the PR is opened as a draft with a review checklist for attribute names, descriptions, types, and sensitivity.
- The issue-creation step only fires when master-spec drift exists but pinned-spec auto-discovery appended nothing (i.e., master is ahead of the pinned client-go release).

### `internal/codegen/cmd/generate/generate_test.go`

- `TestAppendToMappingsFile` and `TestAppendToMappingsFileHandlesMissingTrailingNewline` cover the file-append helper.
- `TestInsertStructFields` and `TestInsertStructFieldsErrorsOnMissingStruct` cover the struct-field insertion, including the missing-struct error path.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests — new tests for `appendToMappingsFile` and `insertStructFields` pass alongside the existing codegen tests.
- [x] Manual testing — simulated the full workflow locally against both the pinned v1.22.36 spec and the current master spec:
  1. `go run ./internal/codegen/cmd/generate/ -mappings ./internal/codegen/mappings.yaml -spec ./internal/codegen/openapi.yaml -discover-apply -out ./internal/resources/projectconfig/` reported `discover-apply: 1 new attributes appended` for the currently-unmapped `hydra_oauth2_preserve_ext_claims` property.
  2. Re-running codegen regenerated `schema_gen.go`, `patches_gen.go`, and `read_gen.go` with entries that correctly reference the new `OAuth2PreserveExtClaims` struct field.
  3. `go build ./...` and `go test ./internal/resources/projectconfig/...` both passed after the auto-applied changes.
  4. Restored the files and re-ran `make format`, `make lint`, and `make sec` — all clean.
- [ ] Acceptance tests — not applicable; the change is a CI + codegen enhancement and does not modify any runtime resource behavior.

## Output

Dry run of the new flow against the pinned v1.22.36 spec:

```
$ go run ./internal/codegen/cmd/generate/ -mappings ./internal/codegen/mappings.yaml -spec ./internal/codegen/openapi.yaml -discover-apply -out ./internal/resources/projectconfig/
...
discover-apply: 1 new attributes appended

$ git diff --stat
 internal/codegen/mappings.yaml                  | 8 ++++++++
 internal/resources/projectconfig/patches_gen.go | 1 +
 internal/resources/projectconfig/read_gen.go    | 1 +
 internal/resources/projectconfig/resource.go    | 3 +++
 internal/resources/projectconfig/schema_gen.go  | 4 ++++
 5 files changed, 17 insertions(+)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated discovery and application of unmapped specification properties to the code generation pipeline.
  * Enhanced CI workflow to conditionally manage pull requests and issues based on auto-discovery results.

* **Tests**
  * Expanded test coverage for file handling and struct field insertion during code generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->