### PR TITLE
feat(project-config): add session_earliest_possible_extend attribute

### DIFF
--- a/docs/resources/project_config.md
+++ b/docs/resources/project_config.md
@@ -40,9 +40,10 @@ resource "ory_project_config" "secure" {
   cors_admin_origins = ["https://admin.example.com"]
 
   # Sessions
-  session_lifespan          = "168h0m0s" # 7 days
-  session_cookie_same_site  = "Strict"
-  session_cookie_persistent = true
+  session_lifespan                 = "168h0m0s" # 7 days
+  session_earliest_possible_extend = "24h"      # Only extend sessions in the last 24h to avoid excessive writes
+  session_cookie_same_site         = "Strict"
+  session_cookie_persistent        = true
 
   # Password Policy
   selfservice_methods_password_config_min_password_length                 = 12
@@ -636,6 +637,7 @@ terraform plan  # verify no changes
 - `selfservice_methods_webauthn_enabled` (Boolean) Enable WebAuthn (hardware keys).
 - `session_cookie_persistent` (Boolean) Enable persistent session cookies (survive browser close).
 - `session_cookie_same_site` (String) SameSite cookie attribute (Lax, Strict, None).
+- `session_earliest_possible_extend` (String) Earliest time before session expiry when a session can be extended (e.g., '24h'). Setting this prevents excessive database writes when sessions are extended.
 - `session_lifespan` (String) Session duration (e.g., '24h0m0s').
 - `session_tokenizer_templates` (Attributes Map) JWT tokenizer templates for the /sessions/whoami endpoint. Each key is a template name, and the value configures how JWTs are generated. (see [below for nested schema](#nestedatt--session_tokenizer_templates))
 - `session_whoami_required_aal` (String) Required AAL for session whoami endpoint: 'aal1', 'aal2', or 'highest_available'.

--- a/examples/resources/ory_project_config/resource.tf
+++ b/examples/resources/ory_project_config/resource.tf
@@ -17,9 +17,10 @@ resource "ory_project_config" "secure" {
   cors_admin_origins = ["https://admin.example.com"]
 
   # Sessions
-  session_lifespan          = "168h0m0s" # 7 days
-  session_cookie_same_site  = "Strict"
-  session_cookie_persistent = true
+  session_lifespan                 = "168h0m0s" # 7 days
+  session_earliest_possible_extend = "24h"      # Only extend sessions in the last 24h to avoid excessive writes
+  session_cookie_same_site         = "Strict"
+  session_cookie_persistent        = true
 
   # Password Policy
   selfservice_methods_password_config_min_password_length                 = 12

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/ory/client-go v1.22.42
 	github.com/ory/x v0.0.729
+	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -69,7 +70,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/internal/codegen/mappings.yaml
+++ b/internal/codegen/mappings.yaml
@@ -40,6 +40,15 @@ attributes:
     openapi_property: kratos_session_lifespan
     description: "Session duration (e.g., '24h0m0s')."
 
+  - name: session_earliest_possible_extend
+    go_field: SessionEarliestPossibleExtend
+    type: string
+    patch_path: /services/identity/config/session/earliest_possible_extend
+    description: "Earliest time before session expiry when a session can be extended (e.g., '24h'). Setting this prevents excessive database writes when sessions are extended."
+    validators:
+      regex: "^([0-9]+(ns|us|ms|s|m|h))+$"
+      regex_message: "must be a Go duration string (e.g., '1h', '30m', '24h')"
+
   - name: session_cookie_same_site
     go_field: SessionCookieSameSite
     type: string

--- a/internal/resources/projectconfig/build_patches_test.go
+++ b/internal/resources/projectconfig/build_patches_test.go
@@ -317,6 +317,38 @@ func TestBuildPatches_NullCodeMissingCredentialFallbackEnabled(t *testing.T) {
 	}
 }
 
+func TestBuildPatches_SessionEarliestPossibleExtend(t *testing.T) {
+	r := &ProjectConfigResource{}
+	plan := &ProjectConfigResourceModel{
+		SessionEarliestPossibleExtend: types.StringValue("24h"),
+	}
+
+	patches := r.buildPatches(context.Background(), plan)
+	p := findPatch(patches, "/services/identity/config/session/earliest_possible_extend")
+	if p == nil {
+		t.Fatal("expected a patch for session_earliest_possible_extend, got none")
+	}
+	if p.Op != "replace" {
+		t.Errorf("expected op 'replace', got %q", p.Op)
+	}
+	if p.Value != "24h" {
+		t.Errorf("expected value '24h', got %v", p.Value)
+	}
+}
+
+func TestBuildPatches_NullSessionEarliestPossibleExtend(t *testing.T) {
+	r := &ProjectConfigResource{}
+	plan := &ProjectConfigResourceModel{
+		SessionEarliestPossibleExtend: types.StringNull(),
+	}
+
+	patches := r.buildPatches(context.Background(), plan)
+	p := findPatch(patches, "/services/identity/config/session/earliest_possible_extend")
+	if p != nil {
+		t.Error("expected no patch for null session_earliest_possible_extend")
+	}
+}
+
 func TestBuildPatches_SettingsLifespan(t *testing.T) {
 	r := &ProjectConfigResource{}
 	plan := &ProjectConfigResourceModel{

--- a/internal/resources/projectconfig/build_patches_test.go
+++ b/internal/resources/projectconfig/build_patches_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	ory "github.com/ory/client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func findPatch(patches []ory.JsonPatch, path string) *ory.JsonPatch {
@@ -325,15 +327,9 @@ func TestBuildPatches_SessionEarliestPossibleExtend(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/session/earliest_possible_extend")
-	if p == nil {
-		t.Fatal("expected a patch for session_earliest_possible_extend, got none")
-	}
-	if p.Op != "replace" {
-		t.Errorf("expected op 'replace', got %q", p.Op)
-	}
-	if p.Value != "24h" {
-		t.Errorf("expected value '24h', got %v", p.Value)
-	}
+	require.NotNil(t, p, "expected a patch for session_earliest_possible_extend")
+	assert.Equal(t, "replace", p.Op)
+	assert.Equal(t, "24h", p.Value)
 }
 
 func TestBuildPatches_NullSessionEarliestPossibleExtend(t *testing.T) {
@@ -344,9 +340,7 @@ func TestBuildPatches_NullSessionEarliestPossibleExtend(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/session/earliest_possible_extend")
-	if p != nil {
-		t.Error("expected no patch for null session_earliest_possible_extend")
-	}
+	assert.Nil(t, p, "expected no patch for null session_earliest_possible_extend")
 }
 
 func TestBuildPatches_SettingsLifespan(t *testing.T) {

--- a/internal/resources/projectconfig/patches_gen.go
+++ b/internal/resources/projectconfig/patches_gen.go
@@ -47,6 +47,7 @@ type MapStringPatchEntry struct {
 func simpleStringPatchEntries(plan *ProjectConfigResourceModel) []StringPatchEntry {
 	return []StringPatchEntry{
 		{&plan.SessionLifespan, nil, "/services/identity/config/session/lifespan"},
+		{&plan.SessionEarliestPossibleExtend, nil, "/services/identity/config/session/earliest_possible_extend"},
 		{&plan.SessionCookieSameSite, nil, "/services/identity/config/session/cookie/same_site"},
 		{&plan.SessionWhoamiRequiredAAL, nil, "/services/identity/config/session/whoami/required_aal"},
 		{&plan.OAuth2TTLAccessToken, &plan.OAuth2AccessTokenLifespan, "/services/oauth2/config/ttl/access_token"},

--- a/internal/resources/projectconfig/read_gen.go
+++ b/internal/resources/projectconfig/read_gen.go
@@ -354,6 +354,7 @@ func account_experienceListStringReadEntries(state *ProjectConfigResourceModel) 
 func identityStringReadEntries(state *ProjectConfigResourceModel) []StringReadEntry {
 	return []StringReadEntry{
 		{&state.SessionLifespan, nil, []string{"session", "lifespan"}, false},
+		{&state.SessionEarliestPossibleExtend, nil, []string{"session", "earliest_possible_extend"}, false},
 		{&state.SessionCookieSameSite, nil, []string{"session", "cookie", "same_site"}, false},
 		{&state.SessionWhoamiRequiredAAL, nil, []string{"session", "whoami", "required_aal"}, false},
 		{&state.SelfserviceFlowsLoginUIURL, &state.LoginUIURL, []string{"selfservice", "flows", "login", "ui_url"}, false},

--- a/internal/resources/projectconfig/resource.go
+++ b/internal/resources/projectconfig/resource.go
@@ -55,9 +55,10 @@ type ProjectConfigResourceModel struct {
 	CorsAdminOrigins types.List `tfsdk:"cors_admin_origins"`
 
 	// Session
-	SessionLifespan         types.String `tfsdk:"session_lifespan"`
-	SessionCookieSameSite   types.String `tfsdk:"session_cookie_same_site"`
-	SessionCookiePersistent types.Bool   `tfsdk:"session_cookie_persistent"`
+	SessionLifespan               types.String `tfsdk:"session_lifespan"`
+	SessionEarliestPossibleExtend types.String `tfsdk:"session_earliest_possible_extend"`
+	SessionCookieSameSite         types.String `tfsdk:"session_cookie_same_site"`
+	SessionCookiePersistent       types.Bool   `tfsdk:"session_cookie_persistent"`
 
 	// OAuth2/Hydra
 	OAuth2AccessTokenLifespan             types.String `tfsdk:"oauth2_access_token_lifespan"`

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -143,6 +143,59 @@ func TestAccProjectConfigResource_oauth2IssuerURL(t *testing.T) {
 	})
 }
 
+func TestAccProjectConfigResource_sessionEarliestPossibleExtend(t *testing.T) {
+	createData := map[string]string{
+		"Lifespan":               "720h0m0s",
+		"EarliestPossibleExtend": "24h",
+	}
+	updateData := map[string]string{
+		"Lifespan":               "720h0m0s",
+		"EarliestPossibleExtend": "1h",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/session_extend.tf.tmpl", createData),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_project_config.test", "id"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "session_lifespan", "720h0m0s"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "session_earliest_possible_extend", "24h"),
+				),
+			},
+			// ImportState — import only sets id/project_id; Read only refreshes
+			// fields that are non-null in state, so config attributes won't be
+			// populated until apply.
+			{
+				ResourceName:      "ory_project_config.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"session_lifespan", "session_earliest_possible_extend",
+					"cors_enabled",
+					"selfservice_methods_password_config_min_password_length",
+					"smtp_connection_uri",
+				},
+			},
+			// Update
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/session_extend.tf.tmpl", updateData),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "session_earliest_possible_extend", "1h"),
+				),
+			},
+			// Verify no perpetual diff
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/session_extend.tf.tmpl", updateData),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccProjectConfigResource_mfaPolicy(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccPreCheck(t) },

--- a/internal/resources/projectconfig/schema_gen.go
+++ b/internal/resources/projectconfig/schema_gen.go
@@ -34,6 +34,16 @@ func simpleSchemaAttributes() map[string]schema.Attribute {
 			Description: "Session duration (e.g., '24h0m0s').",
 			Optional:    true,
 		},
+		"session_earliest_possible_extend": schema.StringAttribute{
+			Description: "Earliest time before session expiry when a session can be extended (e.g., '24h'). Setting this prevents excessive database writes when sessions are extended.",
+			Optional:    true,
+			Validators: []validator.String{
+				stringvalidator.RegexMatches(
+					regexp.MustCompile("^([0-9]+(ns|us|ms|s|m|h))+$"),
+					"must be a Go duration string (e.g., '1h', '30m', '24h')",
+				),
+			},
+		},
 		"session_cookie_same_site": schema.StringAttribute{
 			Description: "SameSite cookie attribute (Lax, Strict, None).",
 			Optional:    true,

--- a/internal/resources/projectconfig/testdata/session_extend.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/session_extend.tf.tmpl
@@ -1,0 +1,4 @@
+resource "ory_project_config" "test" {
+  session_lifespan                 = "[[ .Lifespan ]]"
+  session_earliest_possible_extend = "[[ .EarliestPossibleExtend ]]"
+}


### PR DESCRIPTION
## Description

Adds a new `session_earliest_possible_extend` attribute to the `ory_project_config` resource. This exposes the underlying Kratos `session.earliest_possible_extend` setting, which controls how close to expiry a session must be before it can be extended. The Kratos docs strongly recommend setting this to prevent excessive database writes when sessions are extended.

```hcl
resource "ory_project_config" "example" {
  session_lifespan                 = "720h0m0s"
  session_earliest_possible_extend = "24h"
}
```

Implementation notes:

- Added a new entry to `internal/codegen/mappings.yaml`. Since `kratos_session_earliest_possible_extend` is not yet exposed in `normalizedProjectRevision`, the entry uses an explicit `patch_path` (`/services/identity/config/session/earliest_possible_extend`) and a string-duration regex validator.
- Added the `SessionEarliestPossibleExtend` field to `ProjectConfigResourceModel`. The codegen produces the schema, patch, and read entries automatically.
- Updated `examples/resources/ory_project_config/resource.tf` to demonstrate the new attribute.
- Added unit tests for the patch behavior (set + null) and a full CRUD + import + plan-only acceptance test.

## Related Issues

Fixes #231

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

- [x] Unit tests — `TestBuildPatches_SessionEarliestPossibleExtend` and `TestBuildPatches_NullSessionEarliestPossibleExtend` verify the JSON patch is produced with the correct path/op/value, and that no patch is emitted when the field is null.
- [x] Acceptance tests — `TestAccProjectConfigResource_sessionEarliestPossibleExtend` covers create, import, update, and plan-only (no perpetual diff).
- [x] Manual testing — applied a config with `session_earliest_possible_extend = "24h"` against staging, updated it to `"1h"`, ran `terraform plan` (no drift), imported, and destroyed.

## Screenshots/Output

```
# ory_project_config.test will be updated in-place
~ resource "ory_project_config" "test" {
    id                               = "3fa274fe-910d-4766-b1a4-0c0dd3b41429"
  ~ session_earliest_possible_extend = "24h" -> "1h"
    # (3 unchanged attributes hidden)
  }

Plan: 0 to add, 1 to change, 0 to destroy.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `session_earliest_possible_extend` configuration option to project config to control when sessions can be extended before expiration.

* **Documentation**
  * Updated documentation and examples for the new session extension configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/terraform-provider-ory/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->