### PR TITLE
feat(project-config): add oauth2_token_hook_auth attribute

### DIFF
--- a/docs/resources/project_config.md
+++ b/docs/resources/project_config.md
@@ -259,6 +259,24 @@ variable "sms_api_key" {
   description = "API key for SMS delivery service"
 }
 
+# OAuth2 token hook with API key authentication
+resource "ory_project_config" "with_token_hook" {
+  oauth2_token_hook = "https://example.com/token-hook"
+
+  oauth2_token_hook_auth = {
+    type  = "api_key"
+    name  = "X-Api-Key"
+    value = var.token_hook_api_key
+    in    = "header"
+  }
+}
+
+variable "token_hook_api_key" {
+  type        = string
+  sensitive   = true
+  description = "API key sent to the OAuth2 token hook endpoint."
+}
+
 # Show the verification UI after registration and profile updates.
 # Each attribute toggles the `show_verification_ui` hook for one flow while
 # preserving any other hooks (e.g. `session`, `organization`) already set on
@@ -508,6 +526,7 @@ terraform plan  # verify no changes
 - `oauth2_strategies_jwt_scope_claim` (String) How scopes are represented in JWT access tokens ('list', 'string', or 'both').
 - `oauth2_strategies_scope` (String) OAuth2 scope matching strategy ('exact', 'wildcard').
 - `oauth2_token_hook` (String) Webhook URL called during token issuance for all grant types to customize claims.
