### PR TITLE
fix(action): serialize mutations to prevent clobbered hooks

### DIFF
--- a/internal/resources/action/resource.go
+++ b/internal/resources/action/resource.go
@@ -3,8 +3,10 @@ package action
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -39,6 +41,19 @@ var (
 	_ resource.ResourceWithImportState    = &ActionResource{}
 	_ resource.ResourceWithValidateConfig = &ActionResource{}
 )
+
+// projectMutexes serializes Create, Update, and Delete operations per project.
+// The Ory API stores action hooks as arrays nested in the project config. Every
+// mutation is a read-modify-write (read hooks → append/replace/remove → PatchProject).
+// Without serialization, concurrent operations read the same stale hooks array
+// and the last write wins, silently dropping the other hooks.
+// See: https://github.com/ory/terraform-provider-ory/issues/189
+var projectMutexes sync.Map // map[projectID]*sync.Mutex
+
+func projectMutex(projectID string) *sync.Mutex {
+	v, _ := projectMutexes.LoadOrStore(projectID, &sync.Mutex{})
+	return v.(*sync.Mutex)
+}
 
 func NewResource() resource.Resource {
 	return &ActionResource{}
@@ -485,61 +500,34 @@ func (r *ActionResource) buildHookValue(plan *ActionResourceModel) map[string]in
 	}
 }
 
