### PR TITLE
feat(social-provider): add pkce attribute to social provider resource

### DIFF
--- a/docs/resources/social_provider.md
+++ b/docs/resources/social_provider.md
@@ -323,6 +323,27 @@ resource "ory_social_provider" "enterprise_sso" {
 }
 ```
 
+## PKCE
+
+The `pkce` attribute controls whether the OAuth2 authorization code flow uses [Proof Key for Code Exchange (RFC 7636)](https://datatracker.ietf.org/doc/html/rfc7636) when redirecting users to the upstream provider:
+
+| Value | Description |
+|-------|-------------|
+| `auto` (default) | Enable PKCE only when the upstream provider advertises support via OIDC discovery. |
+| `force` | Always send the PKCE challenge. Use only with providers known to support it — providers that do not understand PKCE may reject the authorization request. |
+| `never` | Disable PKCE for this provider. |
+
+```hcl
+resource "ory_social_provider" "google" {
+  provider_id   = "google"
+  provider_type = "google"
+  client_id     = var.google_client_id
+  client_secret = var.google_client_secret
+  scope         = ["email", "profile"]
+  pkce          = "force"
+}
+```
+
 ## Base Redirect URI
 
 The `base_redirect_uri` attribute overrides the base URL Ory uses when constructing OIDC callback URLs. Use this when your project is accessible under a custom domain and you want callbacks to go to that domain rather than the default Ory project URL.
@@ -385,6 +406,7 @@ The `provider_id` is the unique identifier you chose when creating the provider.
 - `issuer_url` (String) OIDC issuer URL (required for generic providers).
 - `label` (String) Human-readable label for the provider, displayed on the login button (e.g., "Sign in with Corporate SSO").
 - `mapper_url` (String) Jsonnet mapper URL for claims mapping. Can be a URL or base64-encoded Jsonnet (base64://...). If not set, a default mapper that extracts email from claims will be used.
+- `pkce` (String) PKCE (Proof Key for Code Exchange) behavior for the OAuth2 authorization code flow. "auto" (default) enables PKCE when the upstream provider advertises support via OIDC discovery; "force" always sends PKCE (use only with providers known to support it); "never" disables PKCE.
 - `project_id` (String) Project ID. If not set, uses provider's project_id.
 - `scope` (List of String) OAuth2 scopes to request.
 - `tenant` (String) Tenant ID (for Microsoft/Azure providers).

--- a/internal/resources/socialprovider/resource.go
+++ b/internal/resources/socialprovider/resource.go
@@ -79,6 +79,7 @@ type SocialProviderResourceModel struct {
 	AdditionalIDTokenAudiences types.List   `tfsdk:"additional_id_token_audiences"`
 	Aal2AcrValues              types.List   `tfsdk:"aal2_acr_values"`
 	Aal2AmrValues              types.List   `tfsdk:"aal2_amr_values"`
+	Pkce                       types.String `tfsdk:"pkce"`
 }
 
 func (r *SocialProviderResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -205,6 +206,13 @@ func (r *SocialProviderResource) Schema(ctx context.Context, req resource.Schema
 				Description: "Upstream OpenID Connect `amr` values (per RFC 8176, for example `mfa`, `otp`, `hwk`) that mark the session AAL2 when they appear in the upstream `amr` array. Leave unset to ignore the `amr` claim.",
 				Optional:    true,
 				ElementType: types.StringType,
+			},
+			"pkce": schema.StringAttribute{
+				Description: "PKCE (Proof Key for Code Exchange) behavior for the OAuth2 authorization code flow. \"auto\" (default) enables PKCE when the upstream provider advertises support via OIDC discovery; \"force\" always sends PKCE (use only with providers known to support it); \"never\" disables PKCE.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("auto", "force", "never"),
+				},
 			},
 		},
 	}
@@ -391,6 +399,10 @@ func (r *SocialProviderResource) buildProviderConfig(ctx context.Context, plan *
 		if len(values) > 0 {
 			config["aal2_amr_values"] = values
 		}
+	}
+
+	if !plan.Pkce.IsNull() && !plan.Pkce.IsUnknown() {
+		config["pkce"] = plan.Pkce.ValueString()
 	}
 
 	// Apple-specific fields — skip empty strings to avoid sending blank credentials
@@ -759,6 +771,12 @@ func (r *SocialProviderResource) Read(ctx context.Context, req resource.ReadRequ
 	// Read AAL2 elevation lists, clearing state when the API omits them.
 	state.Aal2AcrValues = readStringList(ctx, &resp.Diagnostics, provider["aal2_acr_values"])
 	state.Aal2AmrValues = readStringList(ctx, &resp.Diagnostics, provider["aal2_amr_values"])
+
+	if pkce, ok := provider["pkce"].(string); ok && pkce != "" {
+		state.Pkce = types.StringValue(pkce)
+	} else {
+		state.Pkce = types.StringNull()
+	}
 
 	// Read Apple-specific fields, clearing stale state when not returned by the API
 	if teamID, ok := provider["apple_team_id"].(string); ok && teamID != "" {

--- a/internal/resources/socialprovider/resource_test.go
+++ b/internal/resources/socialprovider/resource_test.go
@@ -313,6 +313,62 @@ func TestAccSocialProviderResource_additionalIDTokenAudiences(t *testing.T) {
 	})
 }
 
+// TestAccSocialProviderResource_pkce verifies that the pkce attribute is set,
+// read, updated, and removed correctly. PKCE accepts "auto", "force", or
+// "never"; this test exercises the round-trip for "force" → "never" → unset.
+func TestAccSocialProviderResource_pkce(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.AccPreCheck(t)
+			acctest.RequireSocialProviderTests(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create with pkce = "force"
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_pkce.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_social_provider.test", "id"),
+					resource.TestCheckResourceAttr("ory_social_provider.test", "provider_id", "test-google-pkce"),
+					resource.TestCheckResourceAttr("ory_social_provider.test", "pkce", "force"),
+				),
+			},
+			// Verify no perpetual diff
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/with_pkce.tf.tmpl", nil),
+				PlanOnly: true,
+			},
+			// Update pkce to "never"
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_pkce_updated.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_social_provider.test", "pkce", "never"),
+				),
+			},
+			// Remove pkce from config — should clear it server-side
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_pkce_removed.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("ory_social_provider.test", "pkce"),
+				),
+			},
+			// Verify no diff after removal
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/with_pkce_removed.tf.tmpl", nil),
+				PlanOnly: true,
+			},
+			// ImportState
+			{
+				ResourceName:            "ory_social_provider.test",
+				ImportState:             true,
+				ImportStateId:           "test-google-pkce",
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"client_secret"},
+			},
+		},
+	})
+}
+
 // TestAccSocialProviderResource_aal2Values exercises aal2_acr_values and
 // aal2_amr_values across create, update (changed list contents), removal, and
 // import. Values are opaque strings stored on the provider config — the API

--- a/internal/resources/socialprovider/resource_test.go
+++ b/internal/resources/socialprovider/resource_test.go
@@ -315,7 +315,9 @@ func TestAccSocialProviderResource_additionalIDTokenAudiences(t *testing.T) {
 
 // TestAccSocialProviderResource_pkce verifies that the pkce attribute is set,
 // read, updated, and removed correctly. PKCE accepts "auto", "force", or
-// "never"; this test exercises the round-trip for "force" → "never" → unset.
+// "never"; this test exercises the round-trip for "force" → "auto" → "never"
+// → unset, including the explicit "auto" value (which the API also uses as
+// its default when the attribute is absent).
 func TestAccSocialProviderResource_pkce(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -336,6 +338,19 @@ func TestAccSocialProviderResource_pkce(t *testing.T) {
 			// Verify no perpetual diff
 			{
 				Config:   acctest.LoadTestConfig(t, "testdata/with_pkce.tf.tmpl", nil),
+				PlanOnly: true,
+			},
+			// Update pkce to "auto" — explicit default; catches drift if the API
+			// normalizes "auto" to absence.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_pkce_auto.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_social_provider.test", "pkce", "auto"),
+				),
+			},
+			// Verify no perpetual diff on "auto"
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/with_pkce_auto.tf.tmpl", nil),
 				PlanOnly: true,
 			},
 			// Update pkce to "never"

--- a/internal/resources/socialprovider/testdata/with_pkce.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/with_pkce.tf.tmpl
@@ -1,0 +1,8 @@
+resource "ory_social_provider" "test" {
+  provider_id   = "test-google-pkce"
+  provider_type = "google"
+  client_id     = "test-client-id.apps.googleusercontent.com"
+  client_secret = "test-client-secret"
+  scope         = ["email", "profile"]
+  pkce          = "force"
+}

--- a/internal/resources/socialprovider/testdata/with_pkce_auto.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/with_pkce_auto.tf.tmpl
@@ -1,0 +1,8 @@
+resource "ory_social_provider" "test" {
+  provider_id   = "test-google-pkce"
+  provider_type = "google"
+  client_id     = "test-client-id.apps.googleusercontent.com"
+  client_secret = "test-client-secret"
+  scope         = ["email", "profile"]
+  pkce          = "auto"
+}

--- a/internal/resources/socialprovider/testdata/with_pkce_removed.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/with_pkce_removed.tf.tmpl
@@ -1,0 +1,8 @@
+resource "ory_social_provider" "test" {
+  provider_id   = "test-google-pkce"
+  provider_type = "google"
+  client_id     = "test-client-id.apps.googleusercontent.com"
+  client_secret = "test-client-secret"
+  scope         = ["email", "profile"]
+  # pkce intentionally omitted to test removal
+}

--- a/internal/resources/socialprovider/testdata/with_pkce_updated.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/with_pkce_updated.tf.tmpl
@@ -1,0 +1,8 @@
+resource "ory_social_provider" "test" {
+  provider_id   = "test-google-pkce"
+  provider_type = "google"
+  client_id     = "test-client-id.apps.googleusercontent.com"
+  client_secret = "test-client-secret"
+  scope         = ["email", "profile"]
+  pkce          = "never"
+}

--- a/internal/resources/socialprovider/validate_config_test.go
+++ b/internal/resources/socialprovider/validate_config_test.go
@@ -43,7 +43,7 @@ func buildTestConfig(t *testing.T, model SocialProviderResourceModel) resource.V
 		"additional_id_token_audiences": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
 		"aal2_acr_values":               tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
 		"aal2_amr_values":               tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
-		"pkce":                          tftypes.NewValue(tftypes.String, nil),
+		"pkce":                          tfStringValue(model.Pkce),
 	}
 
 	objType := tftypes.Object{

--- a/internal/resources/socialprovider/validate_config_test.go
+++ b/internal/resources/socialprovider/validate_config_test.go
@@ -43,6 +43,7 @@ func buildTestConfig(t *testing.T, model SocialProviderResourceModel) resource.V
 		"additional_id_token_audiences": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
 		"aal2_acr_values":               tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
 		"aal2_amr_values":               tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
+		"pkce":                          tftypes.NewValue(tftypes.String, nil),
 	}
 
 	objType := tftypes.Object{
@@ -69,6 +70,7 @@ func buildTestConfig(t *testing.T, model SocialProviderResourceModel) resource.V
 			"additional_id_token_audiences": tftypes.List{ElementType: tftypes.String},
 			"aal2_acr_values":               tftypes.List{ElementType: tftypes.String},
 			"aal2_amr_values":               tftypes.List{ElementType: tftypes.String},
+			"pkce":                          tftypes.String,
 		},
 	}
 

--- a/templates/resources/social_provider.md.tmpl
+++ b/templates/resources/social_provider.md.tmpl
@@ -136,6 +136,27 @@ resource "ory_social_provider" "enterprise_sso" {
 }
 ```
 
