### PR TITLE
feat(project-config): finalize oauth2_token_prefix and refresh_token_rotation_grace_reuse_count

### DIFF
--- a/docs/resources/project_config.md
+++ b/docs/resources/project_config.md
@@ -423,7 +423,7 @@ terraform plan  # verify no changes
 - `oauth2_grant_jwt_jti_optional` (Boolean) Make the `jti` claim optional in JWT assertion grants (RFC 7523).
 - `oauth2_grant_jwt_max_ttl` (String) Maximum TTL for JWT assertions in grant flows (e.g. '720h').
 - `oauth2_grant_refresh_token_rotation_grace_period` (String) Grace period for refresh token rotation (e.g. '5s'). Set to '0s' to disable.
-- `oauth2_grant_refresh_token_rotation_grace_reuse_count` (Number) OAuth2 Grant Refresh Token Rotation Grace Reuse Count. The maximum number of times a refresh token can be reused within the grace period. If set to `null` or `0`, the limit is disabled.
+- `oauth2_grant_refresh_token_rotation_grace_reuse_count` (Number) Maximum number of times a refresh token can be reused within the rotation grace period. Set to `0` to disable the reuse limit.
 - `oauth2_id_token_lifespan` (String, Deprecated) OAuth2 ID token lifespan (e.g., '1h'). Requires Hydra service.
 - `oauth2_issuer_url` (String, Deprecated) OAuth2 issuer URL. Overrides the default project URL used as the OAuth2/OIDC issuer.
 - `oauth2_jwt_scope_claim` (String, Deprecated) How scopes are represented in JWT access tokens ('list', 'string', or 'both').
@@ -449,7 +449,7 @@ terraform plan  # verify no changes
 - `oauth2_strategies_jwt_scope_claim` (String) How scopes are represented in JWT access tokens ('list', 'string', or 'both').
 - `oauth2_strategies_scope` (String) OAuth2 scope matching strategy ('exact', 'wildcard').
 - `oauth2_token_hook` (String) Webhook URL called during token issuance for all grant types to customize claims.
-- `oauth2_token_prefix` (String) Sets a per-project Access Token, Refresh Token, and Authorization Code prefix
+- `oauth2_token_prefix` (String) Per-project Access Token, Refresh Token, and Authorization Code prefix template. Must be a `fmt.Sprintf` template with exactly one `%s` substitution that is replaced at issuance time with the token kind (`at` for access token, `rt` for refresh token, `ac` for authorization code). For example, `acme_%s_` yields `acme_at_…`, `acme_rt_…`, and `acme_ac_…`. The rendered prefix may contain only ASCII letters, digits, and underscores. Leave empty to keep the default `ory_%s_` prefix. This is an Enterprise feature.
 - `oauth2_ttl_access_token` (String) OAuth2 access token lifespan (e.g., '1h', '30m'). Requires Hydra service.
 - `oauth2_ttl_auth_code` (String) OAuth2 authorization code lifespan (e.g., '30m'). Requires Hydra service.
 - `oauth2_ttl_id_token` (String) OAuth2 ID token lifespan (e.g., '1h'). Requires Hydra service.

--- a/internal/codegen/mappings.yaml
+++ b/internal/codegen/mappings.yaml
@@ -172,6 +172,20 @@ attributes:
     deprecated_name: oauth2_scope_strategy
     deprecated_go_field: OAuth2ScopeStrategy
 
+  - name: oauth2_token_prefix
+    go_field: OAuth2TokenPrefix
+    type: string
+    openapi_property: hydra_oauth2_token_prefix
+    description: >-
+      Per-project Access Token, Refresh Token, and Authorization Code prefix template.
+      Must be a `fmt.Sprintf` template with exactly one `%s` substitution that is replaced at issuance time with the token kind
+      (`at` for access token, `rt` for refresh token, `ac` for authorization code). For example, `acme_%s_` yields `acme_at_…`, `acme_rt_…`, and `acme_ac_…`.
+      The rendered prefix may contain only ASCII letters, digits, and underscores. Leave empty to keep the default `ory_%s_` prefix.
+      This is an Enterprise feature.
+    validators:
+      regex: '^$|^[A-Za-z0-9_]*%s[A-Za-z0-9_]*$'
+      regex_message: "must be empty or a fmt.Sprintf template with exactly one '%s' substitution containing only ASCII letters, digits, and underscores (e.g. 'acme_%s_')"
+
   - name: oauth2_urls_consent
     go_field: OAuth2URLsConsent
     type: string