+// copyHooks returns a deep copy of the hooks slice via a JSON round-trip so
+// callers cannot accidentally mutate the cached project state shared with
+// other resources in the same Terraform run.
+func copyHooks(hooks []map[string]interface{}) []map[string]interface{} {
+	b, err := json.Marshal(hooks)
+	if err != nil {
+		return hooks
+	}
+	var cp []map[string]interface{}
+	if err := json.Unmarshal(b, &cp); err != nil {
+		return hooks
+	}
+	return cp
+}
+
 func (r *ActionResource) getHooks(ctx context.Context, projectID, flow, timing, authMethod string) ([]map[string]interface{}, error) {
+	// Prefer cached project state from a previous PatchProject call in this
+	// Terraform run. This avoids reading stale data from the eventually-consistent
+	// GetProject API, which is critical when the mutex serializes back-to-back
+	// mutations — the second operation must see the first operation's result.
+	if cached := r.client.GetCachedProject(projectID); cached != nil {
+		return copyHooks(r.getHooksFromProject(cached, flow, timing, authMethod)), nil
+	}
 	project, err := r.client.GetProject(ctx, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get project %s: %w", projectID, err)
 	}
-
-	if project.Services.Identity == nil {
-		return []map[string]interface{}{}, nil
-	}
-
-	configMap := project.Services.Identity.Config
-	if configMap == nil {
-		return []map[string]interface{}{}, nil
-	}
-
-	selfservice, ok := configMap["selfservice"].(map[string]interface{})
-	if !ok {
-		return []map[string]interface{}{}, nil
-	}
-
-	flows, ok := selfservice["flows"].(map[string]interface{})
-	if !ok {
-		return []map[string]interface{}{}, nil
-	}
-
-	flowConfig, ok := flows[flow].(map[string]interface{})
-	if !ok {
-		return []map[string]interface{}{}, nil
-	}
-
-	timingConfig, ok := flowConfig[timing].(map[string]interface{})
-	if !ok {
-		return []map[string]interface{}{}, nil
-	}
-
-	// For 'after' timing, hooks are nested under the auth method
-	// For 'before' timing, hooks are directly under timing
-	var hooks []interface{}
-	if timing == timingAfter {
-		authMethodConfig, ok := timingConfig[authMethod].(map[string]interface{})
-		if !ok {
-			return []map[string]interface{}{}, nil
-		}
-		hooks, _ = authMethodConfig["hooks"].([]interface{})
-	} else {
-		hooks, _ = timingConfig["hooks"].([]interface{})
-	}
-
-	result := make([]map[string]interface{}, 0, len(hooks))
-	for _, h := range hooks {
-		if hm, ok := h.(map[string]interface{}); ok {
-			result = append(result, hm)
-		}
-	}
-	return result, nil
+	return r.getHooksFromProject(project, flow, timing, authMethod), nil
 }
 
 func (r *ActionResource) findHookIndex(hooks []map[string]interface{}, url, method string) int {
@@ -634,6 +622,11 @@ func (r *ActionResource) Create(ctx context.Context, req resource.CreateRequest,
 	authMethod := plan.AuthMethod.ValueString()
 	url := plan.URL.ValueString()
 	httpMethod := plan.HTTPMethod.ValueString()
+
+	// Serialize mutations to prevent concurrent read-modify-write races.
+	mu := projectMutex(projectID)
+	mu.Lock()
+	defer mu.Unlock()
 
 	// Check if hook already exists
 	hooks, err := r.getHooks(ctx, projectID, flow, timing, authMethod)
@@ -911,6 +904,11 @@ func (r *ActionResource) Update(ctx context.Context, req resource.UpdateRequest,
 	url := state.URL.ValueString() // Use old URL to find
 	httpMethod := state.HTTPMethod.ValueString()
 
+	// Serialize mutations to prevent concurrent read-modify-write races.
+	mu := projectMutex(projectID)
+	mu.Lock()
+	defer mu.Unlock()
+
 	hooks, err := r.getHooks(ctx, projectID, flow, timing, authMethod)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Getting Hooks", err.Error())
@@ -968,6 +966,11 @@ func (r *ActionResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	authMethod := state.AuthMethod.ValueString()
 	url := state.URL.ValueString()
 	httpMethod := state.HTTPMethod.ValueString()
+
+	// Serialize mutations to prevent concurrent read-modify-write races.
+	mu := projectMutex(projectID)
+	mu.Lock()
+	defer mu.Unlock()
 
 	hooks, err := r.getHooks(ctx, projectID, flow, timing, authMethod)
 	if err != nil {

--- a/internal/resources/action/resource.go
+++ b/internal/resources/action/resource.go
@@ -646,7 +646,7 @@ func (r *ActionResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	// Append the new hook to existing hooks and replace the entire array
 	// This handles the case where the hooks array might not exist
-	newHooks := make([]interface{}, 0, len(hooks)+1)
+	newHooks := make([]interface{}, 0, len(hooks))
 	for _, h := range hooks {
 		newHooks = append(newHooks, h)
 	}

--- a/internal/resources/action/resource.go
+++ b/internal/resources/action/resource.go
@@ -506,6 +506,7 @@ func (r *ActionResource) buildHookValue(plan *ActionResourceModel) map[string]in
 func copyHooks(hooks []map[string]interface{}) []map[string]interface{} {
 	b, err := json.Marshal(hooks)
 	if err != nil {
+		// Should never happen — the data was decoded from JSON.
 		return hooks
 	}
 	var cp []map[string]interface{}

--- a/internal/resources/action/resource_test.go
+++ b/internal/resources/action/resource_test.go
@@ -191,6 +191,103 @@ func TestAccActionResource_withBasicAuth(t *testing.T) {
 	})
 }
 
+// TestAccActionResource_parallel verifies that creating and destroying multiple
+// actions in the same flow/timing/auth_method does not suffer from
+// read-modify-write races. Without per-project serialization, Terraform's
+// default parallelism causes concurrent goroutines to read the same hooks
+// array, append their own hook, and replace the array — so the last writer
+// wins and the other hooks are silently dropped. See issue #189.
+func TestAccActionResource_parallel(t *testing.T) {
+	hookPath := "/services/identity/config/selfservice/flows/registration/after/password/hooks"
+	urls := []string{
+		testutil.ExampleWebhookURL + "/parallel-a",
+		testutil.ExampleWebhookURL + "/parallel-b",
+		testutil.ExampleWebhookURL + "/parallel-c",
+		testutil.ExampleWebhookURL + "/parallel-d",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.AccPreCheck(t)
+			for _, u := range urls {
+				cleanupDanglingWebhook(t, hookPath, u)
+			}
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/parallel.tf.tmpl", map[string]string{"WebhookURL": testutil.ExampleWebhookURL}),
+				Check:  allParallelHooksExist(hookPath, urls),
+			},
+		},
+	})
+}
+
+// allParallelHooksExist asserts that every URL in urls is present in the hooks
+// array at hookPath on the test project. This is the invariant issue #189
+// breaks: all resources report success, but only some of them actually landed.
+func allParallelHooksExist(hookPath string, urls []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		c, err := acctest.GetOryClient()
+		if err != nil {
+			return fmt.Errorf("could not create client: %w", err)
+		}
+
+		var projectID string
+		for _, rs := range s.RootModule().Resources {
+			if pid := rs.Primary.Attributes["project_id"]; pid != "" {
+				projectID = pid
+				break
+			}
+		}
+		if projectID == "" {
+			return fmt.Errorf("no project_id found in state")
+		}
+
+		ctx := context.Background()
+		p, err := c.GetProject(ctx, projectID)
+		if err != nil {
+			return fmt.Errorf("could not get project: %w", err)
+		}
+
+		trimmed := strings.TrimPrefix(hookPath, "/services/identity/config/")
+		trimmed = strings.TrimSuffix(trimmed, "/hooks")
+		segments := strings.Split(trimmed, "/")
+
+		var current interface{} = p.Services.Identity.Config
+		for _, seg := range segments {
+			m, ok := current.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("unexpected type at segment %q", seg)
+			}
+			current = m[seg]
+			if current == nil {
+				return fmt.Errorf("nothing found at segment %q", seg)
+			}
+		}
+		hooks, _ := current.(map[string]interface{})["hooks"].([]interface{})
+
+		found := make(map[string]bool, len(urls))
+		for _, h := range hooks {
+			hm, _ := h.(map[string]interface{})
+			if hm["hook"] != "web_hook" {
+				continue
+			}
+			cfg, _ := hm["config"].(map[string]interface{})
+			if url, _ := cfg["url"].(string); url != "" {
+				found[url] = true
+			}
+		}
+
+		for _, u := range urls {
+			if !found[u] {
+				return fmt.Errorf("expected webhook %q to exist at %s but it was not found (race condition clobbered it)", u, hookPath)
+			}
+		}
+		return nil
+	}
+}
+
 func TestAccActionResource_withAPIKeyAuth(t *testing.T) {
 	hookPath := "/services/identity/config/selfservice/flows/registration/after/password/hooks"
 	resource.Test(t, resource.TestCase{

--- a/internal/resources/action/testdata/parallel.tf.tmpl
+++ b/internal/resources/action/testdata/parallel.tf.tmpl
@@ -1,0 +1,31 @@
+resource "ory_action" "parallel_a" {
+  flow        = "registration"
+  timing      = "after"
+  auth_method = "password"
+  url         = "[[ .WebhookURL ]]/parallel-a"
+  method      = "POST"
+}
+
+resource "ory_action" "parallel_b" {
+  flow        = "registration"
+  timing      = "after"
+  auth_method = "password"
+  url         = "[[ .WebhookURL ]]/parallel-b"
+  method      = "POST"
+}
+
+resource "ory_action" "parallel_c" {
+  flow        = "registration"
+  timing      = "after"
+  auth_method = "password"
+  url         = "[[ .WebhookURL ]]/parallel-c"
+  method      = "POST"
+}
+
+resource "ory_action" "parallel_d" {
+  flow        = "registration"
+  timing      = "after"
+  auth_method = "password"
+  url         = "[[ .WebhookURL ]]/parallel-d"
+  method      = "POST"
+}


### PR DESCRIPTION
## Description

Fixes a race condition where applying multiple `ory_action` resources in the same flow/timing/auth_method silently drops all but one of them.

The `ory_action` resource uses a read-modify-write pattern: it reads the full hooks array from the project config, appends/replaces/removes its entry, and PATCHes the entire array back. When Terraform applies multiple actions in parallel (default parallelism is 10), concurrent goroutines read the same stale hooks array and their writes clobber each other. Every `Create` reports success, but only the last writer's hook persists — subsequent plans then show drift and try to create the missing hooks again, producing exactly the symptoms described in the issue (warnings about webhooks found at the location not matching, hooks reordering, apply cycles that never converge).

The fix follows the existing pattern used by `ory_social_provider` for the same class of bug: a per-project `sync.Mutex` serializes `Create`, `Update`, and `Delete` so only one mutation runs against a given project at a time. `getHooks` now also prefers the cached project populated by `PatchProject` so that serialized back-to-back mutations see each other's writes rather than a stale eventually-consistent `GetProject` response.

## Related Issues

Fixes #189

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

- [x] Unit tests — `make test-short` passes
- [x] Acceptance tests — new `TestAccActionResource_parallel` creates four webhooks concurrently on the same flow/timing/auth_method and asserts the backend persists all of them. Existing `TestAccActionResource_basic`, `TestAccActionResource_withBasicAuth`, and `TestAccActionResource_withAPIKeyAuth` still pass.
- [x] Manual testing — reproduced the original bug on staging with four `ory_action` resources via `for_each` (only 2 of 4 persisted before the fix); after the fix, the same config produces all four hooks and `terraform plan` reports no drift. Verified `terraform apply` (create + replace), `terraform import`, and `terraform destroy` with parallelism all converge cleanly.

## Screenshots/Output

Before the fix, a single `terraform apply` of four actions on the same flow reported success for all four but left only two in the backend:

```
ory_action.test["a"]: Creation complete after 8s
ory_action.test["b"]: Creation complete after 7s
ory_action.test["c"]: Creation complete after 7s
ory_action.test["d"]: Creation complete after 5s
Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
```

Immediately followed by `terraform plan`:

```
Plan: 2 to add, 0 to change, 0 to destroy.

Warning: Action Not Found - Resource Removed From State
  No webhook found matching:
    URL: https://webhook.site/example/action-c
    Method: POST
    Flow: registration/after/oidc
  Webhooks found at this location:
    - POST https://webhook.site/example/action-d
    - POST https://webhook.site/example/action-a
```

After the fix, the same apply persists all four and `plan` reports "No changes".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved race/clobber when creating/updating/deleting action resources by serializing per-project operations and preventing shared-state mutation of webhook configurations.

* **Performance**
  * Improved use of cached project data and ensured returned webhook lists are independent copies to maintain consistent state.

* **Tests**
  * Added an acceptance test that creates multiple action resources in parallel and verifies all webhook entries are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->