+## PKCE
+
+The `pkce` attribute controls whether the OAuth2 authorization code flow uses [Proof Key for Code Exchange (RFC 7636)](https://datatracker.ietf.org/doc/html/rfc7636) when redirecting users to the upstream provider:
+
+| Value | Description |
+|-------|-------------|
+| `auto` (default) | Enable PKCE only when the upstream provider advertises support via OIDC discovery. |
+| `force` | Always send the PKCE challenge. Use only with providers known to support it — providers that do not understand PKCE may reject the authorization request. |
+| `never` | Disable PKCE for this provider. |
+
+```hcl
+resource "ory_social_provider" "google" {
+  provider_id   = "google"
+  provider_type = "google"
+  client_id     = var.google_client_id
+  client_secret = var.google_client_secret
+  scope         = ["email", "profile"]
+  pkce          = "force"
+}
+```
+
 ## Base Redirect URI
 
 The `base_redirect_uri` attribute overrides the base URL Ory uses when constructing OIDC callback URLs. Use this when your project is accessible under a custom domain and you want callbacks to go to that domain rather than the default Ory project URL.


### PR DESCRIPTION
## Description

Adds support for configuring the `pkce` attribute on the `ory_social_provider` resource. This controls whether the OAuth2 authorization code flow uses Proof Key for Code Exchange (RFC 7636) when redirecting users to the upstream provider.

Accepts:

- `auto` (default) — enable PKCE only when the upstream provider advertises support via OIDC discovery
- `force` — always send the PKCE challenge
- `never` — disable PKCE for this provider

I have come across the need of this feature while setting up Ory with terraform at my current company and thought that adding it would be a nice contribution.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests — `validate_config_test.go` synthetic schema updated; `go test ./internal/resources/socialprovider/...` passes
- [x] Acceptance tests — new `TestAccSocialProviderResource_pkce` covers create / plan-only / update (`force` → `never`) / remove / plan-only / import, using three fixtures under `testdata/with_pkce*.tf.tmpl`
- [x] Manual testing

## Screenshots/Output

Some manual testing logs:
```
clafoutis@MacbookPro-SiitCharles:~/Desktop/siit-ory/environments/staging # terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ory/ory in /Users/clafoutis/Desktop/terraform-provider-ory
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible
│ with published releases.
╵
module.ory_project.terraform_data.rails_mapper_version: Refreshing state... [id=a0596816-4cc1-d66e-8db6-c9815232991c]
module.ory_project.ory_project.this: Refreshing state... [id=f0686f5b-e5f3-4c71-a2ad-80bf291482f5]
module.ory_project.ory_identity_schema.this: Refreshing state... [id=6d5888e40707a2cdb6422e3ae39d8724f9c25c1228c7d123c92fa20f848b840d71b670a8611ca0c7f67738a47d5940cc1863ea1896347492004eb829f7399c2e]
module.ory_project.ory_project_config.this: Refreshing state... [id=f0686f5b-e5f3-4c71-a2ad-80bf291482f5]
module.ory_project.ory_social_provider.rails: Refreshing state... [id=rails]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.ory_project.ory_social_provider.rails will be updated in-place
  ~ resource "ory_social_provider" "rails" {
        id            = "rails"
      ~ pkce          = "force" -> "auto"
        # (9 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.ory_project.ory_social_provider.rails: Modifying... [id=rails]
module.ory_project.ory_social_provider.rails: Modifications complete after 1s [id=rails]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

[REDACTED]

clafoutis@MacbookPro-SiitCharles:~/Desktop/siit-ory/environments/staging # terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ory/ory in /Users/clafoutis/Desktop/terraform-provider-ory
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible
│ with published releases.
╵
module.ory_project.terraform_data.rails_mapper_version: Refreshing state... [id=a0596816-4cc1-d66e-8db6-c9815232991c]
module.ory_project.ory_project.this: Refreshing state... [id=f0686f5b-e5f3-4c71-a2ad-80bf291482f5]
module.ory_project.ory_identity_schema.this: Refreshing state... [id=6d5888e40707a2cdb6422e3ae39d8724f9c25c1228c7d123c92fa20f848b840d71b670a8611ca0c7f67738a47d5940cc1863ea1896347492004eb829f7399c2e]
module.ory_project.ory_project_config.this: Refreshing state... [id=f0686f5b-e5f3-4c71-a2ad-80bf291482f5]
module.ory_project.ory_social_provider.rails: Refreshing state... [id=rails]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.ory_project.ory_social_provider.rails will be updated in-place
  ~ resource "ory_social_provider" "rails" {
        id            = "rails"
      ~ pkce          = "auto" -> "force"
        # (9 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.ory_project.ory_social_provider.rails: Modifying... [id=rails]
module.ory_project.ory_social_provider.rails: Modifications complete after 3s [id=rails]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

[REDACTED]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `pkce` attribute to social provider resources with three configurable values: `auto` (default), `force`, and `never`. This enables control over Proof Key for Code Exchange behavior in OAuth authentication flows. Full lifecycle management is supported including creation, updates, and removal.

* **Documentation**
  * Updated resource documentation with `pkce` attribute specifications and configuration examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/terraform-provider-ory/pull/222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->