@@ -625,6 +639,12 @@ attributes:
     type: string
     openapi_property: hydra_oauth2_grant_refresh_token_rotation_grace_period
     description: "Grace period for refresh token rotation (e.g. '5s'). Set to '0s' to disable."
+
+  - name: oauth2_grant_refresh_token_rotation_grace_reuse_count
+    go_field: OAuth2GrantRefreshTokenRotationGraceReuseCount
+    type: int64
+    openapi_property: hydra_oauth2_grant_refresh_token_rotation_grace_reuse_count
+    description: "Maximum number of times a refresh token can be reused within the rotation grace period. Set to `0` to disable the reuse limit."
 
   - name: oauth2_refresh_token_hook
     go_field: OAuth2RefreshTokenHook
@@ -1394,17 +1414,4 @@ attributes:
     type: bool
     openapi_property: account_experience_hide_registration_link
     description: "Whether to hide the registration link on the account experience login card."
-
-  # --- Auto-discovered entries (review names/descriptions before merging) ---
-  - name: oauth2_grant_refresh_token_rotation_grace_reuse_count
-    go_field: OAuth2GrantRefreshTokenRotationGraceReuseCount
-    type: int64
-    openapi_property: hydra_oauth2_grant_refresh_token_rotation_grace_reuse_count
-    description: "OAuth2 Grant Refresh Token Rotation Grace Reuse Count. The maximum number of times a refresh token can be reused within the grace period. If set to `null` or `0`, the limit is disabled."
-
-  - name: oauth2_token_prefix
-    go_field: OAuth2TokenPrefix
-    type: string
-    openapi_property: hydra_oauth2_token_prefix
-    description: "Sets a per-project Access Token, Refresh Token, and Authorization Code prefix"
 

--- a/internal/resources/projectconfig/patches_gen.go
+++ b/internal/resources/projectconfig/patches_gen.go
@@ -57,6 +57,7 @@ func simpleStringPatchEntries(plan *ProjectConfigResourceModel) []StringPatchEnt
 		{&plan.OAuth2StrategiesAccessToken, &plan.OAuth2AccessTokenStrategy, "/services/oauth2/config/strategies/access_token"},
 		{&plan.OAuth2StrategiesJWTScopeClaim, &plan.OAuth2JWTScopeClaim, "/services/oauth2/config/strategies/jwt/scope_claim"},
 		{&plan.OAuth2StrategiesScope, &plan.OAuth2ScopeStrategy, "/services/oauth2/config/strategies/scope"},
+		{&plan.OAuth2TokenPrefix, nil, "/services/oauth2/config/oauth2/token_prefix"},
 		{&plan.OAuth2URLsConsent, &plan.OAuth2ConsentURL, "/services/oauth2/config/urls/consent"},
 		{&plan.OAuth2URLsLogin, &plan.OAuth2LoginURL, "/services/oauth2/config/urls/login"},
 		{&plan.OAuth2URLsLogout, &plan.OAuth2LogoutURL, "/services/oauth2/config/urls/logout"},
@@ -156,7 +157,6 @@ func simpleStringPatchEntries(plan *ProjectConfigResourceModel) []StringPatchEnt
 		{&plan.CourierHTTPRequestConfigAuthType, nil, "/services/identity/config/courier/http/request_config/auth/type"},
 		{&plan.CourierHTTPRequestConfigMethod, nil, "/services/identity/config/courier/http/request_config/method"},
 		{&plan.SMTPConnectionURI, nil, "/services/identity/config/courier/smtp/connection_uri"},
-		{&plan.OAuth2TokenPrefix, nil, "/services/oauth2/config/oauth2/token_prefix"},
 	}
 }
 
@@ -225,8 +225,8 @@ func simpleInt64PatchEntries(plan *ProjectConfigResourceModel) []Int64PatchEntry
 	return []Int64PatchEntry{
 		{&plan.SelfserviceMethodsPasswordConfigMinPasswordLength, &plan.PasswordMinLength, "/services/identity/config/selfservice/methods/password/config/min_password_length"},
 		{&plan.SelfserviceMethodsPasswordConfigMaxBreaches, &plan.PasswordMaxBreaches, "/services/identity/config/selfservice/methods/password/config/max_breaches"},
-		{&plan.SelfserviceMethodsCodeConfigMaxSubmissions, nil, "/services/identity/config/selfservice/methods/code/max_submissions"},
 		{&plan.OAuth2GrantRefreshTokenRotationGraceReuseCount, nil, "/services/oauth2/config/oauth2/grant/refresh_token/rotation_grace_reuse_count"},
+		{&plan.SelfserviceMethodsCodeConfigMaxSubmissions, nil, "/services/identity/config/selfservice/methods/code/max_submissions"},
 	}
 }
 

