### PR TITLE
ci: use ORY_BOT_PAT for codegen PR creation to trigger downstream checks

### DIFF
--- a/.github/workflows/regenerate-config.yml
+++ b/.github/workflows/regenerate-config.yml
@@ -176,6 +176,12 @@ jobs:
         if: steps.diff.outputs.changed == 'true' && (github.event_name != 'workflow_dispatch' || github.event.inputs.create_pr == 'true')
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
+          # Use ORY_BOT_PAT so the resulting PR triggers downstream workflows
+          # (lint, unit tests, acceptance tests, security). PRs created with the
+          # default GITHUB_TOKEN do not trigger workflows that listen on the
+          # `pull_request` event. See:
+          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+          token: ${{ secrets.ORY_BOT_PAT }}
           commit-message: ${{ steps.pr_meta.outputs.title }}
           title: ${{ steps.pr_meta.outputs.title }}
           body-path: /tmp/pr-body.md


### PR DESCRIPTION
## Description

The auto-codegen workflow (`.github/workflows/regenerate-config.yml`) was creating PRs that did not trigger the lint, unit-test, acceptance-test, or security workflows. This is a deliberate GitHub safeguard: workflows that listen on `pull_request` events do not run when the PR is opened by the default `GITHUB_TOKEN`, in order to prevent infinite workflow recursion.

PR #206 is the most recent example — only CodeQL (which runs on `push`) and the conventional-commits validation (which uses `pull_request_target`) executed; lint/unit/acceptance/security were silently skipped.

This change passes `secrets.ORY_BOT_PAT` to the `peter-evans/create-pull-request` action, mirroring the pattern already used by the Renovate workflow (`.github/workflows/renovate.yaml:30`). PRs opened with a non-`GITHUB_TOKEN` credential trigger downstream workflows normally.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [ ] I have added tests that prove my fix/feature works
- [ ] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [ ] Unit tests
- [ ] Acceptance tests
- [x] Manual testing

Verified locally:
- `actionlint` passes on the modified workflow
- `make format` produces no changes
- `make sec` (gosec, govulncheck, gitleaks) all pass clean
- `make test` passes

The end-to-end fix can only be verified when `regenerate-config.yml` next opens a PR — the resulting PR should show the full check suite (lint, unit-test, acceptance-test, security) instead of only CodeQL + commit-validation.

## Screenshots/Output

Existing PR with the bug (only CodeQL + commit-validation ran):
https://github.com/ory/terraform-provider-ory/pull/206

For comparison, Renovate PRs use the same `ORY_BOT_PAT` pattern and trigger the full check suite normally (#205, #204, #203).