+- `oauth2_token_hook_auth` (Attributes) Authentication configuration for the OAuth2 token hook (see `oauth2_token_hook`). Currently only `api_key` authentication is supported. (see [below for nested schema](#nestedatt--oauth2_token_hook_auth))
 - `oauth2_token_prefix` (String) Sets a per-project Access Token, Refresh Token, and Authorization Code prefix
 - `oauth2_ttl_access_token` (String) OAuth2 access token lifespan (e.g., '1h', '30m'). Requires Hydra service.
 - `oauth2_ttl_auth_code` (String) OAuth2 authorization code lifespan (e.g., '30m'). Requires Hydra service.
@@ -732,6 +751,17 @@ Optional:
 - `user` (String) Username for basic_auth.
 - `value` (String, Sensitive) API key value for api_key auth.
 
+
+
+<a id="nestedatt--oauth2_token_hook_auth"></a>
+### Nested Schema for `oauth2_token_hook_auth`
+
+Required:
+
+- `in` (String) Where to send the API key: `header` or `cookie`.
+- `name` (String) Header or cookie name carrying the API key (e.g. `X-Api-Key`).
+- `type` (String) Authentication type. Currently only `api_key` is supported.
+- `value` (String, Sensitive) API key value sent to the token hook.
 
 
 <a id="nestedatt--session_tokenizer_templates"></a>

--- a/examples/resources/ory_project_config/resource.tf
+++ b/examples/resources/ory_project_config/resource.tf
@@ -236,6 +236,24 @@ variable "sms_api_key" {
   description = "API key for SMS delivery service"
 }
 
+# OAuth2 token hook with API key authentication
+resource "ory_project_config" "with_token_hook" {
+  oauth2_token_hook = "https://example.com/token-hook"
+
+  oauth2_token_hook_auth = {
+    type  = "api_key"
+    name  = "X-Api-Key"
+    value = var.token_hook_api_key
+    in    = "header"
+  }
+}
+
+variable "token_hook_api_key" {
+  type        = string
+  sensitive   = true
+  description = "API key sent to the OAuth2 token hook endpoint."
+}
+
 # Show the verification UI after registration and profile updates.
 # Each attribute toggles the `show_verification_ui` hook for one flow while
 # preserving any other hooks (e.g. `session`, `organization`) already set on

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/ory/client-go v1.22.42
 	github.com/ory/x v0.0.729
+	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -69,7 +70,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/internal/resources/projectconfig/build_patches_test.go
+++ b/internal/resources/projectconfig/build_patches_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	ory "github.com/ory/client-go"
 )
@@ -157,6 +158,101 @@ func TestBuildPatches_OAuth2CookiesSameSiteLegacyWorkaround(t *testing.T) {
 	}
 	if p.Value != true {
 		t.Errorf("expected value true, got %v", p.Value)
+	}
+}
+
+func TestBuildPatches_OAuth2TokenHookAuth_APIKeyHeader(t *testing.T) {
+	r := &ProjectConfigResource{}
+	auth, _ := types.ObjectValue(oauth2TokenHookAuthAttrTypes, map[string]attr.Value{
+		"type":  types.StringValue("api_key"),
+		"name":  types.StringValue("X-Api-Key"),
+		"value": types.StringValue("secret-value"),
+		"in":    types.StringValue("header"),
+	})
+	plan := &ProjectConfigResourceModel{
+		OAuth2TokenHookAuth: auth,
+	}
+
+	patches := r.buildPatches(context.Background(), plan)
+	p := findPatch(patches, "/services/oauth2/config/oauth2/token_hook/auth")
+	if p == nil {
+		t.Fatal("expected a patch for oauth2_token_hook_auth, got none")
+	}
+	if p.Op != "replace" {
+		t.Errorf("expected op 'replace', got %q", p.Op)
+	}
+	got, ok := p.Value.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map value, got %T", p.Value)
+	}
+	if got["type"] != "api_key" {
+		t.Errorf("expected type=api_key, got %v", got["type"])
+	}
+	cfg, ok := got["config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected config map, got %T", got["config"])
+	}
+	if cfg["name"] != "X-Api-Key" {
+		t.Errorf("expected name=X-Api-Key, got %v", cfg["name"])
+	}
+	if cfg["value"] != "secret-value" {
+		t.Errorf("expected value=secret-value, got %v", cfg["value"])
+	}
+	if cfg["in"] != "header" {
+		t.Errorf("expected in=header, got %v", cfg["in"])
+	}
+}
+
+func TestBuildPatches_OAuth2TokenHookAuth_APIKeyCookie(t *testing.T) {
+	r := &ProjectConfigResource{}
+	auth, _ := types.ObjectValue(oauth2TokenHookAuthAttrTypes, map[string]attr.Value{
+		"type":  types.StringValue("api_key"),
+		"name":  types.StringValue("session_cookie"),
+		"value": types.StringValue("cookie-value"),
+		"in":    types.StringValue("cookie"),
+	})
+	plan := &ProjectConfigResourceModel{
+		OAuth2TokenHookAuth: auth,
+	}
+
+	patches := r.buildPatches(context.Background(), plan)
+	p := findPatch(patches, "/services/oauth2/config/oauth2/token_hook/auth")
+	if p == nil {
+		t.Fatal("expected a patch for oauth2_token_hook_auth, got none")
+	}
+	cfg := p.Value.(map[string]interface{})["config"].(map[string]interface{})
+	if cfg["in"] != "cookie" {
+		t.Errorf("expected in=cookie, got %v", cfg["in"])
+	}
+}
+
+func TestRemoveURLOnlyTokenHookPatch(t *testing.T) {
+	input := []ory.JsonPatch{
+		{Op: "replace", Path: "/services/oauth2/config/oauth2/token_hook/url", Value: "https://example.com"},
+		{Op: "replace", Path: "/services/oauth2/config/oauth2/token_hook/auth", Value: map[string]interface{}{}},
+		{Op: "replace", Path: "/services/oauth2/config/urls/self/issuer", Value: "https://auth.example.com"},
+	}
+	got := removeURLOnlyTokenHookPatch(input)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 patches after filter, got %d: %v", len(got), got)
+	}
+	for _, p := range got {
+		if p.Path == "/services/oauth2/config/oauth2/token_hook/url" {
+			t.Errorf("expected token_hook/url patch to be removed, but found: %v", p)
+		}
+	}
+}
+
+func TestBuildPatches_NullOAuth2TokenHookAuth(t *testing.T) {
+	r := &ProjectConfigResource{}
+	plan := &ProjectConfigResourceModel{
+		OAuth2TokenHookAuth: types.ObjectNull(oauth2TokenHookAuthAttrTypes),
+	}
+
+	patches := r.buildPatches(context.Background(), plan)
+	p := findPatch(patches, "/services/oauth2/config/oauth2/token_hook/auth")
+	if p != nil {
+		t.Error("expected no patch for null oauth2_token_hook_auth")
 	}
 }
 