--- a/internal/resources/projectconfig/read_gen.go
+++ b/internal/resources/projectconfig/read_gen.go
@@ -513,6 +513,7 @@ func oauth2StringReadEntries(state *ProjectConfigResourceModel) []StringReadEntr
 		{&state.OAuth2StrategiesAccessToken, &state.OAuth2AccessTokenStrategy, []string{"strategies", "access_token"}, false},
 		{&state.OAuth2StrategiesJWTScopeClaim, &state.OAuth2JWTScopeClaim, []string{"strategies", "jwt", "scope_claim"}, false},
 		{&state.OAuth2StrategiesScope, &state.OAuth2ScopeStrategy, []string{"strategies", "scope"}, false},
+		{&state.OAuth2TokenPrefix, nil, []string{"oauth2", "token_prefix"}, false},
 		{&state.OAuth2URLsConsent, &state.OAuth2ConsentURL, []string{"urls", "consent"}, false},
 		{&state.OAuth2URLsLogin, &state.OAuth2LoginURL, []string{"urls", "login"}, false},
 		{&state.OAuth2URLsLogout, &state.OAuth2LogoutURL, []string{"urls", "logout"}, false},
@@ -531,7 +532,6 @@ func oauth2StringReadEntries(state *ProjectConfigResourceModel) []StringReadEntr
 		{&state.OAuth2WebfingerOIDCDiscoveryJwksURL, nil, []string{"webfinger", "oidc_discovery", "jwks_url"}, false},
 		{&state.OAuth2WebfingerOIDCDiscoveryTokenURL, nil, []string{"webfinger", "oidc_discovery", "token_url"}, false},
 		{&state.OAuth2WebfingerOIDCDiscoveryUserinfoURL, nil, []string{"webfinger", "oidc_discovery", "userinfo_url"}, false},
-		{&state.OAuth2TokenPrefix, nil, []string{"oauth2", "token_prefix"}, false},
 	}
 }
 

