### PR TITLE
feat(project-config): add show_verification_ui hook attributes

### DIFF
--- a/docs/resources/project_config.md
+++ b/docs/resources/project_config.md
@@ -258,6 +258,21 @@ variable "sms_api_key" {
   sensitive   = true
   description = "API key for SMS delivery service"
 }
+
+# Show the verification UI after registration and profile updates.
+# Each attribute toggles the `show_verification_ui` hook for one flow while
+# preserving any other hooks (e.g. `session`, `organization`) already set on
+# the project.
+resource "ory_project_config" "show_verification_ui" {
+  selfservice_flows_verification_enabled = true
+
+  # After password registration, redirect users to the verification UI.
+  selfservice_flows_registration_after_password_hook_show_verification_ui = true
+  # Same for social (OIDC) registration.
+  selfservice_flows_registration_after_oidc_hook_show_verification_ui = true
+  # When users change their email in profile settings, force re-verification.
+  selfservice_flows_settings_after_profile_hook_show_verification_ui = true
+}
 ```
 
 ## Duration Format
@@ -330,6 +345,18 @@ The `smtp_connection_uri` attribute selects the SMTP security mode through the U
 -> **Credential encoding:** Usernames and passwords must be URI-encoded if they contain special characters (e.g., `@`, `:`, `/`, `?`, `#`). Use [`urlencode`](https://developer.hashicorp.com/terraform/language/functions/urlencode) in Terraform to encode them safely.
 
 For more detail, see the [Ory Kratos SMTP documentation](https://www.ory.com/docs/kratos/emails-sms/sending-emails-smtp).
+
+## Verification After Registration / Settings
+
+Three boolean attributes toggle the [`show_verification_ui`](https://www.ory.com/docs/kratos/self-service/flows/user-registration) post-flow hook for each authentication method:
+
+- `selfservice_flows_registration_after_password_hook_show_verification_ui`
+- `selfservice_flows_registration_after_oidc_hook_show_verification_ui`
+- `selfservice_flows_settings_after_profile_hook_show_verification_ui`
+
+When `true`, the provider adds the `show_verification_ui` hook to the corresponding flow; when `false`, it removes only that hook. Other hooks at the same path (for example `session` or `organization`) are preserved by reading the current hook list before each apply.
+
+To require a verified address before a user can log in (the "Require verified address for login" toggle in the Ory Console), set `feature_flags_legacy_require_verified_login_error = true`. When that flag is `false`, an unverified user is shown the `show_verification_ui` continuation step instead of receiving a form error.
 
 ## Clearing Return URLs
 
@@ -539,8 +566,10 @@ terraform plan  # verify no changes
 - `selfservice_flows_registration_after_code_default_browser_return_url` (String) Return URL after registration via code method.
 - `selfservice_flows_registration_after_default_browser_return_url` (String) Default return URL after registration.
 - `selfservice_flows_registration_after_oidc_default_browser_return_url` (String) Return URL after registration via OIDC.
+- `selfservice_flows_registration_after_oidc_hook_show_verification_ui` (Boolean) Enable the `show_verification_ui` hook after a successful OIDC (social) registration. When true, users are redirected to the verification UI after registering via a social provider. Existing hooks at this path (e.g., `session`, `organization`) are preserved.
 - `selfservice_flows_registration_after_passkey_default_browser_return_url` (String) Return URL after registration via passkey.
 - `selfservice_flows_registration_after_password_default_browser_return_url` (String) Return URL after registration via password.
+- `selfservice_flows_registration_after_password_hook_show_verification_ui` (Boolean) Enable the `show_verification_ui` hook after a successful password registration. When true, users are redirected to the verification UI after registering with email + password. Existing hooks at this path (e.g., `session`, `organization`) are preserved.
 - `selfservice_flows_registration_after_webauthn_default_browser_return_url` (String) Return URL after registration via WebAuthn.
 - `selfservice_flows_registration_enable_legacy_one_step` (Boolean) Revert to legacy one-step registration instead of the two-step flow.
 - `selfservice_flows_registration_enabled` (Boolean) Enable user registration.
@@ -553,6 +582,7 @@ terraform plan  # verify no changes
 - `selfservice_flows_settings_after_passkey_default_browser_return_url` (String) Return URL after updating passkey in settings.
 - `selfservice_flows_settings_after_password_default_browser_return_url` (String) Return URL after updating password in settings.
 - `selfservice_flows_settings_after_profile_default_browser_return_url` (String) Return URL after updating profile in settings.
+- `selfservice_flows_settings_after_profile_hook_show_verification_ui` (Boolean) Enable the `show_verification_ui` hook after a successful profile settings update. When true, users are redirected to the verification UI after updating their profile (e.g., changing their email). Existing hooks at this path (e.g., `organization`) are preserved.
 - `selfservice_flows_settings_after_totp_default_browser_return_url` (String) Return URL after updating TOTP in settings.
 - `selfservice_flows_settings_after_webauthn_default_browser_return_url` (String) Return URL after updating WebAuthn in settings.
 - `selfservice_flows_settings_lifespan` (String) Lifespan of the settings flow (e.g., '30m0s'). Controls how long a settings flow session remains valid.

--- a/examples/resources/ory_project_config/resource.tf
+++ b/examples/resources/ory_project_config/resource.tf
@@ -235,3 +235,18 @@ variable "sms_api_key" {
   sensitive   = true
   description = "API key for SMS delivery service"
 }
+
+# Show the verification UI after registration and profile updates.
+# Each attribute toggles the `show_verification_ui` hook for one flow while
+# preserving any other hooks (e.g. `session`, `organization`) already set on
+# the project.
+resource "ory_project_config" "show_verification_ui" {
+  selfservice_flows_verification_enabled = true
+
+  # After password registration, redirect users to the verification UI.
+  selfservice_flows_registration_after_password_hook_show_verification_ui = true
+  # Same for social (OIDC) registration.
+  selfservice_flows_registration_after_oidc_hook_show_verification_ui = true
+  # When users change their email in profile settings, force re-verification.
+  selfservice_flows_settings_after_profile_hook_show_verification_ui = true
+}

--- a/internal/resources/projectconfig/build_patches_test.go
+++ b/internal/resources/projectconfig/build_patches_test.go
@@ -476,3 +476,219 @@ func TestBuildPatches_NullVerificationNotifyUnknownRecipients(t *testing.T) {
 		t.Error("expected no patch for null verification_notify_unknown_recipients")
 	}
 }
+
+// projectWithIdentityConfig wraps an identity config map in the *ory.Project
+// shape that buildShowVerificationUIHookPatches expects.
+func projectWithIdentityConfig(identityConfig map[string]interface{}) *ory.Project {
+	return &ory.Project{
+		Services: ory.ProjectServices{
+			Identity: &ory.ProjectServiceIdentity{
+				Config: identityConfig,
+			},
+		},
+	}
+}
+
+func TestBuildShowVerificationUIHookPatches_AddPreservesOtherHooks(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsRegistrationAfterPasswordHookShowVerificationUI: types.BoolValue(true),
+	}
+	current := projectWithIdentityConfig(map[string]interface{}{
+		"selfservice": map[string]interface{}{
+			"flows": map[string]interface{}{
+				"registration": map[string]interface{}{
+					"after": map[string]interface{}{
+						"password": map[string]interface{}{
+							"hooks": []interface{}{
+								map[string]interface{}{"hook": "organization"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	patches := buildShowVerificationUIHookPatches(plan, current)
+	if len(patches) != 1 {
+		t.Fatalf("expected 1 patch, got %d", len(patches))
+	}
+	p := patches[0]
+	if p.Op != "replace" {
+		t.Errorf("expected op 'replace', got %q", p.Op)
+	}
+	if p.Path != "/services/identity/config/selfservice/flows/registration/after/password/hooks" {
+		t.Errorf("unexpected patch path: %s", p.Path)
+	}
+	hooks, ok := p.Value.([]map[string]interface{})
+	if !ok {
+		t.Fatalf("expected []map[string]interface{} value, got %T", p.Value)
+	}
+	if len(hooks) != 2 {
+		t.Fatalf("expected 2 hooks (show_verification_ui + organization), got %d", len(hooks))
+	}
+	if hooks[0]["hook"] != "show_verification_ui" {
+		t.Errorf("expected show_verification_ui first, got %v", hooks[0]["hook"])
+	}
+	if hooks[1]["hook"] != "organization" {
+		t.Errorf("expected organization preserved, got %v", hooks[1]["hook"])
+	}
+}
+
+func TestBuildShowVerificationUIHookPatches_RemoveKeepsOthers(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsSettingsAfterProfileHookShowVerificationUI: types.BoolValue(false),
+	}
+	current := projectWithIdentityConfig(map[string]interface{}{
+		"selfservice": map[string]interface{}{
+			"flows": map[string]interface{}{
+				"settings": map[string]interface{}{
+					"after": map[string]interface{}{
+						"profile": map[string]interface{}{
+							"hooks": []interface{}{
+								map[string]interface{}{"hook": "show_verification_ui"},
+								map[string]interface{}{"hook": "organization"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	patches := buildShowVerificationUIHookPatches(plan, current)
+	if len(patches) != 1 {
+		t.Fatalf("expected 1 patch, got %d", len(patches))
+	}
+	hooks, ok := patches[0].Value.([]map[string]interface{})
+	if !ok {
+		t.Fatalf("expected []map[string]interface{} value, got %T", patches[0].Value)
+	}
+	if len(hooks) != 1 {
+		t.Fatalf("expected 1 remaining hook, got %d", len(hooks))
+	}
+	if hooks[0]["hook"] != "organization" {
+		t.Errorf("expected organization to remain, got %v", hooks[0]["hook"])
+	}
+}
+
+func TestBuildShowVerificationUIHookPatches_AddIdempotent(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsRegistrationAfterOIDCHookShowVerificationUI: types.BoolValue(true),
+	}
+	current := projectWithIdentityConfig(map[string]interface{}{
+		"selfservice": map[string]interface{}{
+			"flows": map[string]interface{}{
+				"registration": map[string]interface{}{
+					"after": map[string]interface{}{
+						"oidc": map[string]interface{}{
+							"hooks": []interface{}{
+								map[string]interface{}{"hook": "show_verification_ui"},
+								map[string]interface{}{"hook": "session"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	patches := buildShowVerificationUIHookPatches(plan, current)
+	hooks, _ := patches[0].Value.([]map[string]interface{})
+	if len(hooks) != 2 {
+		t.Fatalf("expected 2 hooks (no duplicate), got %d: %v", len(hooks), hooks)
+	}
+	seen := map[string]int{}
+	for _, h := range hooks {
+		if name, ok := h["hook"].(string); ok {
+			seen[name]++
+		}
+	}
+	if seen["show_verification_ui"] != 1 {
+		t.Errorf("expected exactly one show_verification_ui, got %d", seen["show_verification_ui"])
+	}
+	if seen["session"] != 1 {
+		t.Errorf("expected session preserved, got %d", seen["session"])
+	}
+}
+
+func TestBuildShowVerificationUIHookPatches_NullSkipped(t *testing.T) {
+	plan := &ProjectConfigResourceModel{}
+	current := projectWithIdentityConfig(map[string]interface{}{})
+
+	patches := buildShowVerificationUIHookPatches(plan, current)
+	if len(patches) != 0 {
+		t.Errorf("expected no patches when all hook attrs are null, got %d", len(patches))
+	}
+}
+
+func TestBuildShowVerificationUIHookPatches_NilCurrentProject(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsRegistrationAfterPasswordHookShowVerificationUI: types.BoolValue(true),
+	}
+	patches := buildShowVerificationUIHookPatches(plan, nil)
+	if len(patches) != 0 {
+		t.Errorf("expected no patches when currentProject is nil, got %d", len(patches))
+	}
+}
+
+func TestBuildShowVerificationUIHookPatches_MissingHooksPathIsEmptyArray(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsRegistrationAfterPasswordHookShowVerificationUI: types.BoolValue(true),
+	}
+	current := projectWithIdentityConfig(map[string]interface{}{})
+
+	patches := buildShowVerificationUIHookPatches(plan, current)
+	if len(patches) != 1 {
+		t.Fatalf("expected 1 patch even with empty config, got %d", len(patches))
+	}
+	hooks, ok := patches[0].Value.([]map[string]interface{})
+	if !ok || len(hooks) != 1 {
+		t.Fatalf("expected single show_verification_ui hook, got %v", patches[0].Value)
+	}
+	if hooks[0]["hook"] != "show_verification_ui" {
+		t.Errorf("expected show_verification_ui hook, got %v", hooks[0])
+	}
+}
+
+func TestNeedsHookPrefetch(t *testing.T) {
+	cases := []struct {
+		name string
+		plan ProjectConfigResourceModel
+		want bool
+	}{
+		{
+			name: "all null",
+			plan: ProjectConfigResourceModel{},
+			want: false,
+		},
+		{
+			name: "password set",
+			plan: ProjectConfigResourceModel{
+				SelfserviceFlowsRegistrationAfterPasswordHookShowVerificationUI: types.BoolValue(true),
+			},
+			want: true,
+		},
+		{
+			name: "oidc set false",
+			plan: ProjectConfigResourceModel{
+				SelfserviceFlowsRegistrationAfterOIDCHookShowVerificationUI: types.BoolValue(false),
+			},
+			want: true,
+		},
+		{
+			name: "profile set",
+			plan: ProjectConfigResourceModel{
+				SelfserviceFlowsSettingsAfterProfileHookShowVerificationUI: types.BoolValue(true),
+			},
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := needsHookPrefetch(&tc.plan); got != tc.want {
+				t.Errorf("needsHookPrefetch() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/resources/projectconfig/resource.go
+++ b/internal/resources/projectconfig/resource.go
@@ -407,6 +407,13 @@ type ProjectConfigResourceModel struct {
 	// Auto-discovered (review naming before release)
 	OAuth2GrantRefreshTokenRotationGraceReuseCount types.Int64  `tfsdk:"oauth2_grant_refresh_token_rotation_grace_reuse_count"`
 	OAuth2TokenPrefix                              types.String `tfsdk:"oauth2_token_prefix"`
+
+	// show_verification_ui hooks (custom: not in OpenAPI spec)
+	// Each toggles the show_verification_ui hook within a specific flow's hooks array,
+	// preserving any other hooks already configured.
+	SelfserviceFlowsRegistrationAfterPasswordHookShowVerificationUI types.Bool `tfsdk:"selfservice_flows_registration_after_password_hook_show_verification_ui"`
+	SelfserviceFlowsRegistrationAfterOIDCHookShowVerificationUI     types.Bool `tfsdk:"selfservice_flows_registration_after_oidc_hook_show_verification_ui"`
+	SelfserviceFlowsSettingsAfterProfileHookShowVerificationUI      types.Bool `tfsdk:"selfservice_flows_settings_after_profile_hook_show_verification_ui"`
 }
 
 // --- Nested model types for session tokenizer templates and courier HTTP ---
@@ -646,6 +653,29 @@ func (r *ProjectConfigResource) Schema(ctx context.Context, req resource.SchemaR
 				},
 			},
 		},
+	}
+
+	// show_verification_ui hooks: toggle the show_verification_ui hook in
+	// flow-specific hook arrays. The Ory API stores these as a list of
+	// {"hook": "..."} objects, so the provider performs a read-modify-write
+	// to preserve any other hooks (for example, `session` or `organization`).
+	attrs["selfservice_flows_registration_after_password_hook_show_verification_ui"] = schema.BoolAttribute{
+		Description: "Enable the `show_verification_ui` hook after a successful password registration. " +
+			"When true, users are redirected to the verification UI after registering with email + password. " +
+			"Existing hooks at this path (e.g., `session`, `organization`) are preserved.",
+		Optional: true,
+	}
+	attrs["selfservice_flows_registration_after_oidc_hook_show_verification_ui"] = schema.BoolAttribute{
+		Description: "Enable the `show_verification_ui` hook after a successful OIDC (social) registration. " +
+			"When true, users are redirected to the verification UI after registering via a social provider. " +
+			"Existing hooks at this path (e.g., `session`, `organization`) are preserved.",
+		Optional: true,
+	}
+	attrs["selfservice_flows_settings_after_profile_hook_show_verification_ui"] = schema.BoolAttribute{
+		Description: "Enable the `show_verification_ui` hook after a successful profile settings update. " +
+			"When true, users are redirected to the verification UI after updating their profile (e.g., changing their email). " +
+			"Existing hooks at this path (e.g., `organization`) are preserved.",
+		Optional: true,
 	}
 
 	// Courier HTTP Delivery
@@ -1001,6 +1031,122 @@ func (r *ProjectConfigResource) buildPatches(ctx context.Context, plan *ProjectC
 	return patches
 }
 
+// showVerificationUIHookEntry describes one show_verification_ui hook attribute
+// and the identity-config path whose hooks array it controls.
+type showVerificationUIHookEntry struct {
+	Field    types.Bool
+	PathKeys []string // path under /services/identity/config, ending at the parent of "hooks"
+}
+
+func showVerificationUIHookEntries(plan *ProjectConfigResourceModel) []showVerificationUIHookEntry {
+	return []showVerificationUIHookEntry{
+		{
+			Field:    plan.SelfserviceFlowsRegistrationAfterPasswordHookShowVerificationUI,
+			PathKeys: []string{"selfservice", "flows", "registration", "after", "password"},
+		},
+		{
+			Field:    plan.SelfserviceFlowsRegistrationAfterOIDCHookShowVerificationUI,
+			PathKeys: []string{"selfservice", "flows", "registration", "after", "oidc"},
+		},
+		{
+			Field:    plan.SelfserviceFlowsSettingsAfterProfileHookShowVerificationUI,
+			PathKeys: []string{"selfservice", "flows", "settings", "after", "profile"},
+		},
+	}
+}
+
+// buildShowVerificationUIHookPatches reconciles the show_verification_ui hook
+// for each configured flow by merging the desired state with whatever hooks
+// already exist on the project (for example `session` or `organization`).
+//
+// When currentProject is nil, no merge target is available and the function
+// returns an empty patch list.
+func buildShowVerificationUIHookPatches(plan *ProjectConfigResourceModel, currentProject *ory.Project) []ory.JsonPatch {
+	var patches []ory.JsonPatch
+	if currentProject == nil || currentProject.Services.Identity == nil {
+		return patches
+	}
+	identityConfig := currentProject.Services.Identity.Config
+	for _, e := range showVerificationUIHookEntries(plan) {
+		if e.Field.IsNull() || e.Field.IsUnknown() {
+			continue
+		}
+		desired := e.Field.ValueBool()
+		existingHooks := readHookList(identityConfig, e.PathKeys)
+		newHooks := setHookPresent(existingHooks, "show_verification_ui", desired)
+		patches = append(patches, ory.JsonPatch{
+			Op:    "replace",
+			Path:  "/services/identity/config/" + strings.Join(e.PathKeys, "/") + "/hooks",
+			Value: newHooks,
+		})
+	}
+	return patches
+}
+
+// readHookList extracts the hooks list at the given path from the identity
+// config map, returning an empty slice when the path or array is missing.
+func readHookList(identityConfig map[string]interface{}, pathKeys []string) []map[string]interface{} {
+	keys := append([]string{}, pathKeys...)
+	keys = append(keys, "hooks")
+	raw := getNestedValue(identityConfig, keys...)
+	arr, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+	hooks := make([]map[string]interface{}, 0, len(arr))
+	for _, item := range arr {
+		if m, ok := item.(map[string]interface{}); ok {
+			hooks = append(hooks, m)
+		}
+	}
+	return hooks
+}
+
+// setHookPresent returns a copy of hooks with the given hook name either
+// prepended (if present == true and missing) or removed (if present == false).
+// Other hook entries are preserved in their original order.
+func setHookPresent(hooks []map[string]interface{}, hookName string, present bool) []map[string]interface{} {
+	filtered := make([]map[string]interface{}, 0, len(hooks)+1)
+	alreadyPresent := false
+	for _, h := range hooks {
+		name, _ := h["hook"].(string)
+		if name == hookName {
+			alreadyPresent = true
+			if !present {
+				continue
+			}
+		}
+		filtered = append(filtered, h)
+	}
+	if present && !alreadyPresent {
+		filtered = append([]map[string]interface{}{{"hook": hookName}}, filtered...)
+	}
+	return filtered
+}
+
+// hookListContains reports whether the hooks list at the given path includes
+// the named hook.
+func hookListContains(identityConfig map[string]interface{}, pathKeys []string, hookName string) bool {
+	for _, h := range readHookList(identityConfig, pathKeys) {
+		if name, _ := h["hook"].(string); name == hookName {
+			return true
+		}
+	}
+	return false
+}
+
+// needsHookPrefetch reports whether any of the show_verification_ui hook
+// attributes are set in the plan, in which case the caller must fetch the
+// current project state before building patches.
+func needsHookPrefetch(plan *ProjectConfigResourceModel) bool {
+	for _, e := range showVerificationUIHookEntries(plan) {
+		if !e.Field.IsNull() && !e.Field.IsUnknown() {
+			return true
+		}
+	}
+	return false
+}
+
 func buildHTTPRequestConfigMap(ctx context.Context, cfg *CourierHTTPRequestConfigModel) map[string]interface{} {
 	result := map[string]interface{}{
 		"url":    cfg.URL.ValueString(),
@@ -1067,6 +1213,15 @@ func (r *ProjectConfigResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	patches := r.buildPatches(ctx, &plan)
+
+	if needsHookPrefetch(&plan) {
+		currentProject, err := r.client.GetProject(ctx, projectID)
+		if err != nil {
+			resp.Diagnostics.AddError("Error Reading Project Config For Hook Merge", err.Error())
+			return
+		}
+		patches = append(patches, buildShowVerificationUIHookPatches(&plan, currentProject)...)
+	}
 
 	tflog.Debug(ctx, "Building project config patches", map[string]interface{}{
 		"project_id":  projectID,
@@ -1311,6 +1466,24 @@ func (r *ProjectConfigResource) readProjectConfig(ctx context.Context, project *
 				}
 			}
 		}
+
+		// show_verification_ui hook reads: refresh state only when the
+		// attribute was already set, so untracked flows don't appear in
+		// `terraform plan` output.
+		for _, e := range showVerificationUIHookEntries(state) {
+			if e.Field.IsNull() {
+				continue
+			}
+			present := hookListContains(identityConfig, e.PathKeys, "show_verification_ui")
+			switch {
+			case e.PathKeys[len(e.PathKeys)-1] == "password":
+				state.SelfserviceFlowsRegistrationAfterPasswordHookShowVerificationUI = types.BoolValue(present)
+			case e.PathKeys[len(e.PathKeys)-1] == "oidc":
+				state.SelfserviceFlowsRegistrationAfterOIDCHookShowVerificationUI = types.BoolValue(present)
+			case e.PathKeys[len(e.PathKeys)-1] == "profile":
+				state.SelfserviceFlowsSettingsAfterProfileHookShowVerificationUI = types.BoolValue(present)
+			}
+		}
 	}
 
 	// Permission/Keto service config
@@ -1525,6 +1698,16 @@ func (r *ProjectConfigResource) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	patches := r.buildPatches(ctx, &plan)
+
+	if needsHookPrefetch(&plan) {
+		currentProject, err := r.client.GetProject(ctx, projectID)
+		if err != nil {
+			resp.Diagnostics.AddError("Error Reading Project Config For Hook Merge", err.Error())
+			return
+		}
+		patches = append(patches, buildShowVerificationUIHookPatches(&plan, currentProject)...)
+	}
+
 	if len(patches) > 0 {
 		_, err := r.client.PatchProject(ctx, projectID, patches)
 		if err != nil {

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -648,6 +648,66 @@ func TestAccProjectConfigResource_recoveryFlow(t *testing.T) {
 	})
 }
 
+func TestAccProjectConfigResource_showVerificationUIHooks(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Enable all three show_verification_ui hooks.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/show_verification_ui_hooks.tf.tmpl", map[string]string{
+					"Password": "true",
+					"OIDC":     "true",
+					"Profile":  "true",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_project_config.test", "id"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_registration_after_password_hook_show_verification_ui", "true"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_registration_after_oidc_hook_show_verification_ui", "true"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_settings_after_profile_hook_show_verification_ui", "true"),
+				),
+			},
+			// Disable the password and profile hooks, keep oidc enabled.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/show_verification_ui_hooks.tf.tmpl", map[string]string{
+					"Password": "false",
+					"OIDC":     "true",
+					"Profile":  "false",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_registration_after_password_hook_show_verification_ui", "false"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_registration_after_oidc_hook_show_verification_ui", "true"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_settings_after_profile_hook_show_verification_ui", "false"),
+				),
+			},
+			// Re-apply the same config to confirm no perpetual diff.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/show_verification_ui_hooks.tf.tmpl", map[string]string{
+					"Password": "false",
+					"OIDC":     "true",
+					"Profile":  "false",
+				}),
+				PlanOnly: true,
+			},
+			// Import then verify state.
+			{
+				ResourceName:      "ory_project_config.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"selfservice_flows_registration_after_password_hook_show_verification_ui",
+					"selfservice_flows_registration_after_oidc_hook_show_verification_ui",
+					"selfservice_flows_settings_after_profile_hook_show_verification_ui",
+					"selfservice_flows_verification_enabled",
+					"cors_enabled",
+					"selfservice_methods_password_config_min_password_length",
+					"smtp_connection_uri",
+				},
+			},
+		},
+	})
+}
+
 func TestAccProjectConfigResource_oauth2Advanced(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccPreCheck(t) },

--- a/internal/resources/projectconfig/testdata/show_verification_ui_hooks.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/show_verification_ui_hooks.tf.tmpl
@@ -1,0 +1,7 @@
+resource "ory_project_config" "test" {
+  selfservice_flows_verification_enabled = true
+
+  selfservice_flows_registration_after_password_hook_show_verification_ui = [[ .Password ]]
+  selfservice_flows_registration_after_oidc_hook_show_verification_ui     = [[ .OIDC ]]
+  selfservice_flows_settings_after_profile_hook_show_verification_ui      = [[ .Profile ]]
+}

--- a/templates/resources/project_config.md.tmpl
+++ b/templates/resources/project_config.md.tmpl
@@ -93,6 +93,18 @@ The `smtp_connection_uri` attribute selects the SMTP security mode through the U
 
 For more detail, see the [Ory Kratos SMTP documentation](https://www.ory.com/docs/kratos/emails-sms/sending-emails-smtp).
 
+## Verification After Registration / Settings
+
+Three boolean attributes toggle the [`show_verification_ui`](https://www.ory.com/docs/kratos/self-service/flows/user-registration) post-flow hook for each authentication method:
+
+- `selfservice_flows_registration_after_password_hook_show_verification_ui`
+- `selfservice_flows_registration_after_oidc_hook_show_verification_ui`
+- `selfservice_flows_settings_after_profile_hook_show_verification_ui`
+
+When `true`, the provider adds the `show_verification_ui` hook to the corresponding flow; when `false`, it removes only that hook. Other hooks at the same path (for example `session` or `organization`) are preserved by reading the current hook list before each apply.
+
+To require a verified address before a user can log in (the "Require verified address for login" toggle in the Ory Console), set `feature_flags_legacy_require_verified_login_error = true`. When that flag is `false`, an unverified user is shown the `show_verification_ui` continuation step instead of receiving a form error.
+
 ## Clearing Return URLs
 
 To explicitly clear `default_return_url` and `allowed_return_urls` (e.g., for native-only flows with no browser redirects), set them to empty values:


### PR DESCRIPTION
## Description

Adds three boolean attributes to `ory_project_config` that toggle the `show_verification_ui` post-flow hook for the registration (password / OIDC) and settings (profile) flows:

- `selfservice_flows_registration_after_password_hook_show_verification_ui`
- `selfservice_flows_registration_after_oidc_hook_show_verification_ui`
- `selfservice_flows_settings_after_profile_hook_show_verification_ui`

The Ory API stores hooks as an ordered array of `{"hook": "..."}` objects, so the provider fetches the current project state before each create/update and merges the desired `show_verification_ui` value into the existing list. Other hooks already configured at the same path (for example `session` or `organization`) are preserved.

The existing `feature_flags_legacy_require_verified_login_error` attribute already controls the "Require verified address for login" toggle shown in the Ory Console; the resource documentation now calls this out explicitly.

## Related Issues

Fixes #229

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests (`TestBuildShowVerificationUIHookPatches_*`, `TestNeedsHookPrefetch`)
- [x] Acceptance tests (`TestAccProjectConfigResource_showVerificationUIHooks` covering create, update, plan-only no-drift, and import) against the staging project
- [x] Manual testing: applied terraform configurations end-to-end (create -> update -> import -> destroy) and verified the API state via `curl` to confirm `show_verification_ui` was added/removed correctly while preserving `organization` and `session` hooks

## Screenshots/Output

API state after `terraform apply` with all three hooks enabled:

```
reg.password:     ['show_verification_ui', 'organization']
reg.oidc:         ['show_verification_ui', 'session', 'organization']
settings.profile: ['show_verification_ui', 'organization']
```

After `terraform apply` with the password and profile hooks disabled (OIDC kept enabled):

```
reg.password:     ['organization']
reg.oidc:         ['show_verification_ui', 'session', 'organization']
settings.profile: ['organization']
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new boolean configuration options to control verification UI display after password registration, OIDC registration, and profile settings updates.

* **Documentation**
  * Added documentation and examples demonstrating the new verification UI hook configuration attributes and their usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/terraform-provider-ory/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->