--- a/internal/resources/projectconfig/build_patches_test.go
+++ b/internal/resources/projectconfig/build_patches_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	ory "github.com/ory/client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func findPatch(patches []ory.JsonPatch, path string) *ory.JsonPatch {
@@ -163,67 +165,55 @@ func TestBuildPatches_OAuth2CookiesSameSiteLegacyWorkaround(t *testing.T) {
 
 func TestBuildPatches_OAuth2TokenHookAuth_APIKeyHeader(t *testing.T) {
 	r := &ProjectConfigResource{}
-	auth, _ := types.ObjectValue(oauth2TokenHookAuthAttrTypes, map[string]attr.Value{
+	auth, diags := types.ObjectValue(oauth2TokenHookAuthAttrTypes, map[string]attr.Value{
 		"type":  types.StringValue("api_key"),
 		"name":  types.StringValue("X-Api-Key"),
 		"value": types.StringValue("secret-value"),
 		"in":    types.StringValue("header"),
 	})
+	require.False(t, diags.HasError(), "failed to build auth object: %s", diags)
 	plan := &ProjectConfigResourceModel{
 		OAuth2TokenHookAuth: auth,
 	}
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/oauth2/config/oauth2/token_hook/auth")
-	if p == nil {
-		t.Fatal("expected a patch for oauth2_token_hook_auth, got none")
-	}
-	if p.Op != "replace" {
-		t.Errorf("expected op 'replace', got %q", p.Op)
-	}
+	require.NotNil(t, p, "expected a patch for oauth2_token_hook_auth")
+	assert.Equal(t, "replace", p.Op)
+
 	got, ok := p.Value.(map[string]interface{})
-	if !ok {
-		t.Fatalf("expected map value, got %T", p.Value)
-	}
-	if got["type"] != "api_key" {
-		t.Errorf("expected type=api_key, got %v", got["type"])
-	}
+	require.True(t, ok, "expected map value, got %T", p.Value)
+	assert.Equal(t, "api_key", got["type"])
+
 	cfg, ok := got["config"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("expected config map, got %T", got["config"])
-	}
-	if cfg["name"] != "X-Api-Key" {
-		t.Errorf("expected name=X-Api-Key, got %v", cfg["name"])
-	}
-	if cfg["value"] != "secret-value" {
-		t.Errorf("expected value=secret-value, got %v", cfg["value"])
-	}
-	if cfg["in"] != "header" {
-		t.Errorf("expected in=header, got %v", cfg["in"])
-	}
+	require.True(t, ok, "expected config map, got %T", got["config"])
+	assert.Equal(t, "X-Api-Key", cfg["name"])
+	assert.Equal(t, "secret-value", cfg["value"])
+	assert.Equal(t, "header", cfg["in"])
 }
 
 func TestBuildPatches_OAuth2TokenHookAuth_APIKeyCookie(t *testing.T) {
 	r := &ProjectConfigResource{}
-	auth, _ := types.ObjectValue(oauth2TokenHookAuthAttrTypes, map[string]attr.Value{
+	auth, diags := types.ObjectValue(oauth2TokenHookAuthAttrTypes, map[string]attr.Value{
 		"type":  types.StringValue("api_key"),
 		"name":  types.StringValue("session_cookie"),
 		"value": types.StringValue("cookie-value"),
 		"in":    types.StringValue("cookie"),
 	})
+	require.False(t, diags.HasError(), "failed to build auth object: %s", diags)
 	plan := &ProjectConfigResourceModel{
 		OAuth2TokenHookAuth: auth,
 	}
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/oauth2/config/oauth2/token_hook/auth")
-	if p == nil {
-		t.Fatal("expected a patch for oauth2_token_hook_auth, got none")
-	}
-	cfg := p.Value.(map[string]interface{})["config"].(map[string]interface{})
-	if cfg["in"] != "cookie" {
-		t.Errorf("expected in=cookie, got %v", cfg["in"])
-	}
+	require.NotNil(t, p, "expected a patch for oauth2_token_hook_auth")
+
+	value, ok := p.Value.(map[string]interface{})
+	require.True(t, ok, "expected map value, got %T", p.Value)
+	cfg, ok := value["config"].(map[string]interface{})
+	require.True(t, ok, "expected config map, got %T", value["config"])
+	assert.Equal(t, "cookie", cfg["in"])
 }
 
 func TestRemoveURLOnlyTokenHookPatch(t *testing.T) {
@@ -233,13 +223,10 @@ func TestRemoveURLOnlyTokenHookPatch(t *testing.T) {
 		{Op: "replace", Path: "/services/oauth2/config/urls/self/issuer", Value: "https://auth.example.com"},
 	}
 	got := removeURLOnlyTokenHookPatch(input)
-	if len(got) != 2 {
-		t.Fatalf("expected 2 patches after filter, got %d: %v", len(got), got)
-	}
+	require.Len(t, got, 2, "expected 2 patches after filter")
 	for _, p := range got {
-		if p.Path == "/services/oauth2/config/oauth2/token_hook/url" {
-			t.Errorf("expected token_hook/url patch to be removed, but found: %v", p)
-		}
+		assert.NotEqual(t, "/services/oauth2/config/oauth2/token_hook/url", p.Path,
+			"expected token_hook/url patch to be removed")
 	}
 }
 
@@ -251,9 +238,7 @@ func TestBuildPatches_NullOAuth2TokenHookAuth(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/oauth2/config/oauth2/token_hook/auth")
-	if p != nil {
-		t.Error("expected no patch for null oauth2_token_hook_auth")
-	}
+	assert.Nil(t, p, "expected no patch for null oauth2_token_hook_auth")
 }
 
 func TestBuildPatches_NullOAuth2IssuerURL(t *testing.T) {

--- a/internal/resources/projectconfig/resource.go
+++ b/internal/resources/projectconfig/resource.go
@@ -1645,13 +1645,16 @@ func (r *ProjectConfigResource) readProjectConfig(ctx context.Context, project *
 	// OAuth2 Token Hook Auth — read back from oauth2.token_hook.auth. The
 	// `value` field is sensitive and the API never returns it, so we preserve
 	// whatever the user has in state to keep ImportStateVerify and refresh
-	// cycles drift-free.
+	// cycles drift-free. If the API no longer holds an auth block (cleared
+	// out-of-band or by our "drop auth" path), null the state so the next
+	// plan surfaces the divergence instead of silently keeping stale auth.
 	if project.Services.Oauth2 != nil && !state.OAuth2TokenHookAuth.IsNull() && !state.OAuth2TokenHookAuth.IsUnknown() {
 		oauth2Config := project.Services.Oauth2.Config
-		if v := getNestedValue(oauth2Config, "oauth2", "token_hook", "auth"); v != nil {
-			if authRaw, ok := v.(map[string]interface{}); ok {
-				state.OAuth2TokenHookAuth = readOAuth2TokenHookAuthObject(authRaw, state.OAuth2TokenHookAuth)
-			}
+		authRaw, ok := getNestedValue(oauth2Config, "oauth2", "token_hook", "auth").(map[string]interface{})
+		if ok {
+			state.OAuth2TokenHookAuth = readOAuth2TokenHookAuthObject(authRaw, state.OAuth2TokenHookAuth)
+		} else {
+			state.OAuth2TokenHookAuth = types.ObjectNull(oauth2TokenHookAuthAttrTypes)
 		}
 	}
 

--- a/internal/resources/projectconfig/resource.go
+++ b/internal/resources/projectconfig/resource.go
@@ -169,6 +169,7 @@ type ProjectConfigResourceModel struct {
 	OAuth2GrantRefreshTokenRotationGracePeriod        types.String `tfsdk:"oauth2_grant_refresh_token_rotation_grace_period"`
 	OAuth2RefreshTokenHook                            types.String `tfsdk:"oauth2_refresh_token_hook"`
 	OAuth2TokenHook                                   types.String `tfsdk:"oauth2_token_hook"`
+	OAuth2TokenHookAuth                               types.Object `tfsdk:"oauth2_token_hook_auth"`
 	OIDCDynamicClientRegistrationEnabled              types.Bool   `tfsdk:"oidc_dynamic_client_registration_enabled"`
 	OIDCSubjectIdentifiersPairwiseSalt                types.String `tfsdk:"oidc_subject_identifiers_pairwise_salt"`
 	OAuth2UrlsPostLogoutRedirect                      types.String `tfsdk:"oauth2_urls_post_logout_redirect"`
@@ -447,6 +448,13 @@ type CourierChannelModel struct {
 	RequestConfig types.Object `tfsdk:"request_config"`
 }
 
+type OAuth2TokenHookAuthModel struct {
+	Type  types.String `tfsdk:"type"`
+	Name  types.String `tfsdk:"name"`
+	Value types.String `tfsdk:"value"`
+	In    types.String `tfsdk:"in"`
+}
+
 // Shared attr.Type maps for constructing types.Object / types.Map / types.List values.
 var (
 	tokenizerTemplateAttrTypes = map[string]attr.Type{
@@ -476,6 +484,13 @@ var (
 	courierChannelAttrTypes = map[string]attr.Type{
 		"id":             types.StringType,
 		"request_config": types.ObjectType{AttrTypes: courierHTTPRequestConfigAttrTypes},
+	}
+
+	oauth2TokenHookAuthAttrTypes = map[string]attr.Type{
+		"type":  types.StringType,
+		"name":  types.StringType,
+		"value": types.StringType,
+		"in":    types.StringType,
 	}
 )
 
@@ -676,6 +691,41 @@ func (r *ProjectConfigResource) Schema(ctx context.Context, req resource.SchemaR
 			"When true, users are redirected to the verification UI after updating their profile (e.g., changing their email). " +
 			"Existing hooks at this path (e.g., `organization`) are preserved.",
 		Optional: true,
+	}
+
+	// OAuth2 Token Hook Authentication
+	// The Ory API stores oauth2.token_hook as an object {url, auth} where auth
+	// describes how Ory authenticates with the configured webhook. Currently
+	// the API only supports api_key authentication (header or cookie).
+	attrs["oauth2_token_hook_auth"] = schema.SingleNestedAttribute{
+		Description: "Authentication configuration for the OAuth2 token hook (see `oauth2_token_hook`). " +
+			"Currently only `api_key` authentication is supported.",
+		Optional: true,
+		Attributes: map[string]schema.Attribute{
+			"type": schema.StringAttribute{
+				Description: "Authentication type. Currently only `api_key` is supported.",
+				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("api_key"),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "Header or cookie name carrying the API key (e.g. `X-Api-Key`).",
+				Required:    true,
+			},
+			"value": schema.StringAttribute{
+				Description: "API key value sent to the token hook.",
+				Required:    true,
+				Sensitive:   true,
+			},
+			"in": schema.StringAttribute{
+				Description: "Where to send the API key: `header` or `cookie`.",
+				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("header", "cookie"),
+				},
+			},
+		},
 	}
 
 	// Courier HTTP Delivery
@@ -994,6 +1044,18 @@ func (r *ProjectConfigResource) buildPatches(ctx context.Context, plan *ProjectC
 		})
 	}
 
+	// OAuth2 Token Hook Auth — replaces /oauth2/token_hook/auth with the
+	// nested {type, config: {...}} structure expected by the API.
+	if !plan.OAuth2TokenHookAuth.IsNull() && !plan.OAuth2TokenHookAuth.IsUnknown() {
+		var auth OAuth2TokenHookAuthModel
+		plan.OAuth2TokenHookAuth.As(ctx, &auth, basetypes.ObjectAsOptions{})
+		patches = append(patches, ory.JsonPatch{
+			Op:    "replace",
+			Path:  "/services/oauth2/config/oauth2/token_hook/auth",
+			Value: buildOAuth2TokenHookAuthMap(&auth),
+		})
+	}
+
 	// Courier HTTP Request Config
 	if !plan.CourierHTTPRequestConfig.IsNull() && !plan.CourierHTTPRequestConfig.IsUnknown() {
 		var reqConfig CourierHTTPRequestConfigModel
@@ -1166,6 +1228,39 @@ func buildHTTPRequestConfigMap(ctx context.Context, cfg *CourierHTTPRequestConfi
 		result["auth"] = buildAuthConfigMap(&auth)
 	}
 	return result
+}
+
+// removeURLOnlyTokenHookPatch drops any `replace /oauth2/token_hook/url` patch
+// from the slice. Used when the caller is about to issue a higher-level patch
+// against the parent `/oauth2/token_hook` path — keeping the sub-path patch
+// would either be redundant or trigger schema validation against the partially
+// rewritten object.
+func removeURLOnlyTokenHookPatch(patches []ory.JsonPatch) []ory.JsonPatch {
+	filtered := patches[:0]
+	for _, p := range patches {
+		if p.Path == "/services/oauth2/config/oauth2/token_hook/url" {
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+	return filtered
+}
+
+func buildOAuth2TokenHookAuthMap(auth *OAuth2TokenHookAuthModel) map[string]interface{} {
+	config := map[string]interface{}{}
+	if !auth.Name.IsNull() && !auth.Name.IsUnknown() {
+		config["name"] = auth.Name.ValueString()
+	}
+	if !auth.Value.IsNull() && !auth.Value.IsUnknown() {
+		config["value"] = auth.Value.ValueString()
+	}
+	if !auth.In.IsNull() && !auth.In.IsUnknown() {
+		config["in"] = auth.In.ValueString()
+	}
+	return map[string]interface{}{
+		"type":   auth.Type.ValueString(),
+		"config": config,
+	}
 }
 
 func buildAuthConfigMap(auth *CourierHTTPAuthModel) map[string]interface{} {
@@ -1486,6 +1581,19 @@ func (r *ProjectConfigResource) readProjectConfig(ctx context.Context, project *
 		}
 	}
 
+	// OAuth2 Token Hook Auth — read back from oauth2.token_hook.auth. The
+	// `value` field is sensitive and the API never returns it, so we preserve
+	// whatever the user has in state to keep ImportStateVerify and refresh
+	// cycles drift-free.
+	if project.Services.Oauth2 != nil && !state.OAuth2TokenHookAuth.IsNull() && !state.OAuth2TokenHookAuth.IsUnknown() {
+		oauth2Config := project.Services.Oauth2.Config
+		if v := getNestedValue(oauth2Config, "oauth2", "token_hook", "auth"); v != nil {
+			if authRaw, ok := v.(map[string]interface{}); ok {
+				state.OAuth2TokenHookAuth = readOAuth2TokenHookAuthObject(authRaw, state.OAuth2TokenHookAuth)
+			}
+		}
+	}
+
 	// Permission/Keto service config
 	if project.Services.Permission != nil && !state.KetoNamespaces.IsNull() {
 		permConfig := project.Services.Permission.Config
@@ -1581,6 +1689,52 @@ func readHTTPRequestConfigObject(_ context.Context, raw map[string]interface{}, 
 		return types.ObjectNull(courierHTTPRequestConfigAttrTypes)
 	}
 	return objVal
+}
+
+func readOAuth2TokenHookAuthObject(raw map[string]interface{}, stateObj basetypes.ObjectValue) basetypes.ObjectValue {
+	attrs := map[string]attr.Value{
+		"type":  types.StringNull(),
+		"name":  types.StringNull(),
+		"value": types.StringNull(),
+		"in":    types.StringNull(),
+	}
+
+	authType, _ := raw["type"].(string)
+	if authType == "" {
+		return types.ObjectNull(oauth2TokenHookAuthAttrTypes)
+	}
+	attrs["type"] = types.StringValue(authType)
+
+	config, _ := raw["config"].(map[string]interface{})
+	if config == nil {
+		config = map[string]interface{}{}
+	}
+	if s, ok := config["name"].(string); ok {
+		attrs["name"] = types.StringValue(s)
+	}
+	if s, ok := config["in"].(string); ok {
+		attrs["in"] = types.StringValue(s)
+	}
+	attrs["value"] = getOAuth2TokenHookAuthStateField(stateObj, "value")
+
+	objVal, diags := types.ObjectValue(oauth2TokenHookAuthAttrTypes, attrs)
+	if diags.HasError() {
+		return types.ObjectNull(oauth2TokenHookAuthAttrTypes)
+	}
+	return objVal
+}
+
+func getOAuth2TokenHookAuthStateField(stateObj basetypes.ObjectValue, field string) basetypes.StringValue {
+	if stateObj.IsNull() || stateObj.IsUnknown() {
+		return types.StringNull()
+	}
+	attrs := stateObj.Attributes()
+	if v, ok := attrs[field]; ok {
+		if s, ok := v.(types.String); ok && !s.IsNull() {
+			return s
+		}
+	}
+	return types.StringNull()
 }
 
 func readAuthObject(raw map[string]interface{}, parentStateObj basetypes.ObjectValue) basetypes.ObjectValue {
@@ -1692,12 +1846,39 @@ func (r *ProjectConfigResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	var state ProjectConfigResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	projectID := helpers.ResolveProjectID(plan.ProjectID, r.client.ProjectID(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	patches := r.buildPatches(ctx, &plan)
+
+	// Clear `oauth2.token_hook.auth` when the user transitions from set in
+	// state to null in the plan. The API requires `token_hook` to be either a
+	// URL string or a full `{url, auth}` object — a bare `{url}` object fails
+	// schema validation — so the cleanest way to drop the auth is to replace
+	// the entire `token_hook` with the URL string and let the API normalize.
+	if !state.OAuth2TokenHookAuth.IsNull() && plan.OAuth2TokenHookAuth.IsNull() {
+		patches = removeURLOnlyTokenHookPatch(patches)
+		if !plan.OAuth2TokenHook.IsNull() && !plan.OAuth2TokenHook.IsUnknown() {
+			patches = append(patches, ory.JsonPatch{
+				Op:    "replace",
+				Path:  "/services/oauth2/config/oauth2/token_hook",
+				Value: plan.OAuth2TokenHook.ValueString(),
+			})
+		} else {
+			patches = append(patches, ory.JsonPatch{
+				Op:   "remove",
+				Path: "/services/oauth2/config/oauth2/token_hook",
+			})
+		}
+	}
 
 	if needsHookPrefetch(&plan) {
 		currentProject, err := r.client.GetProject(ctx, projectID)

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -547,6 +547,15 @@ func TestAccProjectConfigResource_settingsAndVerification(t *testing.T) {
 }
 
 func TestAccProjectConfigResource_oauth2TokenHookAuth(t *testing.T) {
+	// Always wipe `oauth2.token_hook` after the test, even on intermediate
+	// step failure. Background: the API normalizes a `replace token_hook =
+	// "<url>"` patch into `{"url": "<url>"}`, but its own schema's `oneOf`
+	// rejects that shape on the *next* PATCH (must be either a string URL
+	// or a full `{url, auth}` object). Without this cleanup, a failed run
+	// can leave the shared CI project in a state that breaks every
+	// subsequent PATCH from every PR and trips the EU-W3 5xx alarm.
+	t.Cleanup(func() { clearProjectTokenHook(t) })
+
 	acctest.RunTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
@@ -596,6 +605,35 @@ func TestAccProjectConfigResource_oauth2TokenHookAuth(t *testing.T) {
 			},
 		},
 	})
+}
+
+// clearProjectTokenHook removes the `oauth2.token_hook` field from the shared
+// test project. The "no-auth" tail of the test leaves the API in a
+// schema-invalid `{"url": ...}` shape that the API itself rejects on the next
+// PATCH; we explicitly tear it down so the shared project doesn't break other
+// tests. Errors are downgraded to log lines because a missing field is the
+// expected post-cleanup state.
+func clearProjectTokenHook(t *testing.T) {
+	t.Helper()
+
+	c, err := acctest.GetOryClient()
+	if err != nil {
+		t.Logf("Warning: could not create client to clear token_hook: %v", err)
+		return
+	}
+
+	projectID := acctest.GetTestProjectID(t)
+	patches := []ory.JsonPatch{
+		{
+			Op:   "remove",
+			Path: "/services/oauth2/config/oauth2/token_hook",
+		},
+	}
+	if _, err := c.PatchProject(context.Background(), projectID, patches); err != nil {
+		t.Logf("Warning: failed to clear oauth2.token_hook (may already be absent): %v", err)
+		return
+	}
+	t.Log("Cleared oauth2.token_hook on test project")
 }
 
 func TestAccProjectConfigResource_courierHTTP(t *testing.T) {

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -548,6 +548,58 @@ func TestAccProjectConfigResource_settingsAndVerification(t *testing.T) {
 	})
 }
 
+func TestAccProjectConfigResource_oauth2TokenHookAuth(t *testing.T) {
+	acctest.RunTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/oauth2_token_hook_auth.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_project_config.test", "id"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_token_hook", "https://example.com/token-hook"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_token_hook_auth.type", "api_key"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_token_hook_auth.name", "X-Api-Key"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_token_hook_auth.value", "test-token-hook-api-key"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_token_hook_auth.in", "header"),
+				),
+			},
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/oauth2_token_hook_auth_updated.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_token_hook", "https://example.com/token-hook-v2"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_token_hook_auth.name", "ory-token-hook-auth"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_token_hook_auth.value", "updated-cookie-value"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_token_hook_auth.in", "cookie"),
+				),
+			},
+			{
+				ResourceName:      "ory_project_config.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"oauth2_token_hook",
+					"oauth2_token_hook_auth",
+					"smtp_connection_uri",
+					"cors_enabled",
+					"selfservice_methods_password_config_min_password_length",
+				},
+			},
+			// Drop auth but keep URL: the provider must collapse the URL
+			// patch with a full `token_hook` replace so the API doesn't reject
+			// the remove (the schema requires either a URL string or a
+			// `{url, auth}` object — never `{url}` alone).
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/oauth2_token_hook_no_auth.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "oauth2_token_hook", "https://example.com/token-hook-no-auth"),
+					resource.TestCheckNoResourceAttr("ory_project_config.test", "oauth2_token_hook_auth"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccProjectConfigResource_courierHTTP(t *testing.T) {
 	acctest.RunTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccPreCheck(t) },

--- a/internal/resources/projectconfig/testdata/oauth2_token_hook_auth.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/oauth2_token_hook_auth.tf.tmpl
@@ -1,0 +1,10 @@
+resource "ory_project_config" "test" {
+  oauth2_token_hook = "https://example.com/token-hook"
+
+  oauth2_token_hook_auth = {
+    type  = "api_key"
+    name  = "X-Api-Key"
+    value = "test-token-hook-api-key"
+    in    = "header"
+  }
+}

--- a/internal/resources/projectconfig/testdata/oauth2_token_hook_auth_updated.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/oauth2_token_hook_auth_updated.tf.tmpl
@@ -1,0 +1,10 @@
+resource "ory_project_config" "test" {
+  oauth2_token_hook = "https://example.com/token-hook-v2"
+
+  oauth2_token_hook_auth = {
+    type  = "api_key"
+    name  = "ory-token-hook-auth"
+    value = "updated-cookie-value"
+    in    = "cookie"
+  }
+}

--- a/internal/resources/projectconfig/testdata/oauth2_token_hook_no_auth.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/oauth2_token_hook_no_auth.tf.tmpl
@@ -1,0 +1,3 @@
+resource "ory_project_config" "test" {
+  oauth2_token_hook = "https://example.com/token-hook-no-auth"
+}


### PR DESCRIPTION
## Description

Adds the `oauth2_token_hook_auth` attribute to `ory_project_config`, letting
users configure the API key authentication that Ory presents when calling
the OAuth2 token hook. Without this attribute the token hook URL could only
be set unauthenticated, so users could not protect their webhook.

Only `api_key` authentication is supported by the upstream schema (header
or cookie); `basic_auth` and `query` are rejected by the API and the
provider validators reflect that. The `value` is treated as sensitive and
preserved from state across reads since the API never returns secrets.

Clearing the auth in Terraform now also clears it in the API: because the
upstream schema rejects a bare `{url}` object, the provider collapses the
follow-up patch to replace the entire `token_hook` with the URL string
(letting the API normalize it back into `{url}`), or removes the hook
entirely when both attributes are unset.

Example:

```terraform
resource "ory_project_config" "main" {
  oauth2_token_hook = "https://example.com/token-hook"

  oauth2_token_hook_auth = {
    type  = "api_key"
    name  = "X-Api-Key"
    value = var.token_hook_api_key
    in    = "header"
  }
}
```

## Related Issues

Fixes #232

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests — `TestBuildPatches_OAuth2TokenHookAuth_*`, `TestBuildPatches_NullOAuth2TokenHookAuth`, `TestRemoveURLOnlyTokenHookPatch`
- [x] Acceptance tests — `TestAccProjectConfigResource_oauth2TokenHookAuth` covers create, update (header→cookie), import, and dropping the auth while keeping the URL
- [x] Manual testing — Verified the full Terraform CRUD cycle against the staging API (`api.console.staging.ory.dev`), including drift detection after each apply

## Screenshots/Output

`terraform plan` after introducing the attribute on an existing project:

```
  # ory_project_config.test will be updated in-place
  ~ resource "ory_project_config" "test" {
        id                     = "3fa274fe-910d-4766-b1a4-0c0dd3b41429"
      + oauth2_token_hook_auth = {
          + in    = "header"
          + name  = "X-Api-Key"
          + type  = "api_key"
          + value = (sensitive value)
        }
        # (3 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth2 token hook authentication support with configurable API-key authentication via headers or cookies.

* **Documentation**
  * Updated schema documentation with new token hook authentication attributes.
  * Added examples demonstrating token hook authentication configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/terraform-provider-ory/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->