--- a/internal/resources/projectconfig/resource.go
+++ b/internal/resources/projectconfig/resource.go
@@ -167,8 +167,10 @@ type ProjectConfigResourceModel struct {
 	OAuth2GrantJWTJTIOptional                         types.Bool   `tfsdk:"oauth2_grant_jwt_jti_optional"`
 	OAuth2GrantJWTMaxTTL                              types.String `tfsdk:"oauth2_grant_jwt_max_ttl"`
 	OAuth2GrantRefreshTokenRotationGracePeriod        types.String `tfsdk:"oauth2_grant_refresh_token_rotation_grace_period"`
+	OAuth2GrantRefreshTokenRotationGraceReuseCount    types.Int64  `tfsdk:"oauth2_grant_refresh_token_rotation_grace_reuse_count"`
 	OAuth2RefreshTokenHook                            types.String `tfsdk:"oauth2_refresh_token_hook"`
 	OAuth2TokenHook                                   types.String `tfsdk:"oauth2_token_hook"`
+	OAuth2TokenPrefix                                 types.String `tfsdk:"oauth2_token_prefix"`
 	OIDCDynamicClientRegistrationEnabled              types.Bool   `tfsdk:"oidc_dynamic_client_registration_enabled"`
 	OIDCSubjectIdentifiersPairwiseSalt                types.String `tfsdk:"oidc_subject_identifiers_pairwise_salt"`
 	OAuth2UrlsPostLogoutRedirect                      types.String `tfsdk:"oauth2_urls_post_logout_redirect"`
@@ -403,10 +405,6 @@ type ProjectConfigResourceModel struct {
 	// Auto-discovered (review naming before release)
 	AccountExperienceHideOryBranding      types.Bool `tfsdk:"account_experience_hide_ory_branding"`
 	AccountExperienceHideRegistrationLink types.Bool `tfsdk:"account_experience_hide_registration_link"`
-
-	// Auto-discovered (review naming before release)
-	OAuth2GrantRefreshTokenRotationGraceReuseCount types.Int64  `tfsdk:"oauth2_grant_refresh_token_rotation_grace_reuse_count"`
-	OAuth2TokenPrefix                              types.String `tfsdk:"oauth2_token_prefix"`
 }
 
 // --- Nested model types for session tokenizer templates and courier HTTP ---

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -4,6 +4,7 @@ package projectconfig_test
 
 import (
 	"context"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -62,6 +63,7 @@ func TestAccProjectConfigResource_hydraConfig(t *testing.T) {
 					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_strategies_scope", "wildcard"),
 					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_pkce_enforced", "false"),
 					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_pkce_enforced_for_public_clients", "false"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_grant_refresh_token_rotation_grace_reuse_count", "3"),
 					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_allowed_top_level_claims.#", "2"),
 					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_mirror_top_level_claims", "false"),
 					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_urls_login", "https://example.com/login"),
@@ -642,6 +644,76 @@ func TestAccProjectConfigResource_recoveryFlow(t *testing.T) {
 					"cors_enabled",
 					"selfservice_methods_password_config_min_password_length",
 					"smtp_connection_uri",
+				},
+			},
+		},
+	})
+}
+
+func TestAccProjectConfigResource_oauth2TokenPrefix(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Reject invalid prefix at plan time (no `%s` substitution).
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/oauth2_token_prefix.tf.tmpl", map[string]string{
+					"Prefix": "acme_",
+				}),
+				ExpectError: regexp.MustCompile(`(?s)must be empty or a fmt\.Sprintf template`),
+			},
+			// Reject invalid prefix at plan time (contains hyphen).
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/oauth2_token_prefix.tf.tmpl", map[string]string{
+					"Prefix": "a-b_%s_",
+				}),
+				ExpectError: regexp.MustCompile(`(?s)must be empty or a fmt\.Sprintf template`),
+			},
+			// Create with a valid prefix.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/oauth2_token_prefix.tf.tmpl", map[string]string{
+					"Prefix": "acme_%s_",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_project_config.test", "id"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_token_prefix", "acme_%s_"),
+				),
+			},
+			// Update to a different valid prefix.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/oauth2_token_prefix.tf.tmpl", map[string]string{
+					"Prefix": "tfprov_%s_",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_token_prefix", "tfprov_%s_"),
+				),
+			},
+			// Plan-only: no diff after apply.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/oauth2_token_prefix.tf.tmpl", map[string]string{
+					"Prefix": "tfprov_%s_",
+				}),
+				PlanOnly: true,
+			},
+			// Reset to the default by sending an empty prefix.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/oauth2_token_prefix.tf.tmpl", map[string]string{
+					"Prefix": "",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_token_prefix", ""),
+				),
+			},
+			// Import verifies the resource ID round-trips. Per-attribute values
+			// aren't refreshed until the next apply (project_config is a
+			// singleton view over the project), so we ignore them on import.
+			{
+				ResourceName:      "ory_project_config.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"oauth2_token_prefix",
+					"cors_enabled",
 				},
 			},
 		},

--- a/internal/resources/projectconfig/schema_gen.go
+++ b/internal/resources/projectconfig/schema_gen.go
@@ -154,6 +154,16 @@ func simpleSchemaAttributes() map[string]schema.Attribute {
 			Optional:           true,
 			DeprecationMessage: "Use oauth2_strategies_scope instead. This attribute will be removed in a future major version.",
 		},
