### PR TITLE
feat(project-config): add session hook for password registration

### DIFF
--- a/docs/resources/project_config.md
+++ b/docs/resources/project_config.md
@@ -273,6 +273,15 @@ resource "ory_project_config" "show_verification_ui" {
   # When users change their email in profile settings, force re-verification.
   selfservice_flows_settings_after_profile_hook_show_verification_ui = true
 }
+
+# Automatically sign users in after they register with email + password.
+# OIDC, WebAuthn and Passkey flows already issue a session on registration,
+# so this toggle only affects the password flow — it mirrors the Ory Console
+# "Enable sign in after registration" toggle. Existing hooks at the same path
+# (e.g. `organization`) are preserved.
+resource "ory_project_config" "sign_in_after_registration" {
+  selfservice_flows_registration_after_password_hook_session = true
+}
 ```
 
 ## Duration Format
@@ -569,6 +578,7 @@ terraform plan  # verify no changes
 - `selfservice_flows_registration_after_oidc_hook_show_verification_ui` (Boolean) Enable the `show_verification_ui` hook after a successful OIDC (social) registration. When true, users are redirected to the verification UI after registering via a social provider. Existing hooks at this path (e.g., `session`, `organization`) are preserved.
 - `selfservice_flows_registration_after_passkey_default_browser_return_url` (String) Return URL after registration via passkey.
 - `selfservice_flows_registration_after_password_default_browser_return_url` (String) Return URL after registration via password.
+- `selfservice_flows_registration_after_password_hook_session` (Boolean) Enable the `session` hook after a successful password registration, automatically signing the user in. Mirrors the Ory Console "Enable sign in after registration" toggle. Existing hooks at this path (e.g., `organization`) are preserved.
 - `selfservice_flows_registration_after_password_hook_show_verification_ui` (Boolean) Enable the `show_verification_ui` hook after a successful password registration. When true, users are redirected to the verification UI after registering with email + password. Existing hooks at this path (e.g., `session`, `organization`) are preserved.
 - `selfservice_flows_registration_after_webauthn_default_browser_return_url` (String) Return URL after registration via WebAuthn.
 - `selfservice_flows_registration_enable_legacy_one_step` (Boolean) Revert to legacy one-step registration instead of the two-step flow.

--- a/examples/resources/ory_project_config/resource.tf
+++ b/examples/resources/ory_project_config/resource.tf
@@ -250,3 +250,12 @@ resource "ory_project_config" "show_verification_ui" {
   # When users change their email in profile settings, force re-verification.
   selfservice_flows_settings_after_profile_hook_show_verification_ui = true
 }
+
+# Automatically sign users in after they register with email + password.
+# OIDC, WebAuthn and Passkey flows already issue a session on registration,
+# so this toggle only affects the password flow — it mirrors the Ory Console
+# "Enable sign in after registration" toggle. Existing hooks at the same path
+# (e.g. `organization`) are preserved.
+resource "ory_project_config" "sign_in_after_registration" {
+  selfservice_flows_registration_after_password_hook_session = true
+}

--- a/internal/resources/projectconfig/build_patches_test.go
+++ b/internal/resources/projectconfig/build_patches_test.go
@@ -368,7 +368,7 @@ func TestBuildPatches_NullVerificationNotifyUnknownRecipients(t *testing.T) {
 }
 
 // projectWithIdentityConfig wraps an identity config map in the *ory.Project
-// shape that buildShowVerificationUIHookPatches expects.
+// shape that buildHookPatches expects.
 func projectWithIdentityConfig(identityConfig map[string]interface{}) *ory.Project {
 	return &ory.Project{
 		Services: ory.ProjectServices{
@@ -399,7 +399,7 @@ func TestBuildShowVerificationUIHookPatches_AddPreservesOtherHooks(t *testing.T)
 		},
 	})
 
-	patches := buildShowVerificationUIHookPatches(plan, current)
+	patches := buildHookPatches(plan, current)
 	require.Len(t, patches, 1)
 	p := patches[0]
 	assert.Equal(t, "replace", p.Op)
@@ -432,7 +432,7 @@ func TestBuildShowVerificationUIHookPatches_RemoveKeepsOthers(t *testing.T) {
 		},
 	})
 
-	patches := buildShowVerificationUIHookPatches(plan, current)
+	patches := buildHookPatches(plan, current)
 	require.Len(t, patches, 1)
 	hooks, ok := patches[0].Value.([]map[string]interface{})
 	require.True(t, ok, "expected []map[string]interface{} value, got %T", patches[0].Value)
@@ -461,7 +461,7 @@ func TestBuildShowVerificationUIHookPatches_AddIdempotent(t *testing.T) {
 		},
 	})
 
-	patches := buildShowVerificationUIHookPatches(plan, current)
+	patches := buildHookPatches(plan, current)
 	hooks, _ := patches[0].Value.([]map[string]interface{})
 	require.Len(t, hooks, 2, "expected 2 hooks (no duplicate): %v", hooks)
 	seen := map[string]int{}
@@ -478,7 +478,7 @@ func TestBuildShowVerificationUIHookPatches_NullSkipped(t *testing.T) {
 	plan := &ProjectConfigResourceModel{}
 	current := projectWithIdentityConfig(map[string]interface{}{})
 
-	patches := buildShowVerificationUIHookPatches(plan, current)
+	patches := buildHookPatches(plan, current)
 	assert.Empty(t, patches, "expected no patches when all hook attrs are null")
 }
 
@@ -486,7 +486,7 @@ func TestBuildShowVerificationUIHookPatches_NilCurrentProject(t *testing.T) {
 	plan := &ProjectConfigResourceModel{
 		SelfserviceFlowsRegistrationAfterPasswordHookShowVerificationUI: types.BoolValue(true),
 	}
-	patches := buildShowVerificationUIHookPatches(plan, nil)
+	patches := buildHookPatches(plan, nil)
 	assert.Empty(t, patches, "expected no patches when currentProject is nil")
 }
 
@@ -496,7 +496,7 @@ func TestBuildShowVerificationUIHookPatches_MissingHooksPathIsEmptyArray(t *test
 	}
 	current := projectWithIdentityConfig(map[string]interface{}{})
 
-	patches := buildShowVerificationUIHookPatches(plan, current)
+	patches := buildHookPatches(plan, current)
 	require.Len(t, patches, 1, "expected 1 patch even with empty config")
 	hooks, ok := patches[0].Value.([]map[string]interface{})
 	require.True(t, ok, "expected []map[string]interface{} value, got %T", patches[0].Value)
@@ -536,10 +536,140 @@ func TestNeedsHookPrefetch(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "password session hook set",
+			plan: ProjectConfigResourceModel{
+				SelfserviceFlowsRegistrationAfterPasswordHookSession: types.BoolValue(true),
+			},
+			want: true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, needsHookPrefetch(&tc.plan))
 		})
+	}
+}
+
+func TestBuildHookPatches_SessionAddPreservesOtherHooks(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsRegistrationAfterPasswordHookSession: types.BoolValue(true),
+	}
+	current := projectWithIdentityConfig(map[string]interface{}{
+		"selfservice": map[string]interface{}{
+			"flows": map[string]interface{}{
+				"registration": map[string]interface{}{
+					"after": map[string]interface{}{
+						"password": map[string]interface{}{
+							"hooks": []interface{}{
+								map[string]interface{}{"hook": "organization"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	patches := buildHookPatches(plan, current)
+	if len(patches) != 1 {
+		t.Fatalf("expected 1 patch, got %d", len(patches))
+	}
+	p := patches[0]
+	if p.Path != "/services/identity/config/selfservice/flows/registration/after/password/hooks" {
+		t.Errorf("unexpected patch path: %s", p.Path)
+	}
+	hooks, ok := p.Value.([]map[string]interface{})
+	if !ok {
+		t.Fatalf("expected []map[string]interface{} value, got %T", p.Value)
+	}
+	if len(hooks) != 2 {
+		t.Fatalf("expected 2 hooks (session + organization), got %d: %v", len(hooks), hooks)
+	}
+	if hooks[0]["hook"] != "session" {
+		t.Errorf("expected session first, got %v", hooks[0]["hook"])
+	}
+	if hooks[1]["hook"] != "organization" {
+		t.Errorf("expected organization preserved, got %v", hooks[1]["hook"])
+	}
+}
+
+func TestBuildHookPatches_SessionRemoveKeepsOthers(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsRegistrationAfterPasswordHookSession: types.BoolValue(false),
+	}
+	current := projectWithIdentityConfig(map[string]interface{}{
+		"selfservice": map[string]interface{}{
+			"flows": map[string]interface{}{
+				"registration": map[string]interface{}{
+					"after": map[string]interface{}{
+						"password": map[string]interface{}{
+							"hooks": []interface{}{
+								map[string]interface{}{"hook": "session"},
+								map[string]interface{}{"hook": "organization"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	patches := buildHookPatches(plan, current)
+	if len(patches) != 1 {
+		t.Fatalf("expected 1 patch, got %d", len(patches))
+	}
+	hooks, _ := patches[0].Value.([]map[string]interface{})
+	if len(hooks) != 1 {
+		t.Fatalf("expected 1 remaining hook, got %d", len(hooks))
+	}
+	if hooks[0]["hook"] != "organization" {
+		t.Errorf("expected organization to remain, got %v", hooks[0]["hook"])
+	}
+}
+
+// When two hook attributes (show_verification_ui and session) target the same
+// hooks array, buildHookPatches emits a single patch that reflects both
+// toggles instead of clobbering one with the other.
+func TestBuildHookPatches_MultipleHooksAtSamePathMerged(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsRegistrationAfterPasswordHookShowVerificationUI: types.BoolValue(true),
+		SelfserviceFlowsRegistrationAfterPasswordHookSession:            types.BoolValue(true),
+	}
+	current := projectWithIdentityConfig(map[string]interface{}{
+		"selfservice": map[string]interface{}{
+			"flows": map[string]interface{}{
+				"registration": map[string]interface{}{
+					"after": map[string]interface{}{
+						"password": map[string]interface{}{
+							"hooks": []interface{}{
+								map[string]interface{}{"hook": "organization"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	patches := buildHookPatches(plan, current)
+	if len(patches) != 1 {
+		t.Fatalf("expected exactly 1 merged patch for the password hooks path, got %d", len(patches))
+	}
+	hooks, _ := patches[0].Value.([]map[string]interface{})
+	seen := map[string]int{}
+	for _, h := range hooks {
+		if name, ok := h["hook"].(string); ok {
+			seen[name]++
+		}
+	}
+	if seen["show_verification_ui"] != 1 {
+		t.Errorf("expected show_verification_ui to be present once, got %d", seen["show_verification_ui"])
+	}
+	if seen["session"] != 1 {
+		t.Errorf("expected session to be present once, got %d", seen["session"])
+	}
+	if seen["organization"] != 1 {
+		t.Errorf("expected organization to be preserved, got %d", seen["organization"])
 	}
 }

--- a/internal/resources/projectconfig/build_patches_test.go
+++ b/internal/resources/projectconfig/build_patches_test.go
@@ -572,26 +572,14 @@ func TestBuildHookPatches_SessionAddPreservesOtherHooks(t *testing.T) {
 	})
 
 	patches := buildHookPatches(plan, current)
-	if len(patches) != 1 {
-		t.Fatalf("expected 1 patch, got %d", len(patches))
-	}
+	require.Len(t, patches, 1)
 	p := patches[0]
-	if p.Path != "/services/identity/config/selfservice/flows/registration/after/password/hooks" {
-		t.Errorf("unexpected patch path: %s", p.Path)
-	}
+	assert.Equal(t, "/services/identity/config/selfservice/flows/registration/after/password/hooks", p.Path)
 	hooks, ok := p.Value.([]map[string]interface{})
-	if !ok {
-		t.Fatalf("expected []map[string]interface{} value, got %T", p.Value)
-	}
-	if len(hooks) != 2 {
-		t.Fatalf("expected 2 hooks (session + organization), got %d: %v", len(hooks), hooks)
-	}
-	if hooks[0]["hook"] != "session" {
-		t.Errorf("expected session first, got %v", hooks[0]["hook"])
-	}
-	if hooks[1]["hook"] != "organization" {
-		t.Errorf("expected organization preserved, got %v", hooks[1]["hook"])
-	}
+	require.True(t, ok, "expected []map[string]interface{} value, got %T", p.Value)
+	require.Len(t, hooks, 2, "expected 2 hooks (session + organization)")
+	assert.Equal(t, "session", hooks[0]["hook"], "expected session first")
+	assert.Equal(t, "organization", hooks[1]["hook"], "expected organization preserved")
 }
 
 func TestBuildHookPatches_SessionRemoveKeepsOthers(t *testing.T) {
@@ -616,16 +604,10 @@ func TestBuildHookPatches_SessionRemoveKeepsOthers(t *testing.T) {
 	})
 
 	patches := buildHookPatches(plan, current)
-	if len(patches) != 1 {
-		t.Fatalf("expected 1 patch, got %d", len(patches))
-	}
+	require.Len(t, patches, 1)
 	hooks, _ := patches[0].Value.([]map[string]interface{})
-	if len(hooks) != 1 {
-		t.Fatalf("expected 1 remaining hook, got %d", len(hooks))
-	}
-	if hooks[0]["hook"] != "organization" {
-		t.Errorf("expected organization to remain, got %v", hooks[0]["hook"])
-	}
+	require.Len(t, hooks, 1, "expected 1 remaining hook")
+	assert.Equal(t, "organization", hooks[0]["hook"], "expected organization to remain")
 }
 
 // When two hook attributes (show_verification_ui and session) target the same
@@ -653,9 +635,7 @@ func TestBuildHookPatches_MultipleHooksAtSamePathMerged(t *testing.T) {
 	})
 
 	patches := buildHookPatches(plan, current)
-	if len(patches) != 1 {
-		t.Fatalf("expected exactly 1 merged patch for the password hooks path, got %d", len(patches))
-	}
+	require.Len(t, patches, 1, "expected exactly 1 merged patch for the password hooks path")
 	hooks, _ := patches[0].Value.([]map[string]interface{})
 	seen := map[string]int{}
 	for _, h := range hooks {
@@ -663,13 +643,7 @@ func TestBuildHookPatches_MultipleHooksAtSamePathMerged(t *testing.T) {
 			seen[name]++
 		}
 	}
-	if seen["show_verification_ui"] != 1 {
-		t.Errorf("expected show_verification_ui to be present once, got %d", seen["show_verification_ui"])
-	}
-	if seen["session"] != 1 {
-		t.Errorf("expected session to be present once, got %d", seen["session"])
-	}
-	if seen["organization"] != 1 {
-		t.Errorf("expected organization to be preserved, got %d", seen["organization"])
-	}
+	assert.Equal(t, 1, seen["show_verification_ui"], "expected show_verification_ui to be present once")
+	assert.Equal(t, 1, seen["session"], "expected session to be present once")
+	assert.Equal(t, 1, seen["organization"], "expected organization to be preserved")
 }

--- a/internal/resources/projectconfig/resource.go
+++ b/internal/resources/projectconfig/resource.go
@@ -414,6 +414,11 @@ type ProjectConfigResourceModel struct {
 	SelfserviceFlowsRegistrationAfterPasswordHookShowVerificationUI types.Bool `tfsdk:"selfservice_flows_registration_after_password_hook_show_verification_ui"`
 	SelfserviceFlowsRegistrationAfterOIDCHookShowVerificationUI     types.Bool `tfsdk:"selfservice_flows_registration_after_oidc_hook_show_verification_ui"`
 	SelfserviceFlowsSettingsAfterProfileHookShowVerificationUI      types.Bool `tfsdk:"selfservice_flows_settings_after_profile_hook_show_verification_ui"`
+
+	// session hook on password registration (custom: not in OpenAPI spec).
+	// Toggles the session hook in registration.after.password.hooks, mirroring
+	// the Ory Console "Enable sign in after registration" toggle.
+	SelfserviceFlowsRegistrationAfterPasswordHookSession types.Bool `tfsdk:"selfservice_flows_registration_after_password_hook_session"`
 }
 
 // --- Nested model types for session tokenizer templates and courier HTTP ---
@@ -674,6 +679,17 @@ func (r *ProjectConfigResource) Schema(ctx context.Context, req resource.SchemaR
 	attrs["selfservice_flows_settings_after_profile_hook_show_verification_ui"] = schema.BoolAttribute{
 		Description: "Enable the `show_verification_ui` hook after a successful profile settings update. " +
 			"When true, users are redirected to the verification UI after updating their profile (e.g., changing their email). " +
+			"Existing hooks at this path (e.g., `organization`) are preserved.",
+		Optional: true,
+	}
+
+	// session hook: mirrors the Ory Console "Enable sign in after registration"
+	// toggle. OIDC, WebAuthn and Passkey flows always issue a session on
+	// registration, so the console only exposes this for the password flow.
+	attrs["selfservice_flows_registration_after_password_hook_session"] = schema.BoolAttribute{
+		Description: "Enable the `session` hook after a successful password registration, " +
+			"automatically signing the user in. Mirrors the Ory Console " +
+			"\"Enable sign in after registration\" toggle. " +
 			"Existing hooks at this path (e.g., `organization`) are preserved.",
 		Optional: true,
 	}
@@ -1031,53 +1047,104 @@ func (r *ProjectConfigResource) buildPatches(ctx context.Context, plan *ProjectC
 	return patches
 }
 
-// showVerificationUIHookEntry describes one show_verification_ui hook attribute
-// and the identity-config path whose hooks array it controls.
-type showVerificationUIHookEntry struct {
+// hookEntry describes one boolean hook attribute: the field on the model, the
+// identity-config path whose hooks array it controls, the hook name within
+// that array, and a setter that writes the read-back value into state.
+type hookEntry struct {
 	Field    types.Bool
 	PathKeys []string // path under /services/identity/config, ending at the parent of "hooks"
+	HookName string
+	Set      func(state *ProjectConfigResourceModel, value types.Bool)
 }
 
-func showVerificationUIHookEntries(plan *ProjectConfigResourceModel) []showVerificationUIHookEntry {
-	return []showVerificationUIHookEntry{
+// hookEntries returns every hook attribute the provider exposes. Adding a new
+// hook toggle is a matter of appending one entry here, declaring the model
+// field, and registering the schema attribute.
+func hookEntries(plan *ProjectConfigResourceModel) []hookEntry {
+	return []hookEntry{
 		{
 			Field:    plan.SelfserviceFlowsRegistrationAfterPasswordHookShowVerificationUI,
 			PathKeys: []string{"selfservice", "flows", "registration", "after", "password"},
+			HookName: "show_verification_ui",
+			Set: func(s *ProjectConfigResourceModel, v types.Bool) {
+				s.SelfserviceFlowsRegistrationAfterPasswordHookShowVerificationUI = v
+			},
 		},
 		{
 			Field:    plan.SelfserviceFlowsRegistrationAfterOIDCHookShowVerificationUI,
 			PathKeys: []string{"selfservice", "flows", "registration", "after", "oidc"},
+			HookName: "show_verification_ui",
+			Set: func(s *ProjectConfigResourceModel, v types.Bool) {
+				s.SelfserviceFlowsRegistrationAfterOIDCHookShowVerificationUI = v
+			},
 		},
 		{
 			Field:    plan.SelfserviceFlowsSettingsAfterProfileHookShowVerificationUI,
 			PathKeys: []string{"selfservice", "flows", "settings", "after", "profile"},
+			HookName: "show_verification_ui",
+			Set: func(s *ProjectConfigResourceModel, v types.Bool) {
+				s.SelfserviceFlowsSettingsAfterProfileHookShowVerificationUI = v
+			},
+		},
+		{
+			Field:    plan.SelfserviceFlowsRegistrationAfterPasswordHookSession,
+			PathKeys: []string{"selfservice", "flows", "registration", "after", "password"},
+			HookName: "session",
+			Set: func(s *ProjectConfigResourceModel, v types.Bool) {
+				s.SelfserviceFlowsRegistrationAfterPasswordHookSession = v
+			},
 		},
 	}
 }
 
-// buildShowVerificationUIHookPatches reconciles the show_verification_ui hook
-// for each configured flow by merging the desired state with whatever hooks
-// already exist on the project (for example `session` or `organization`).
+// buildHookPatches reconciles every configured hook attribute by merging the
+// desired state with whatever hooks already exist on the project (for example
+// `organization`, which the Ory Console adds by default and that we must
+// preserve).
 //
 // When currentProject is nil, no merge target is available and the function
 // returns an empty patch list.
-func buildShowVerificationUIHookPatches(plan *ProjectConfigResourceModel, currentProject *ory.Project) []ory.JsonPatch {
+func buildHookPatches(plan *ProjectConfigResourceModel, currentProject *ory.Project) []ory.JsonPatch {
 	var patches []ory.JsonPatch
 	if currentProject == nil || currentProject.Services.Identity == nil {
 		return patches
 	}
 	identityConfig := currentProject.Services.Identity.Config
-	for _, e := range showVerificationUIHookEntries(plan) {
+
+	// Multiple entries can share the same hooks-array path (e.g. the password
+	// registration flow has both show_verification_ui and session toggles).
+	// We accumulate per-path edits in order, then emit one patch per path so
+	// the final array reflects all toggles consistently.
+	type accum struct {
+		pathKeys []string
+		hooks    []map[string]interface{}
+	}
+	accumulators := map[string]*accum{}
+	order := []string{}
+
+	for _, e := range hookEntries(plan) {
 		if e.Field.IsNull() || e.Field.IsUnknown() {
 			continue
 		}
-		desired := e.Field.ValueBool()
-		existingHooks := readHookList(identityConfig, e.PathKeys)
-		newHooks := setHookPresent(existingHooks, "show_verification_ui", desired)
+		pathKey := strings.Join(e.PathKeys, "/")
+		acc, ok := accumulators[pathKey]
+		if !ok {
+			acc = &accum{
+				pathKeys: e.PathKeys,
+				hooks:    readHookList(identityConfig, e.PathKeys),
+			}
+			accumulators[pathKey] = acc
+			order = append(order, pathKey)
+		}
+		acc.hooks = setHookPresent(acc.hooks, e.HookName, e.Field.ValueBool())
+	}
+
+	for _, pathKey := range order {
+		acc := accumulators[pathKey]
 		patches = append(patches, ory.JsonPatch{
 			Op:    "replace",
-			Path:  "/services/identity/config/" + strings.Join(e.PathKeys, "/") + "/hooks",
-			Value: newHooks,
+			Path:  "/services/identity/config/" + pathKey + "/hooks",
+			Value: acc.hooks,
 		})
 	}
 	return patches
@@ -1135,11 +1202,12 @@ func hookListContains(identityConfig map[string]interface{}, pathKeys []string, 
 	return false
 }
 
-// needsHookPrefetch reports whether any of the show_verification_ui hook
-// attributes are set in the plan, in which case the caller must fetch the
-// current project state before building patches.
+// needsHookPrefetch reports whether any hook attribute is set in the plan, in
+// which case the caller must fetch the current project state before building
+// patches so that other hooks already present (e.g. `organization`) are
+// preserved.
 func needsHookPrefetch(plan *ProjectConfigResourceModel) bool {
-	for _, e := range showVerificationUIHookEntries(plan) {
+	for _, e := range hookEntries(plan) {
 		if !e.Field.IsNull() && !e.Field.IsUnknown() {
 			return true
 		}
@@ -1220,7 +1288,7 @@ func (r *ProjectConfigResource) Create(ctx context.Context, req resource.CreateR
 			resp.Diagnostics.AddError("Error Reading Project Config For Hook Merge", err.Error())
 			return
 		}
-		patches = append(patches, buildShowVerificationUIHookPatches(&plan, currentProject)...)
+		patches = append(patches, buildHookPatches(&plan, currentProject)...)
 	}
 
 	tflog.Debug(ctx, "Building project config patches", map[string]interface{}{
@@ -1467,22 +1535,14 @@ func (r *ProjectConfigResource) readProjectConfig(ctx context.Context, project *
 			}
 		}
 
-		// show_verification_ui hook reads: refresh state only when the
-		// attribute was already set, so untracked flows don't appear in
-		// `terraform plan` output.
-		for _, e := range showVerificationUIHookEntries(state) {
+		// Hook reads: refresh state only when the attribute was already set,
+		// so untracked flows don't produce drift in `terraform plan`.
+		for _, e := range hookEntries(state) {
 			if e.Field.IsNull() {
 				continue
 			}
-			present := hookListContains(identityConfig, e.PathKeys, "show_verification_ui")
-			switch {
-			case e.PathKeys[len(e.PathKeys)-1] == "password":
-				state.SelfserviceFlowsRegistrationAfterPasswordHookShowVerificationUI = types.BoolValue(present)
-			case e.PathKeys[len(e.PathKeys)-1] == "oidc":
-				state.SelfserviceFlowsRegistrationAfterOIDCHookShowVerificationUI = types.BoolValue(present)
-			case e.PathKeys[len(e.PathKeys)-1] == "profile":
-				state.SelfserviceFlowsSettingsAfterProfileHookShowVerificationUI = types.BoolValue(present)
-			}
+			present := hookListContains(identityConfig, e.PathKeys, e.HookName)
+			e.Set(state, types.BoolValue(present))
 		}
 	}
 
@@ -1705,7 +1765,7 @@ func (r *ProjectConfigResource) Update(ctx context.Context, req resource.UpdateR
 			resp.Diagnostics.AddError("Error Reading Project Config For Hook Merge", err.Error())
 			return
 		}
-		patches = append(patches, buildShowVerificationUIHookPatches(&plan, currentProject)...)
+		patches = append(patches, buildHookPatches(&plan, currentProject)...)
 	}
 
 	if len(patches) > 0 {

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -646,6 +646,53 @@ func TestAccProjectConfigResource_recoveryFlow(t *testing.T) {
 	})
 }
 
+func TestAccProjectConfigResource_sessionHookOnPasswordRegistration(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Enable the session hook on the password registration flow.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/session_hook.tf.tmpl", map[string]string{
+					"Session": "true",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_project_config.test", "id"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_registration_after_password_hook_session", "true"),
+				),
+			},
+			// Disable it.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/session_hook.tf.tmpl", map[string]string{
+					"Session": "false",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_registration_after_password_hook_session", "false"),
+				),
+			},
+			// Re-apply the same config to confirm no perpetual diff.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/session_hook.tf.tmpl", map[string]string{
+					"Session": "false",
+				}),
+				PlanOnly: true,
+			},
+			// Import then verify state.
+			{
+				ResourceName:      "ory_project_config.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"selfservice_flows_registration_after_password_hook_session",
+					"cors_enabled",
+					"selfservice_methods_password_config_min_password_length",
+					"smtp_connection_uri",
+				},
+			},
+		},
+	})
+}
+
 func TestAccProjectConfigResource_showVerificationUIHooks(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccPreCheck(t) },

--- a/internal/resources/projectconfig/testdata/session_hook.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/session_hook.tf.tmpl
@@ -1,0 +1,3 @@
+resource "ory_project_config" "test" {
+  selfservice_flows_registration_after_password_hook_session = [[ .Session ]]
+}


### PR DESCRIPTION
## Description

Adds `selfservice_flows_registration_after_password_hook_session`, a boolean
attribute that toggles the `session` hook on the password registration flow.
This mirrors the Ory Console "Enable sign in after registration" toggle:
when enabled, a session is automatically issued after a user registers via
email and password, signing them in.

Other registration flows (OIDC, WebAuthn, Passkey) always issue a session
on registration regardless of this toggle, which is why the Ory Console
only exposes the setting for the password flow.

While adding the attribute, the existing `show_verification_ui` hook
machinery was refactored into a single unified `hookEntries()` list. Each
entry carries its own hook name and a state setter, so adding more hook
attributes in the future is one struct literal. The patches builder also
now coalesces multiple toggles that target the same hooks array (e.g.
`show_verification_ui` and `session` both on the password registration
path) into a single patch so they no longer overwrite each other.

## Related Issues

Fixes #233

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

### Unit tests

Three new unit tests cover the session hook path and the multi-hook
coalescing behavior, alongside the existing show_verification_ui tests:

```
TestBuildHookPatches_SessionAddPreservesOtherHooks
TestBuildHookPatches_SessionRemoveKeepsOthers
TestBuildHookPatches_MultipleHooksAtSamePathMerged
```

`TestNeedsHookPrefetch` gains a `password session hook set` case.

### Acceptance tests

`TestAccProjectConfigResource_sessionHookOnPasswordRegistration` exercises
enable, disable, idempotent re-apply, and import on a staging project. Both
the new test and the pre-existing `TestAccProjectConfigResource_showVerificationUIHooks`
pass after the refactor:

```
--- PASS: TestAccProjectConfigResource_sessionHookOnPasswordRegistration (7.90s)
--- PASS: TestAccProjectConfigResource_showVerificationUIHooks (7.65s)
PASS
ok  github.com/ory/terraform-provider-ory/internal/resources/projectconfig  16.215s
```

### Manual testing

Built the provider locally and ran a terraform config against a staging
project. Verified each lifecycle operation against the live Ory API:

| Step                    | `password.hooks` on API                                     |
|-------------------------|-------------------------------------------------------------|
| Apply with `= true`     | `[{"hook":"session"},{"hook":"organization"}]`              |
| Apply with `= false`    | `[{"hook":"organization"}]`                                 |
| Re-plan (idempotency)   | No changes                                                  |
| Import + plan           | Round-trips cleanly                                         |
| Destroy                 | No-op (project_config Delete is intentionally a no-op)      |

## Screenshots/Output

The Ory Console toggle this attribute controls:

> Enable sign in after registration — If enabled, users will be automatically
> logged in after they register.

The note below the toggle reads: *"A session is automatically issued for
OIDC, WebAuthn and Passkey registration flows. This setting only affects
password flows."*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatic user sign-in immediately after password-based registration.

* **Documentation**
  * Updated documentation and example configurations demonstrating how to enable sign-in after registration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/terraform-provider-ory/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->