+		"oauth2_token_prefix": schema.StringAttribute{
+			Description: "Per-project Access Token, Refresh Token, and Authorization Code prefix template. Must be a `fmt.Sprintf` template with exactly one `%s` substitution that is replaced at issuance time with the token kind (`at` for access token, `rt` for refresh token, `ac` for authorization code). For example, `acme_%s_` yields `acme_at_…`, `acme_rt_…`, and `acme_ac_…`. The rendered prefix may contain only ASCII letters, digits, and underscores. Leave empty to keep the default `ory_%s_` prefix. This is an Enterprise feature.",
+			Optional:    true,
+			Validators: []validator.String{
+				stringvalidator.RegexMatches(
+					regexp.MustCompile("^$|^[A-Za-z0-9_]*%s[A-Za-z0-9_]*$"),
+					"must be empty or a fmt.Sprintf template with exactly one '%s' substitution containing only ASCII letters, digits, and underscores (e.g. 'acme_%s_')",
+				),
+			},
+		},
 		"oauth2_urls_consent": schema.StringAttribute{
 			Description: "OAuth2 consent endpoint URL.",
 			Optional:    true,
@@ -601,6 +611,10 @@ func simpleSchemaAttributes() map[string]schema.Attribute {
 		},
 		"oauth2_grant_refresh_token_rotation_grace_period": schema.StringAttribute{
 			Description: "Grace period for refresh token rotation (e.g. '5s'). Set to '0s' to disable.",
+			Optional:    true,
+		},
+		"oauth2_grant_refresh_token_rotation_grace_reuse_count": schema.Int64Attribute{
+			Description: "Maximum number of times a refresh token can be reused within the rotation grace period. Set to `0` to disable the reuse limit.",
 			Optional:    true,
 		},
 		"oauth2_refresh_token_hook": schema.StringAttribute{
@@ -1112,14 +1126,6 @@ func simpleSchemaAttributes() map[string]schema.Attribute {
 		},
 		"account_experience_hide_registration_link": schema.BoolAttribute{
 			Description: "Whether to hide the registration link on the account experience login card.",
-			Optional:    true,
-		},
-		"oauth2_grant_refresh_token_rotation_grace_reuse_count": schema.Int64Attribute{
-			Description: "OAuth2 Grant Refresh Token Rotation Grace Reuse Count. The maximum number of times a refresh token can be reused within the grace period. If set to `null` or `0`, the limit is disabled.",
-			Optional:    true,
-		},
-		"oauth2_token_prefix": schema.StringAttribute{
-			Description: "Sets a per-project Access Token, Refresh Token, and Authorization Code prefix",
 			Optional:    true,
 		},
 	}

--- a/internal/resources/projectconfig/testdata/hydra_config.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/hydra_config.tf.tmpl
@@ -15,6 +15,9 @@ resource "ory_project_config" "test" {
   oauth2_pkce_enforced                    = false
   oauth2_pkce_enforced_for_public_clients = false
 
+  # Refresh token rotation
+  oauth2_grant_refresh_token_rotation_grace_reuse_count = 3
+
   # Claims
   oauth2_allowed_top_level_claims = ["amr", "acr"]
   oauth2_mirror_top_level_claims  = false

--- a/internal/resources/projectconfig/testdata/oauth2_token_prefix.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/oauth2_token_prefix.tf.tmpl
@@ -1,0 +1,3 @@
+resource "ory_project_config" "test" {
+  oauth2_token_prefix = "[[ .Prefix ]]"
+}


### PR DESCRIPTION
## Description

Promotes the two attributes appended by the auto-discovery workflow (PR #227) out of the auto-discovered section into their logical OAuth2/Hydra grouping in `mappings.yaml`, fleshes out their docs, adds client-side validation for `oauth2_token_prefix`, and covers both attributes with acceptance tests.

- `oauth2_token_prefix`: expand the description with the full spec guidance (substitution semantics, allowed character set, default, Enterprise feature note) and add a regex validator that rejects invalid templates at plan time so users see the error before an API round-trip.
- `oauth2_grant_refresh_token_rotation_grace_reuse_count`: rewrite the description for clarity and place it next to the existing `oauth2_grant_refresh_token_rotation_grace_period` entry.

## Related Issues

Fixes #226

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

`make generate && make build && make format && make test-short && make sec` all pass.

Acceptance tests against the staging project:

```
=== RUN   TestAccProjectConfigResource_hydraConfig
--- PASS: TestAccProjectConfigResource_hydraConfig (3.55s)
=== RUN   TestAccProjectConfigResource_oauth2TokenPrefix
--- PASS: TestAccProjectConfigResource_oauth2TokenPrefix (8.98s)
=== RUN   TestAccProjectConfigResource_oauth2Advanced
--- PASS: TestAccProjectConfigResource_oauth2Advanced (3.08s)
```

`TestAccProjectConfigResource_oauth2TokenPrefix` exercises create, update, plan-only stability, reset-to-default and import, plus validation errors for templates missing `%s` and templates with disallowed characters. `TestAccProjectConfigResource_hydraConfig` now also verifies `oauth2_grant_refresh_token_rotation_grace_reuse_count` round-trips through the API.

Manually verified end-to-end against the staging project (`3fa274fe-910d-4766-b1a4-0c0dd3b41429`) via the console API: PATCHing both fields persists them, PATCH with `remove` clears them, and the API rejects invalid `token_prefix` values with the same regex contract the schema now enforces locally.

## Screenshots/Output

n/a