### PR TITLE
test: use testify require/assert for test assertions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -482,6 +482,29 @@ make generate && make build && make format && make test-short && make sec && mak
 - Add meaningful comments for complex logic
 - Use `#nosec` annotations for false positives (with a justification comment)
 
+### Test Assertions
+
+Use [testify](https://github.com/stretchr/testify) (`require` / `assert`) for assertions instead of hand-rolled `if`/`t.Errorf` blocks. This keeps assertions concise, produces consistent failure messages, and makes intent explicit.
+
+- `require.X` aborts the test immediately on failure — use it for setup steps and preconditions where continuing would produce misleading errors (e.g., `require.NoError(t, err)` after creating a client).
+- `assert.X` records the failure but lets the test keep running — use it for independent checks so a single test run surfaces every problem at once.
+
+```go
+import (
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestExample(t *testing.T) {
+    result, err := doSomething()
+    require.NoError(t, err)         // stops the test if setup failed
+    require.NotNil(t, result)       // stops the test if result is nil
+
+    assert.Equal(t, "expected", result.Name)  // records and continues
+    assert.Len(t, result.Items, 3)            // records and continues
+}
+```
+
 ### Commit Messages
 
 Use [Conventional Commits](https://www.conventionalcommits.org/) format:

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/ory/client-go v1.22.42
 	github.com/ory/x v0.0.729
+	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -69,7 +70,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	ory "github.com/ory/client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ory/terraform-provider-ory/internal/testutil"
 )
@@ -23,22 +25,14 @@ func TestNewOryClient_DefaultURLs(t *testing.T) {
 	}
 
 	client, err := NewOryClient(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
-	if client.consoleClient == nil {
-		t.Error("console client should be initialized with workspace API key")
-	}
+	assert.NotNil(t, client.consoleClient, "console client should be initialized with workspace API key")
 
 	// Verify console client servers are configured
 	servers := client.consoleClient.GetConfig().Servers
-	if len(servers) == 0 {
-		t.Error("console client should have servers configured")
-	}
-	if servers[0].URL != DefaultConsoleAPIURL {
-		t.Errorf("expected console URL '%s', got '%s'", DefaultConsoleAPIURL, servers[0].URL)
-	}
+	require.NotEmpty(t, servers, "console client should have servers configured")
+	assert.Equal(t, DefaultConsoleAPIURL, servers[0].URL)
 }
 
 func TestNewOryClient_CustomConsoleURL(t *testing.T) {
@@ -49,24 +43,16 @@ func TestNewOryClient_CustomConsoleURL(t *testing.T) {
 	}
 
 	client, err := NewOryClient(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	servers := client.consoleClient.GetConfig().Servers
-	if servers[0].URL != testutil.ExampleConsoleAPIURL {
-		t.Errorf("expected custom console URL, got '%s'", servers[0].URL)
-	}
+	assert.Equal(t, testutil.ExampleConsoleAPIURL, servers[0].URL)
 
 	// Verify operation servers are also configured with custom URL
 	opServers := client.consoleClient.GetConfig().OperationServers
-	if createProjectServers, ok := opServers["ProjectAPIService.CreateProject"]; ok {
-		if createProjectServers[0].URL != testutil.ExampleConsoleAPIURL {
-			t.Errorf("expected operation server URL to be custom, got '%s'", createProjectServers[0].URL)
-		}
-	} else {
-		t.Error("CreateProject operation server should be configured")
-	}
+	createProjectServers, ok := opServers["ProjectAPIService.CreateProject"]
+	require.True(t, ok, "CreateProject operation server should be configured")
+	assert.Equal(t, testutil.ExampleConsoleAPIURL, createProjectServers[0].URL)
 }
 
 func TestNewOryClient_CustomProjectURL(t *testing.T) {
@@ -78,19 +64,13 @@ func TestNewOryClient_CustomProjectURL(t *testing.T) {
 	}
 
 	client, err := NewOryClient(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
-	if client.projectClient == nil {
-		t.Error("project client should be initialized with project API key and slug")
-	}
+	require.NotNil(t, client.projectClient, "project client should be initialized with project API key and slug")
 
 	servers := client.projectClient.GetConfig().Servers
 	expectedURL := fmt.Sprintf(testutil.ExampleProjectAPIURL, testutil.TestProjectSlug)
-	if servers[0].URL != expectedURL {
-		t.Errorf("expected project URL '%s', got '%s'", expectedURL, servers[0].URL)
-	}
+	assert.Equal(t, expectedURL, servers[0].URL)
 }
 
 func TestNewOryClient_DefaultProjectURL(t *testing.T) {
@@ -101,15 +81,11 @@ func TestNewOryClient_DefaultProjectURL(t *testing.T) {
 	}
 
 	client, err := NewOryClient(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	servers := client.projectClient.GetConfig().Servers
 	expectedURL := fmt.Sprintf(DefaultProjectAPIURL, testutil.TestProjectSlug)
-	if servers[0].URL != expectedURL {
-		t.Errorf("expected default project URL '%s', got '%s'", expectedURL, servers[0].URL)
-	}
+	assert.Equal(t, expectedURL, servers[0].URL)
 }
 
 func TestNewOryClient_NoProjectClientWithoutSlug(t *testing.T) {
@@ -119,13 +95,9 @@ func TestNewOryClient_NoProjectClientWithoutSlug(t *testing.T) {
 	}
 
 	client, err := NewOryClient(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
-	if client.projectClient != nil {
-		t.Error("project client should not be initialized without project slug")
-	}
+	assert.Nil(t, client.projectClient, "project client should not be initialized without project slug")
 }
 
 func TestNewOryClient_NoConsoleClientWithoutWorkspaceKey(t *testing.T) {
@@ -135,13 +107,9 @@ func TestNewOryClient_NoConsoleClientWithoutWorkspaceKey(t *testing.T) {
 	}
 
 	client, err := NewOryClient(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
-	if client.consoleClient != nil {
-		t.Error("console client should not be initialized without workspace API key")
-	}
+	assert.Nil(t, client.consoleClient, "console client should not be initialized without workspace API key")
 }
 
 func TestOryClient_Config(t *testing.T) {
@@ -156,21 +124,13 @@ func TestOryClient_Config(t *testing.T) {
 	}
 
 	client, err := NewOryClient(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Verify config is accessible
 	retrievedCfg := client.Config()
-	if retrievedCfg.WorkspaceAPIKey != cfg.WorkspaceAPIKey {
-		t.Error("WorkspaceAPIKey mismatch")
-	}
-	if retrievedCfg.ConsoleAPIURL != cfg.ConsoleAPIURL {
-		t.Error("ConsoleAPIURL mismatch")
-	}
-	if retrievedCfg.ProjectAPIURL != cfg.ProjectAPIURL {
-		t.Error("ProjectAPIURL mismatch")
-	}
+	assert.Equal(t, cfg.WorkspaceAPIKey, retrievedCfg.WorkspaceAPIKey)
+	assert.Equal(t, cfg.ConsoleAPIURL, retrievedCfg.ConsoleAPIURL)
+	assert.Equal(t, cfg.ProjectAPIURL, retrievedCfg.ProjectAPIURL)
 }
 
 func TestOryClient_ProjectID(t *testing.T) {
@@ -179,13 +139,9 @@ func TestOryClient_ProjectID(t *testing.T) {
 	}
 
 	client, err := NewOryClient(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
-	if client.ProjectID() != "test-project-id" {
-		t.Errorf("expected 'test-project-id', got '%s'", client.ProjectID())
-	}
+	assert.Equal(t, "test-project-id", client.ProjectID())
 }
 
 func TestOryClient_WorkspaceID(t *testing.T) {
@@ -194,20 +150,14 @@ func TestOryClient_WorkspaceID(t *testing.T) {
 	}
 
 	client, err := NewOryClient(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
-	if client.WorkspaceID() != "test-workspace-id" {
-		t.Errorf("expected 'test-workspace-id', got '%s'", client.WorkspaceID())
-	}
+	assert.Equal(t, "test-workspace-id", client.WorkspaceID())
 }
 
 func TestExtractDebugInfo_NilError(t *testing.T) {
 	info := extractDebugInfo(nil)
-	if info.ErrorType != "<nil>" {
-		t.Errorf("expected '<nil>' error type, got '%s'", info.ErrorType)
-	}
+	assert.Equal(t, "<nil>", info.ErrorType)
 }
 
 func TestOryErrorDebugInfo_String(t *testing.T) {
@@ -223,30 +173,13 @@ func TestOryErrorDebugInfo_String(t *testing.T) {
 	}
 
 	str := info.String()
-	if str == "" {
-		t.Error("String() should return non-empty debug info")
-	}
+	require.NotEmpty(t, str, "String() should return non-empty debug info")
 
 	// Check key information is present
 	checks := []string{"TestError", "400", "err-123", "Bad Request", "Invalid input", "req-456", "test-feature"}
 	for _, check := range checks {
-		if !contains(str, check) {
-			t.Errorf("String() should contain '%s'", check)
-		}
+		assert.Contains(t, str, check)
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
-}
-
-func containsHelper(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }
 
 func TestNewOryClient_InvalidConsoleURL(t *testing.T) {
@@ -256,12 +189,8 @@ func TestNewOryClient_InvalidConsoleURL(t *testing.T) {
 	}
 
 	_, err := NewOryClient(cfg)
-	if err == nil {
-		t.Error("expected error for invalid console URL")
-	}
-	if !contains(err.Error(), "invalid console API URL") {
-		t.Errorf("expected error message to contain 'invalid console API URL', got: %s", err.Error())
-	}
+	require.Error(t, err, "expected error for invalid console URL")
+	assert.Contains(t, err.Error(), "invalid console API URL")
 }
 
 func TestNewOryClient_InvalidProjectURL(t *testing.T) {
@@ -272,12 +201,8 @@ func TestNewOryClient_InvalidProjectURL(t *testing.T) {
 	}
 
 	_, err := NewOryClient(cfg)
-	if err == nil {
-		t.Error("expected error for invalid project URL")
-	}
-	if !contains(err.Error(), "invalid project API URL") {
-		t.Errorf("expected error message to contain 'invalid project API URL', got: %s", err.Error())
-	}
+	require.Error(t, err, "expected error for invalid project URL")
+	assert.Contains(t, err.Error(), "invalid project API URL")
 }
 
 func TestIsRateLimitError(t *testing.T) {
@@ -315,10 +240,7 @@ func TestIsRateLimitError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isRateLimitError(tt.err)
-			if result != tt.expected {
-				t.Errorf("isRateLimitError(%v) = %v, want %v", tt.err, result, tt.expected)
-			}
+			assert.Equal(t, tt.expected, isRateLimitError(tt.err))
 		})
 	}
 }
@@ -331,21 +253,13 @@ func TestOryClient_EnsureProjectClient_NilWithoutCredentials(t *testing.T) {
 	}
 
 	client, err := NewOryClient(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
-	if client.projectClient != nil {
-		t.Error("project client should be nil without credentials")
-	}
+	assert.Nil(t, client.projectClient, "project client should be nil without credentials")
 
 	err = client.ensureProjectClient()
-	if err == nil {
-		t.Fatal("expected error from ensureProjectClient without credentials")
-	}
-	if !contains(err.Error(), "project_slug and project_api_key are required") {
-		t.Errorf("unexpected error message: %s", err.Error())
-	}
+	require.Error(t, err, "expected error from ensureProjectClient without credentials")
+	assert.Contains(t, err.Error(), "project_slug and project_api_key are required")
 }
 
 func TestOryClient_EnsureProjectClient_LazyInit(t *testing.T) {
@@ -355,19 +269,13 @@ func TestOryClient_EnsureProjectClient_LazyInit(t *testing.T) {
 	}
 
 	client, err := NewOryClient(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Project client should already be initialized since credentials were provided at creation
-	if client.projectClient == nil {
-		t.Error("project client should be initialized when credentials provided at creation")
-	}
+	assert.NotNil(t, client.projectClient, "project client should be initialized when credentials provided at creation")
 
 	// ensureProjectClient should succeed (client already initialized)
-	if err := client.ensureProjectClient(); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	assert.NoError(t, client.ensureProjectClient())
 }
 
 func TestOryClient_WithProjectCredentials(t *testing.T) {
@@ -378,50 +286,32 @@ func TestOryClient_WithProjectCredentials(t *testing.T) {
 	}
 
 	parent, err := NewOryClient(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Create a child client with project credentials
 	child := parent.WithProjectCredentials(testutil.TestProjectSlug, testutil.TestProjectAPIKey)
 
 	// Parent should still have no project credentials
-	if parent.config.ProjectSlug != "" {
-		t.Error("parent config should not be modified")
-	}
+	assert.Empty(t, parent.config.ProjectSlug, "parent config should not be modified")
 
 	// Child should have the new credentials
-	if child.config.ProjectSlug != testutil.TestProjectSlug {
-		t.Errorf("expected slug '%s', got '%s'", testutil.TestProjectSlug, child.config.ProjectSlug)
-	}
-	if child.config.ProjectAPIKey != testutil.TestProjectAPIKey {
-		t.Errorf("expected API key '%s', got '%s'", testutil.TestProjectAPIKey, child.config.ProjectAPIKey)
-	}
+	assert.Equal(t, testutil.TestProjectSlug, child.config.ProjectSlug)
+	assert.Equal(t, testutil.TestProjectAPIKey, child.config.ProjectAPIKey)
 
 	// Child should share the parent's console client
-	if child.consoleClient != parent.consoleClient {
-		t.Error("child should share the parent's console client")
-	}
+	assert.Same(t, parent.consoleClient, child.consoleClient, "child should share the parent's console client")
 
 	// Child's project client should be lazily initialized
-	if child.projectClient != nil {
-		t.Error("child project client should be nil before first use")
-	}
+	assert.Nil(t, child.projectClient, "child project client should be nil before first use")
 
 	// ensureProjectClient should initialize the child's project client
-	if err := child.ensureProjectClient(); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if child.projectClient == nil {
-		t.Error("child project client should be initialized after ensureProjectClient")
-	}
+	require.NoError(t, child.ensureProjectClient())
+	assert.NotNil(t, child.projectClient, "child project client should be initialized after ensureProjectClient")
 
 	// Verify the child's project client URL
 	servers := child.projectClient.GetConfig().Servers
 	expectedURL := fmt.Sprintf(DefaultProjectAPIURL, testutil.TestProjectSlug)
-	if servers[0].URL != expectedURL {
-		t.Errorf("expected project URL '%s', got '%s'", expectedURL, servers[0].URL)
-	}
+	assert.Equal(t, expectedURL, servers[0].URL)
 }
 
 func TestOryClient_WithProjectCredentials_Isolation(t *testing.T) {
@@ -431,41 +321,29 @@ func TestOryClient_WithProjectCredentials_Isolation(t *testing.T) {
 	}
 
 	parent, err := NewOryClient(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Create two children with different credentials
 	child1 := parent.WithProjectCredentials("slug-one", "key-one")
 	child2 := parent.WithProjectCredentials("slug-two", "key-two")
 
 	// Initialize both
-	if err := child1.ensureProjectClient(); err != nil {
-		t.Fatalf("unexpected error for child1: %v", err)
-	}
-	if err := child2.ensureProjectClient(); err != nil {
-		t.Fatalf("unexpected error for child2: %v", err)
-	}
+	require.NoError(t, child1.ensureProjectClient())
+	require.NoError(t, child2.ensureProjectClient())
 
 	// Verify each child has its own project client with correct URL
 	servers1 := child1.projectClient.GetConfig().Servers
 	expectedURL1 := fmt.Sprintf(DefaultProjectAPIURL, "slug-one")
-	if servers1[0].URL != expectedURL1 {
-		t.Errorf("child1: expected project URL '%s', got '%s'", expectedURL1, servers1[0].URL)
-	}
+	assert.Equal(t, expectedURL1, servers1[0].URL, "child1 project URL")
 
 	servers2 := child2.projectClient.GetConfig().Servers
 	expectedURL2 := fmt.Sprintf(DefaultProjectAPIURL, "slug-two")
-	if servers2[0].URL != expectedURL2 {
-		t.Errorf("child2: expected project URL '%s', got '%s'", expectedURL2, servers2[0].URL)
-	}
+	assert.Equal(t, expectedURL2, servers2[0].URL, "child2 project URL")
 
 	// Parent should still have its original project client
 	parentServers := parent.projectClient.GetConfig().Servers
 	expectedParent := fmt.Sprintf(DefaultProjectAPIURL, testutil.TestProjectSlug)
-	if parentServers[0].URL != expectedParent {
-		t.Errorf("parent: expected project URL '%s', got '%s'", expectedParent, parentServers[0].URL)
-	}
+	assert.Equal(t, expectedParent, parentServers[0].URL, "parent project URL")
 }
 
 func TestOryClient_EnsureProjectClient_MissingSlugOnly(t *testing.T) {
@@ -475,17 +353,11 @@ func TestOryClient_EnsureProjectClient_MissingSlugOnly(t *testing.T) {
 	}
 
 	client, err := NewOryClient(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	err = client.ensureProjectClient()
-	if err == nil {
-		t.Fatal("expected error when slug is missing")
-	}
-	if !contains(err.Error(), "project_slug and project_api_key are required") {
-		t.Errorf("unexpected error message: %s", err.Error())
-	}
+	require.Error(t, err, "expected error when slug is missing")
+	assert.Contains(t, err.Error(), "project_slug and project_api_key are required")
 }
 
 func TestOryClient_EnsureProjectClient_MissingKeyOnly(t *testing.T) {
@@ -495,17 +367,11 @@ func TestOryClient_EnsureProjectClient_MissingKeyOnly(t *testing.T) {
 	}
 
 	client, err := NewOryClient(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	err = client.ensureProjectClient()
-	if err == nil {
-		t.Fatal("expected error when API key is missing")
-	}
-	if !contains(err.Error(), "project_slug and project_api_key are required") {
-		t.Errorf("unexpected error message: %s", err.Error())
-	}
+	require.Error(t, err, "expected error when API key is missing")
+	assert.Contains(t, err.Error(), "project_slug and project_api_key are required")
 }
 
 func TestOryClient_RequireConsoleClient_NilReturnsError(t *testing.T) {
@@ -519,25 +385,17 @@ func TestOryClient_RequireConsoleClient_NilReturnsError(t *testing.T) {
 	}
 
 	client, err := NewOryClient(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
-	if client.consoleClient != nil {
-		t.Fatal("consoleClient should be nil for this test")
-	}
+	require.Nil(t, client.consoleClient, "consoleClient should be nil for this test")
 
 	ctx := context.Background()
 
 	// requireSentinel asserts the error wraps ErrConsoleClientNotConfigured.
 	requireSentinel := func(t *testing.T, err error) {
 		t.Helper()
-		if err == nil {
-			t.Fatal("expected error when consoleClient is nil")
-		}
-		if !errors.Is(err, ErrConsoleClientNotConfigured) {
-			t.Errorf("expected ErrConsoleClientNotConfigured, got: %v", err)
-		}
+		require.Error(t, err, "expected error when consoleClient is nil")
+		assert.ErrorIs(t, err, ErrConsoleClientNotConfigured)
 	}
 
 	// Project operations
@@ -694,10 +552,7 @@ func TestIsRetryableError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isRetryableError(tt.err)
-			if result != tt.expected {
-				t.Errorf("isRetryableError(%v) = %v, want %v", tt.err, result, tt.expected)
-			}
+			assert.Equal(t, tt.expected, isRetryableError(tt.err))
 		})
 	}
 }
@@ -708,7 +563,7 @@ func receiveWithTimeout(t *testing.T, ch <-chan string) string {
 	case v := <-ch:
 		return v
 	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for User-Agent header")
+		require.FailNow(t, "timed out waiting for User-Agent header")
 		return ""
 	}
 }
@@ -730,9 +585,7 @@ func TestProviderUserAgent(t *testing.T) {
 			ProjectAPIKey: "dummy-project-api-key",
 			UserAgent:     expectedUserAgent,
 		})
-		if err != nil {
-			t.Fatalf("Could not set up client: %v", err)
-		}
+		require.NoError(t, err, "Could not set up client")
 
 		_, resp, err := c.ProjectAPI().ProjectAPI.GetProject(context.Background(), "dummy-project-id").Execute()
 		if resp != nil && resp.Body != nil {
@@ -743,9 +596,7 @@ func TestProviderUserAgent(t *testing.T) {
 		}
 
 		got := receiveWithTimeout(t, uaChan)
-		if got != expectedUserAgent {
-			t.Errorf("Expected User-Agent %q, but got %q", expectedUserAgent, got)
-		}
+		assert.Equal(t, expectedUserAgent, got)
 	})
 
 	t.Run("ConsoleAPI", func(t *testing.T) {
@@ -761,9 +612,7 @@ func TestProviderUserAgent(t *testing.T) {
 			WorkspaceAPIKey: "dummy-workspace-api-key",
 			UserAgent:       expectedUserAgent,
 		})
-		if err != nil {
-			t.Fatalf("Could not set up client: %v", err)
-		}
+		require.NoError(t, err, "Could not set up client")
 
 		_, resp, err := c.ConsoleAPI().ProjectAPI.GetProject(context.Background(), "dummy-project-id").Execute()
 		if resp != nil && resp.Body != nil {
@@ -774,9 +623,7 @@ func TestProviderUserAgent(t *testing.T) {
 		}
 
 		got := receiveWithTimeout(t, uaChan)
-		if got != expectedUserAgent {
-			t.Errorf("Expected User-Agent %q, but got %q", expectedUserAgent, got)
-		}
+		assert.Equal(t, expectedUserAgent, got)
 	})
 
 	t.Run("WithProjectCredentials_LazyInit", func(t *testing.T) {
@@ -793,15 +640,11 @@ func TestProviderUserAgent(t *testing.T) {
 			WorkspaceAPIKey: "dummy-workspace-api-key",
 			UserAgent:       expectedUserAgent,
 		})
-		if err != nil {
-			t.Fatalf("Could not set up client: %v", err)
-		}
+		require.NoError(t, err, "Could not set up client")
 
 		child := parent.WithProjectCredentials("child-slug", "child-api-key")
 
-		if err := child.ensureProjectClient(); err != nil {
-			t.Fatalf("ensureProjectClient failed: %v", err)
-		}
+		require.NoError(t, child.ensureProjectClient(), "ensureProjectClient failed")
 
 		_, resp, err := child.ProjectAPI().ProjectAPI.GetProject(context.Background(), "dummy-project-id").Execute()
 		if resp != nil && resp.Body != nil {
@@ -812,9 +655,7 @@ func TestProviderUserAgent(t *testing.T) {
 		}
 
 		got := receiveWithTimeout(t, uaChan)
-		if got != expectedUserAgent {
-			t.Errorf("Expected User-Agent %q, but got %q", expectedUserAgent, got)
-		}
+		assert.Equal(t, expectedUserAgent, got)
 	})
 }
 
@@ -848,9 +689,7 @@ func TestPatchProject_SerialisedPerProject(t *testing.T) {
 			WorkspaceAPIKey: testutil.TestWorkspaceAPIKey,
 			ConsoleAPIURL:   srv.URL,
 		})
-		if err != nil {
-			t.Fatalf("client: %v", err)
-		}
+		require.NoError(t, err)
 
 		var wg sync.WaitGroup
 		for i := 0; i < 5; i++ {
@@ -862,9 +701,7 @@ func TestPatchProject_SerialisedPerProject(t *testing.T) {
 		}
 		wg.Wait()
 
-		if got := atomic.LoadInt32(&maxConcurrent); got != 1 {
-			t.Fatalf("expected max 1 concurrent patch per project, got %d", got)
-		}
+		assert.Equal(t, int32(1), atomic.LoadInt32(&maxConcurrent), "expected max 1 concurrent patch per project")
 	})
 
 	t.Run("different projects run in parallel", func(t *testing.T) {
@@ -889,9 +726,7 @@ func TestPatchProject_SerialisedPerProject(t *testing.T) {
 			WorkspaceAPIKey: testutil.TestWorkspaceAPIKey,
 			ConsoleAPIURL:   srv.URL,
 		})
-		if err != nil {
-			t.Fatalf("client: %v", err)
-		}
+		require.NoError(t, err)
 
 		var wg sync.WaitGroup
 		for i := 0; i < 5; i++ {
@@ -904,8 +739,6 @@ func TestPatchProject_SerialisedPerProject(t *testing.T) {
 		}
 		wg.Wait()
 
-		if got := atomic.LoadInt32(&maxConcurrent); got < 2 {
-			t.Fatalf("expected concurrent patches across different projects, got max %d", got)
-		}
+		assert.GreaterOrEqual(t, atomic.LoadInt32(&maxConcurrent), int32(2), "expected concurrent patches across different projects")
 	})
 }

--- a/internal/client/extract_schemas_test.go
+++ b/internal/client/extract_schemas_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	ory "github.com/ory/client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractSchemasFromProjectConfig(t *testing.T) {
@@ -15,12 +17,8 @@ func TestExtractSchemasFromProjectConfig(t *testing.T) {
 			Services: ory.ProjectServices{},
 		}
 		schemas, err := extractSchemasFromProjectConfig(context.Background(), project)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(schemas) != 0 {
-			t.Fatalf("expected 0 schemas, got %d", len(schemas))
-		}
+		require.NoError(t, err)
+		assert.Empty(t, schemas)
 	})
 
 	t.Run("base64 schema", func(t *testing.T) {
@@ -43,21 +41,11 @@ func TestExtractSchemasFromProjectConfig(t *testing.T) {
 			},
 		}
 		schemas, err := extractSchemasFromProjectConfig(context.Background(), project)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(schemas) != 1 {
-			t.Fatalf("expected 1 schema, got %d", len(schemas))
-		}
-		if schemas[0].GetId() != "test-schema-hash" {
-			t.Errorf("expected id 'test-schema-hash', got %q", schemas[0].GetId())
-		}
-		if schemas[0].Schema == nil {
-			t.Fatal("expected schema content to be decoded, got nil")
-		}
-		if schemas[0].Schema["type"] != "object" {
-			t.Errorf("expected schema type 'object', got %v", schemas[0].Schema["type"])
-		}
+		require.NoError(t, err)
+		require.Len(t, schemas, 1)
+		assert.Equal(t, "test-schema-hash", schemas[0].GetId())
+		require.NotNil(t, schemas[0].Schema, "expected schema content to be decoded")
+		assert.Equal(t, "object", schemas[0].Schema["type"])
 	})
 
 	t.Run("preset schema returns empty object", func(t *testing.T) {
@@ -78,21 +66,11 @@ func TestExtractSchemasFromProjectConfig(t *testing.T) {
 			},
 		}
 		schemas, err := extractSchemasFromProjectConfig(context.Background(), project)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(schemas) != 1 {
-			t.Fatalf("expected 1 schema, got %d", len(schemas))
-		}
-		if schemas[0].GetId() != "preset://username" {
-			t.Errorf("expected id 'preset://username', got %q", schemas[0].GetId())
-		}
-		if schemas[0].Schema == nil {
-			t.Fatal("expected schema to be empty object, got nil")
-		}
-		if len(schemas[0].Schema) != 0 {
-			t.Errorf("expected empty schema object, got %v", schemas[0].Schema)
-		}
+		require.NoError(t, err)
+		require.Len(t, schemas, 1)
+		assert.Equal(t, "preset://username", schemas[0].GetId())
+		require.NotNil(t, schemas[0].Schema, "expected schema to be empty object")
+		assert.Empty(t, schemas[0].Schema)
 	})
 
 	t.Run("invalid base64 returns error", func(t *testing.T) {
@@ -113,9 +91,7 @@ func TestExtractSchemasFromProjectConfig(t *testing.T) {
 			},
 		}
 		_, err := extractSchemasFromProjectConfig(context.Background(), project)
-		if err == nil {
-			t.Fatal("expected error for invalid base64, got nil")
-		}
+		require.Error(t, err, "expected error for invalid base64")
 	})
 
 	t.Run("invalid JSON in base64 returns error", func(t *testing.T) {
@@ -137,9 +113,7 @@ func TestExtractSchemasFromProjectConfig(t *testing.T) {
 			},
 		}
 		_, err := extractSchemasFromProjectConfig(context.Background(), project)
-		if err == nil {
-			t.Fatal("expected error for invalid JSON, got nil")
-		}
+		require.Error(t, err, "expected error for invalid JSON")
 	})
 
 	t.Run("multiple schemas", func(t *testing.T) {
@@ -165,12 +139,8 @@ func TestExtractSchemasFromProjectConfig(t *testing.T) {
 			},
 		}
 		schemas, err := extractSchemasFromProjectConfig(context.Background(), project)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(schemas) != 2 {
-			t.Fatalf("expected 2 schemas, got %d", len(schemas))
-		}
+		require.NoError(t, err)
+		assert.Len(t, schemas, 2)
 	})
 }
 
@@ -210,47 +180,27 @@ func TestExtractSchemasFromProjectConfig_HTTPS(t *testing.T) {
 	}
 
 	schemas, err := extractSchemasFromProjectConfig(context.Background(), project)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(schemas) != 1 {
-		t.Fatalf("expected 1 schema, got %d", len(schemas))
-	}
-	if schemas[0].GetId() != "https-schema-id" {
-		t.Errorf("expected id 'https-schema-id', got %q", schemas[0].GetId())
-	}
-	if schemas[0].Schema == nil {
-		t.Fatal("expected schema content from HTTPS fetch, got nil")
-	}
-	if schemas[0].Schema["type"] != "object" {
-		t.Errorf("expected schema type 'object', got %v", schemas[0].Schema["type"])
-	}
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+	assert.Equal(t, "https-schema-id", schemas[0].GetId())
+	require.NotNil(t, schemas[0].Schema, "expected schema content from HTTPS fetch")
+	assert.Equal(t, "object", schemas[0].Schema["type"])
 	props, ok := schemas[0].Schema["properties"].(map[string]interface{})
-	if !ok {
-		t.Fatal("expected properties map in schema")
-	}
-	if _, hasEmail := props["email"]; !hasEmail {
-		t.Error("expected 'email' property in fetched schema")
-	}
+	require.True(t, ok, "expected properties map in schema")
+	assert.Contains(t, props, "email")
 }
 
 func TestHasProjectClient(t *testing.T) {
 	t.Run("configured", func(t *testing.T) {
 		c := &OryClient{config: OryClientConfig{ProjectSlug: "slug", ProjectAPIKey: "key"}}
-		if !c.HasProjectClient() {
-			t.Error("expected HasProjectClient to return true")
-		}
+		assert.True(t, c.HasProjectClient())
 	})
 	t.Run("missing slug", func(t *testing.T) {
 		c := &OryClient{config: OryClientConfig{ProjectAPIKey: "key"}}
-		if c.HasProjectClient() {
-			t.Error("expected HasProjectClient to return false")
-		}
+		assert.False(t, c.HasProjectClient())
 	})
 	t.Run("missing key", func(t *testing.T) {
 		c := &OryClient{config: OryClientConfig{ProjectSlug: "slug"}}
-		if c.HasProjectClient() {
-			t.Error("expected HasProjectClient to return false")
-		}
+		assert.False(t, c.HasProjectClient())
 	})
 }

--- a/internal/client/fetch_schema_test.go
+++ b/internal/client/fetch_schema_test.go
@@ -6,6 +6,9 @@ import (
 	"net/http/httptest"
 	"net/netip"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFetchSchemaFromURL(t *testing.T) {
@@ -34,12 +37,8 @@ func TestFetchSchemaFromURL(t *testing.T) {
 			_, _ = w.Write([]byte(`{"type":"object","properties":{"name":{"type":"string"}}}`))
 		}, func(t *testing.T, url string) {
 			result, err := fetchSchemaFromURL(context.Background(), url)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if result["type"] != "object" {
-				t.Errorf("expected type=object, got %v", result["type"])
-			}
+			require.NoError(t, err)
+			assert.Equal(t, "object", result["type"])
 		})
 	})
 
@@ -48,9 +47,7 @@ func TestFetchSchemaFromURL(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 		}, func(t *testing.T, url string) {
 			_, err := fetchSchemaFromURL(context.Background(), url)
-			if err == nil {
-				t.Fatal("expected error for non-200 response")
-			}
+			require.Error(t, err, "expected error for non-200 response")
 		})
 	})
 
@@ -59,31 +56,23 @@ func TestFetchSchemaFromURL(t *testing.T) {
 			_, _ = w.Write([]byte(`not json`))
 		}, func(t *testing.T, url string) {
 			_, err := fetchSchemaFromURL(context.Background(), url)
-			if err == nil {
-				t.Fatal("expected error for invalid JSON")
-			}
+			require.Error(t, err, "expected error for invalid JSON")
 		})
 	})
 
 	t.Run("rejects non-HTTPS URL", func(t *testing.T) {
 		_, err := fetchSchemaFromURL(context.Background(), "http://example.com/schema.json")
-		if err == nil {
-			t.Fatal("expected error for non-HTTPS URL")
-		}
+		require.Error(t, err, "expected error for non-HTTPS URL")
 	})
 
 	t.Run("rejects private host IP", func(t *testing.T) {
 		_, err := fetchSchemaFromURL(context.Background(), "https://127.0.0.1/schema.json")
-		if err == nil {
-			t.Fatal("expected error for loopback IP")
-		}
+		require.Error(t, err, "expected error for loopback IP")
 	})
 
 	t.Run("rejects private host 10.x", func(t *testing.T) {
 		_, err := fetchSchemaFromURL(context.Background(), "https://10.0.0.1/schema.json")
-		if err == nil {
-			t.Fatal("expected error for private IP 10.x")
-		}
+		require.Error(t, err, "expected error for private IP 10.x")
 	})
 }
 
@@ -128,9 +117,7 @@ func TestFetchSchemaFromURL_RedirectToPrivateHost(t *testing.T) {
 	schemaFetchClient = c
 
 	_, err := fetchSchemaFromURL(context.Background(), publicSrv.URL+"/schema.json")
-	if err == nil {
-		t.Fatal("expected error when redirect target is a private host")
-	}
+	require.Error(t, err, "expected error when redirect target is a private host")
 }
 
 func TestFetchSchemaFromURL_RedirectToHTTP(t *testing.T) {
@@ -160,9 +147,7 @@ func TestFetchSchemaFromURL_RedirectToHTTP(t *testing.T) {
 	schemaFetchClient = c
 
 	_, err := fetchSchemaFromURL(context.Background(), publicSrv.URL+"/schema.json")
-	if err == nil {
-		t.Fatal("expected error when redirect goes to HTTP")
-	}
+	require.Error(t, err, "expected error when redirect goes to HTTP")
 }
 
 func TestIsPrivateHost(t *testing.T) {
@@ -204,18 +189,11 @@ func TestIsPrivateHost(t *testing.T) {
 		t.Run(tt.host, func(t *testing.T) {
 			got, err := isPrivateHost(context.Background(), tt.host)
 			if tt.wantErr {
-				if err == nil {
-					t.Errorf("isPrivateHost(%q) expected error, got nil", tt.host)
-				}
+				assert.Error(t, err)
 				return
 			}
-			if err != nil {
-				t.Errorf("isPrivateHost(%q) unexpected error: %v", tt.host, err)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("isPrivateHost(%q) = %v, want %v", tt.host, got, tt.want)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -245,13 +223,8 @@ func TestIsPrivateAddr(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.ip, func(t *testing.T) {
 			addr, err := netip.ParseAddr(tt.ip)
-			if err != nil {
-				t.Fatalf("failed to parse %q: %v", tt.ip, err)
-			}
-			got := isPrivateAddr(addr)
-			if got != tt.want {
-				t.Errorf("isPrivateAddr(%q) = %v, want %v", tt.ip, got, tt.want)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, isPrivateAddr(addr))
 		})
 	}
 }
@@ -264,16 +237,12 @@ func TestIsPrivateAddr(t *testing.T) {
 func TestFetchSafeHTTPS(t *testing.T) {
 	t.Run("rejects non-HTTPS scheme", func(t *testing.T) {
 		_, err := FetchSafeHTTPS(context.Background(), "email template", "http://example.com/x.txt")
-		if err == nil {
-			t.Fatal("expected error for http:// URL")
-		}
+		require.Error(t, err, "expected error for http:// URL")
 	})
 
 	t.Run("rejects private host", func(t *testing.T) {
 		_, err := FetchSafeHTTPS(context.Background(), "email template", "https://127.0.0.1/x.txt")
-		if err == nil {
-			t.Fatal("expected error for loopback host")
-		}
+		require.Error(t, err, "expected error for loopback host")
 	})
 
 	t.Run("returns body and caps at MaxBytes", func(t *testing.T) {
@@ -297,11 +266,7 @@ func TestFetchSafeHTTPS(t *testing.T) {
 		}()
 
 		body, err := FetchSafeHTTPS(context.Background(), "email template", srv.URL+"/big.txt")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if int64(len(body)) != FetchSafeHTTPSMaxBytes {
-			t.Fatalf("expected body capped at %d bytes, got %d", FetchSafeHTTPSMaxBytes, len(body))
-		}
+		require.NoError(t, err)
+		assert.Equal(t, int(FetchSafeHTTPSMaxBytes), len(body))
 	})
 }

--- a/internal/codegen/cmd/generate/generate_test.go
+++ b/internal/codegen/cmd/generate/generate_test.go
@@ -5,6 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGovernsToPatchPath(t *testing.T) {
@@ -32,13 +35,10 @@ func TestGovernsToPatchPath(t *testing.T) {
 
 	for _, tt := range tests {
 		path, ok := governsToPatchPath(tt.property, tt.desc)
-		if ok != tt.wantOK {
-			t.Errorf("governsToPatchPath(%q): got ok=%v, want %v", tt.property, ok, tt.wantOK)
+		if !assert.Equal(t, tt.wantOK, ok, "governsToPatchPath(%q): ok", tt.property) {
 			continue
 		}
-		if path != tt.wantPath {
-			t.Errorf("governsToPatchPath(%q): got %q, want %q", tt.property, path, tt.wantPath)
-		}
+		assert.Equal(t, tt.wantPath, path, "governsToPatchPath(%q): path", tt.property)
 	}
 }
 
@@ -57,10 +57,7 @@ func TestCleanDescription(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := cleanDescription(tt.input)
-		if got != tt.want {
-			t.Errorf("cleanDescription(%q):\n  got  %q\n  want %q", tt.input, got, tt.want)
-		}
+		assert.Equal(t, tt.want, cleanDescription(tt.input), "cleanDescription(%q)", tt.input)
 	}
 }
 
@@ -78,10 +75,7 @@ func TestDeriveTerraformName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := deriveTerraformName(tt.openapi)
-		if got != tt.want {
-			t.Errorf("deriveTerraformName(%q): got %q, want %q", tt.openapi, got, tt.want)
-		}
+		assert.Equal(t, tt.want, deriveTerraformName(tt.openapi), "deriveTerraformName(%q)", tt.openapi)
 	}
 }
 
@@ -89,38 +83,23 @@ func TestAppendToMappingsFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "mappings.yaml")
 	original := "attributes:\n  - name: foo\n    go_field: Foo\n    type: bool\n"
-	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
-		t.Fatalf("seed: %v", err)
-	}
-	if err := appendToMappingsFile(path, "\n  - name: bar\n    go_field: Bar\n"); err != nil {
-		t.Fatalf("append: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(original), 0o600), "seed")
+	require.NoError(t, appendToMappingsFile(path, "\n  - name: bar\n    go_field: Bar\n"), "append")
 	got, err := os.ReadFile(path) //nolint:gosec // test file
-	if err != nil {
-		t.Fatalf("read: %v", err)
-	}
+	require.NoError(t, err, "read")
 	want := "attributes:\n  - name: foo\n    go_field: Foo\n    type: bool\n\n  - name: bar\n    go_field: Bar\n"
-	if string(got) != want {
-		t.Errorf("unexpected content:\n--- got ---\n%s\n--- want ---\n%s", got, want)
-	}
+	assert.Equal(t, want, string(got))
 }
 
 func TestAppendToMappingsFileHandlesMissingTrailingNewline(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "mappings.yaml")
-	if err := os.WriteFile(path, []byte("attributes:\n  - name: foo"), 0o600); err != nil {
-		t.Fatalf("seed: %v", err)
-	}
-	if err := appendToMappingsFile(path, "\n  - name: bar\n"); err != nil {
-		t.Fatalf("append: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte("attributes:\n  - name: foo"), 0o600), "seed")
+	require.NoError(t, appendToMappingsFile(path, "\n  - name: bar\n"), "append")
 	got, err := os.ReadFile(path) //nolint:gosec // test file
-	if err != nil {
-		t.Fatalf("read: %v", err)
-	}
-	if !strings.HasPrefix(string(got), "attributes:\n  - name: foo\n\n") {
-		t.Errorf("expected single-newline separator, got %q", got)
-	}
+	require.NoError(t, err, "read")
+	assert.True(t, strings.HasPrefix(string(got), "attributes:\n  - name: foo\n\n"),
+		"expected single-newline separator, got %q", got)
 }
 
 func TestInsertStructFields(t *testing.T) {
@@ -134,40 +113,25 @@ type ProjectConfigResourceModel struct {
 
 func other() {}
 `
-	if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
-		t.Fatalf("seed: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o600), "seed")
 	fields := []string{
 		"\tNewField1 types.Bool `tfsdk:\"new_field_1\"`",
 		"\tNewField2 types.String `tfsdk:\"new_field_2\"`",
 	}
-	if err := insertStructFields(path, "ProjectConfigResourceModel", fields); err != nil {
-		t.Fatalf("insert: %v", err)
-	}
+	require.NoError(t, insertStructFields(path, "ProjectConfigResourceModel", fields), "insert")
 	got, err := os.ReadFile(path) //nolint:gosec // test file
-	if err != nil {
-		t.Fatalf("read: %v", err)
-	}
+	require.NoError(t, err, "read")
 	content := string(got)
-	if !strings.Contains(content, "\tID types.String `tfsdk:\"id\"`\n") {
-		t.Errorf("original field missing: %s", content)
-	}
-	if !strings.Contains(content, "NewField1 types.Bool") || !strings.Contains(content, "NewField2 types.String") {
-		t.Errorf("inserted fields missing: %s", content)
-	}
-	if !strings.Contains(content, "\n}\n\nfunc other()") {
-		t.Errorf("closing brace or trailing content broken: %s", content)
-	}
+	assert.Contains(t, content, "\tID types.String `tfsdk:\"id\"`\n", "original field missing")
+	assert.Contains(t, content, "NewField1 types.Bool", "NewField1 missing")
+	assert.Contains(t, content, "NewField2 types.String", "NewField2 missing")
+	assert.Contains(t, content, "\n}\n\nfunc other()", "closing brace or trailing content broken")
 }
 
 func TestInsertStructFieldsErrorsOnMissingStruct(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "resource.go")
-	if err := os.WriteFile(path, []byte("package foo\n"), 0o600); err != nil {
-		t.Fatalf("seed: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte("package foo\n"), 0o600), "seed")
 	err := insertStructFields(path, "ProjectConfigResourceModel", []string{"\tX types.Bool"})
-	if err == nil {
-		t.Fatal("expected error for missing struct, got nil")
-	}
+	require.Error(t, err, "expected error for missing struct")
 }

--- a/internal/datasources/identityschema/datasource_unit_test.go
+++ b/internal/datasources/identityschema/datasource_unit_test.go
@@ -1,6 +1,10 @@
 package identityschema
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestIsEmptySchemaBody(t *testing.T) {
 	tests := []struct {
@@ -16,9 +20,7 @@ func TestIsEmptySchemaBody(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isEmptySchemaBody(tt.input); got != tt.want {
-				t.Errorf("isEmptySchemaBody(%q) = %v, want %v", string(tt.input), got, tt.want)
-			}
+			assert.Equal(t, tt.want, isEmptySchemaBody(tt.input), "isEmptySchemaBody(%q)", string(tt.input))
 		})
 	}
 }

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -5,98 +5,64 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolveProjectID_PlanValue(t *testing.T) {
 	var diags diag.Diagnostics
 	result := ResolveProjectID(types.StringValue("plan-id"), "client-id", &diags)
-	if diags.HasError() {
-		t.Fatalf("unexpected error: %v", diags.Errors())
-	}
-	if result != "plan-id" {
-		t.Errorf("expected 'plan-id', got '%s'", result)
-	}
+	require.False(t, diags.HasError(), "unexpected diagnostic errors: %v", diags.Errors())
+	assert.Equal(t, "plan-id", result)
 }
 
 func TestResolveProjectID_FallbackToClient(t *testing.T) {
 	var diags diag.Diagnostics
 	result := ResolveProjectID(types.StringValue(""), "client-id", &diags)
-	if diags.HasError() {
-		t.Fatalf("unexpected error: %v", diags.Errors())
-	}
-	if result != "client-id" {
-		t.Errorf("expected 'client-id', got '%s'", result)
-	}
+	require.False(t, diags.HasError(), "unexpected diagnostic errors: %v", diags.Errors())
+	assert.Equal(t, "client-id", result)
 }
 
 func TestResolveProjectID_NullPlanFallbackToClient(t *testing.T) {
 	var diags diag.Diagnostics
 	result := ResolveProjectID(types.StringNull(), "client-id", &diags)
-	if diags.HasError() {
-		t.Fatalf("unexpected error: %v", diags.Errors())
-	}
-	if result != "client-id" {
-		t.Errorf("expected 'client-id', got '%s'", result)
-	}
+	require.False(t, diags.HasError(), "unexpected diagnostic errors: %v", diags.Errors())
+	assert.Equal(t, "client-id", result)
 }
 
 func TestResolveProjectID_BothEmpty(t *testing.T) {
 	var diags diag.Diagnostics
 	result := ResolveProjectID(types.StringValue(""), "", &diags)
-	if !diags.HasError() {
-		t.Fatal("expected error when both plan and client ID are empty")
-	}
-	if result != "" {
-		t.Errorf("expected empty string, got '%s'", result)
-	}
-	if diags.Errors()[0].Summary() != "Missing Project ID" {
-		t.Errorf("expected 'Missing Project ID' error, got '%s'", diags.Errors()[0].Summary())
-	}
+	require.True(t, diags.HasError(), "expected error when both plan and client ID are empty")
+	assert.Empty(t, result)
+	assert.Equal(t, "Missing Project ID", diags.Errors()[0].Summary())
 }
 
 func TestResolveProjectCreds_Valid(t *testing.T) {
 	var diags diag.Diagnostics
 	ok := ResolveProjectCreds("my-slug", "my-key", &diags)
-	if !ok {
-		t.Fatal("expected true for valid credentials")
-	}
-	if diags.HasError() {
-		t.Fatalf("unexpected error: %v", diags.Errors())
-	}
+	require.True(t, ok, "expected true for valid credentials")
+	assert.False(t, diags.HasError(), "unexpected diagnostic errors: %v", diags.Errors())
 }
 
 func TestResolveProjectCreds_MissingSlug(t *testing.T) {
 	var diags diag.Diagnostics
 	ok := ResolveProjectCreds("", "my-key", &diags)
-	if ok {
-		t.Fatal("expected false when slug is empty")
-	}
-	if !diags.HasError() {
-		t.Fatal("expected error when slug is empty")
-	}
-	if diags.Errors()[0].Summary() != "Missing Project Credentials" {
-		t.Errorf("expected 'Missing Project Credentials' error, got '%s'", diags.Errors()[0].Summary())
-	}
+	require.False(t, ok, "expected false when slug is empty")
+	require.True(t, diags.HasError(), "expected error when slug is empty")
+	assert.Equal(t, "Missing Project Credentials", diags.Errors()[0].Summary())
 }
 
 func TestResolveProjectCreds_MissingAPIKey(t *testing.T) {
 	var diags diag.Diagnostics
 	ok := ResolveProjectCreds("my-slug", "", &diags)
-	if ok {
-		t.Fatal("expected false when API key is empty")
-	}
-	if !diags.HasError() {
-		t.Fatal("expected error when API key is empty")
-	}
+	require.False(t, ok, "expected false when API key is empty")
+	assert.True(t, diags.HasError(), "expected error when API key is empty")
 }
 
 func TestResolveProjectCreds_BothEmpty(t *testing.T) {
 	var diags diag.Diagnostics
 	ok := ResolveProjectCreds("", "", &diags)
-	if ok {
-		t.Fatal("expected false when both are empty")
-	}
-	if !diags.HasError() {
-		t.Fatal("expected error when both are empty")
-	}
+	require.False(t, ok, "expected false when both are empty")
+	assert.True(t, diags.HasError(), "expected error when both are empty")
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ory/terraform-provider-ory/internal/testutil"
 )
@@ -14,9 +16,7 @@ import (
 func TestProvider(t *testing.T) {
 	// Verify the provider can be instantiated
 	p := New("test")()
-	if p == nil {
-		t.Fatal("provider should not be nil")
-	}
+	require.NotNil(t, p, "provider should not be nil")
 }
 
 func TestProviderMetadata(t *testing.T) {
@@ -27,12 +27,8 @@ func TestProviderMetadata(t *testing.T) {
 
 	p.Metadata(context.Background(), req, resp)
 
-	if resp.TypeName != "ory" {
-		t.Errorf("expected TypeName 'ory', got '%s'", resp.TypeName)
-	}
-	if resp.Version != "1.0.0" {
-		t.Errorf("expected Version '1.0.0', got '%s'", resp.Version)
-	}
+	assert.Equal(t, "ory", resp.TypeName)
+	assert.Equal(t, "1.0.0", resp.Version)
 }
 
 func TestResolveString(t *testing.T) {
@@ -80,10 +76,7 @@ func TestResolveString(t *testing.T) {
 				defer func() { _ = os.Unsetenv(tt.envVar) }()
 			}
 
-			result := resolveString(tt.tfValue, tt.envVar)
-			if result != tt.expected {
-				t.Errorf("expected '%s', got '%s'", tt.expected, result)
-			}
+			assert.Equal(t, tt.expected, resolveString(tt.tfValue, tt.envVar))
 		})
 	}
 }
@@ -146,10 +139,7 @@ func TestResolveStringDefault(t *testing.T) {
 				defer func() { _ = os.Unsetenv(tt.envVar) }()
 			}
 
-			result := resolveStringDefault(tt.tfValue, tt.envVar, tt.defaultValue)
-			if result != tt.expected {
-				t.Errorf("expected '%s', got '%s'", tt.expected, result)
-			}
+			assert.Equal(t, tt.expected, resolveStringDefault(tt.tfValue, tt.envVar, tt.defaultValue))
 		})
 	}
 }
@@ -168,12 +158,8 @@ func TestProviderModelAttributes(t *testing.T) {
 	}
 
 	// Verify values can be retrieved
-	if model.ConsoleAPIURL.ValueString() != testutil.ExampleConsoleAPIURL {
-		t.Error("ConsoleAPIURL not set correctly")
-	}
-	if model.ProjectAPIURL.ValueString() != testutil.ExampleProjectAPIURL {
-		t.Error("ProjectAPIURL not set correctly")
-	}
+	assert.Equal(t, testutil.ExampleConsoleAPIURL, model.ConsoleAPIURL.ValueString())
+	assert.Equal(t, testutil.ExampleProjectAPIURL, model.ProjectAPIURL.ValueString())
 }
 
 func TestBuildUserAgent(t *testing.T) {
@@ -207,10 +193,7 @@ func TestBuildUserAgent(t *testing.T) {
 				t.Setenv("TF_APPEND_USER_AGENT", "")
 			}
 
-			got := buildUserAgent(tt.tfVersion, tt.providerVersion)
-			if got != tt.expected {
-				t.Errorf("expected %q, got %q", tt.expected, got)
-			}
+			assert.Equal(t, tt.expected, buildUserAgent(tt.tfVersion, tt.providerVersion))
 		})
 	}
 }

--- a/internal/resources/action/validate_config_test.go
+++ b/internal/resources/action/validate_config_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
 )
 
 // buildActionTestConfig creates a ValidateConfigRequest from an ActionResourceModel.
@@ -96,9 +97,7 @@ func TestValidateConfig_NoWebhookAuth(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if resp.Diagnostics.HasError() {
-		t.Errorf("expected no errors when webhook auth is not configured, got: %s", resp.Diagnostics.Errors()[0].Detail())
-	}
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors when webhook auth is not configured: %v", resp.Diagnostics.Errors())
 }
 
 // TestValidateConfig_APIKey_AllKnown_Passes verifies valid api_key config passes.
@@ -118,9 +117,7 @@ func TestValidateConfig_APIKey_AllKnown_Passes(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if resp.Diagnostics.HasError() {
-		t.Errorf("expected no errors for valid api_key config, got: %s", resp.Diagnostics.Errors()[0].Detail())
-	}
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for valid api_key config: %v", resp.Diagnostics.Errors())
 }
 
 // TestValidateConfig_APIKey_MissingValue_Fails verifies that null api_key_value fails.
@@ -140,9 +137,7 @@ func TestValidateConfig_APIKey_MissingValue_Fails(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if !resp.Diagnostics.HasError() {
-		t.Error("expected error for missing webhook_auth_api_key_value, got none")
-	}
+	assert.True(t, resp.Diagnostics.HasError(), "expected error for missing webhook_auth_api_key_value")
 }
 
 // TestValidateConfig_APIKey_UnknownValue_SkipsValidation verifies that an unknown
@@ -163,9 +158,7 @@ func TestValidateConfig_APIKey_UnknownValue_SkipsValidation(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if resp.Diagnostics.HasError() {
-		t.Errorf("expected no errors for unknown webhook_auth_api_key_value, got: %s", resp.Diagnostics.Errors()[0].Detail())
-	}
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for unknown webhook_auth_api_key_value: %v", resp.Diagnostics.Errors())
 }
 
 // TestValidateConfig_APIKey_UnknownName_SkipsValidation verifies that an unknown
@@ -186,9 +179,7 @@ func TestValidateConfig_APIKey_UnknownName_SkipsValidation(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if resp.Diagnostics.HasError() {
-		t.Errorf("expected no errors for unknown webhook_auth_api_key_name, got: %s", resp.Diagnostics.Errors()[0].Detail())
-	}
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for unknown webhook_auth_api_key_name: %v", resp.Diagnostics.Errors())
 }
 
 // TestValidateConfig_APIKey_UnknownIn_SkipsValidation verifies that an unknown
@@ -209,9 +200,7 @@ func TestValidateConfig_APIKey_UnknownIn_SkipsValidation(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if resp.Diagnostics.HasError() {
-		t.Errorf("expected no errors for unknown webhook_auth_api_key_in, got: %s", resp.Diagnostics.Errors()[0].Detail())
-	}
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for unknown webhook_auth_api_key_in: %v", resp.Diagnostics.Errors())
 }
 
 // TestValidateConfig_BasicAuth_AllKnown_Passes verifies valid basic_auth config passes.
@@ -230,9 +219,7 @@ func TestValidateConfig_BasicAuth_AllKnown_Passes(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if resp.Diagnostics.HasError() {
-		t.Errorf("expected no errors for valid basic_auth config, got: %s", resp.Diagnostics.Errors()[0].Detail())
-	}
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for valid basic_auth config: %v", resp.Diagnostics.Errors())
 }
 
 // TestValidateConfig_BasicAuth_MissingPassword_Fails verifies that null password fails.
@@ -251,9 +238,7 @@ func TestValidateConfig_BasicAuth_MissingPassword_Fails(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if !resp.Diagnostics.HasError() {
-		t.Error("expected error for missing webhook_auth_basic_auth_password, got none")
-	}
+	assert.True(t, resp.Diagnostics.HasError(), "expected error for missing webhook_auth_basic_auth_password")
 }
 
 // TestValidateConfig_BasicAuth_UnknownPassword_SkipsValidation verifies that an unknown
@@ -273,9 +258,7 @@ func TestValidateConfig_BasicAuth_UnknownPassword_SkipsValidation(t *testing.T) 
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if resp.Diagnostics.HasError() {
-		t.Errorf("expected no errors for unknown webhook_auth_basic_auth_password, got: %s", resp.Diagnostics.Errors()[0].Detail())
-	}
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for unknown webhook_auth_basic_auth_password: %v", resp.Diagnostics.Errors())
 }
 
 // TestValidateConfig_BasicAuth_UnknownUser_SkipsValidation verifies that an unknown
@@ -295,9 +278,7 @@ func TestValidateConfig_BasicAuth_UnknownUser_SkipsValidation(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if resp.Diagnostics.HasError() {
-		t.Errorf("expected no errors for unknown webhook_auth_basic_auth_user, got: %s", resp.Diagnostics.Errors()[0].Detail())
-	}
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for unknown webhook_auth_basic_auth_user: %v", resp.Diagnostics.Errors())
 }
 
 // TestValidateConfig_APIKey_UnknownValue_NullName_StillFails verifies that when
@@ -319,9 +300,7 @@ func TestValidateConfig_APIKey_UnknownValue_NullName_StillFails(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if !resp.Diagnostics.HasError() {
-		t.Error("expected error for null webhook_auth_api_key_name even when value is unknown, got none")
-	}
+	assert.True(t, resp.Diagnostics.HasError(), "expected error for null webhook_auth_api_key_name even when value is unknown")
 }
 
 // TestValidateConfig_BasicAuth_UnknownPassword_NullUser_StillFails verifies that when
@@ -342,7 +321,5 @@ func TestValidateConfig_BasicAuth_UnknownPassword_NullUser_StillFails(t *testing
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if !resp.Diagnostics.HasError() {
-		t.Error("expected error for null webhook_auth_basic_auth_user even when password is unknown, got none")
-	}
+	assert.True(t, resp.Diagnostics.HasError(), "expected error for null webhook_auth_basic_auth_user even when password is unknown")
 }

--- a/internal/resources/customdomain/resource_test.go
+++ b/internal/resources/customdomain/resource_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ory/terraform-provider-ory/internal/acctest"
 )
@@ -31,9 +32,7 @@ func cleanupStaleCustomDomains(t *testing.T) {
 	t.Helper()
 
 	oryClient, err := acctest.GetOryClient()
-	if err != nil {
-		t.Fatalf("failed to create Ory client for custom domain cleanup: %s", err)
-	}
+	require.NoError(t, err, "failed to create Ory client for custom domain cleanup")
 
 	projectID := acctest.GetTestProjectID(t)
 	ctx := context.Background()
@@ -46,9 +45,8 @@ func cleanupStaleCustomDomains(t *testing.T) {
 
 	for _, d := range domains {
 		t.Logf("cleaning up stale custom domain: id=%s", d.GetId())
-		if err := oryClient.DeleteCustomDomain(ctx, projectID, d.GetId()); err != nil {
-			t.Fatalf("failed to delete stale custom domain %s: %s", d.GetId(), err)
-		}
+		require.NoError(t, oryClient.DeleteCustomDomain(ctx, projectID, d.GetId()),
+			"failed to delete stale custom domain %s", d.GetId())
 	}
 }
 

--- a/internal/resources/emailtemplate/resolve_test.go
+++ b/internal/resources/emailtemplate/resolve_test.go
@@ -6,6 +6,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHashFromURL(t *testing.T) {
@@ -62,12 +65,8 @@ func TestHashFromURL(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, ok := hashFromURL(tc.in)
-			if ok != tc.ok {
-				t.Fatalf("ok mismatch: got %v want %v", ok, tc.ok)
-			}
-			if got != tc.want {
-				t.Fatalf("hash mismatch: got %q want %q", got, tc.want)
-			}
+			require.Equal(t, tc.ok, ok, "ok mismatch")
+			assert.Equal(t, tc.want, got, "hash mismatch")
 		})
 	}
 }
@@ -80,15 +79,9 @@ func TestUrlHashMatchesContent(t *testing.T) {
 	hexHash := hex.EncodeToString(sum[:])
 	url := "https://storage.example.com/templates/" + hexHash + ".txt"
 
-	if !urlHashMatchesContent(url, content) {
-		t.Fatal("expected matching hash for known content")
-	}
-	if urlHashMatchesContent(url, "different content") {
-		t.Fatal("expected mismatch for different content")
-	}
-	if urlHashMatchesContent("not-a-storage-url", content) {
-		t.Fatal("expected mismatch for non-URL input")
-	}
+	assert.True(t, urlHashMatchesContent(url, content), "expected matching hash for known content")
+	assert.False(t, urlHashMatchesContent(url, "different content"), "expected mismatch for different content")
+	assert.False(t, urlHashMatchesContent("not-a-storage-url", content), "expected mismatch for non-URL input")
 }
 
 func TestIsHTTPSURL(t *testing.T) {
@@ -109,9 +102,7 @@ func TestIsHTTPSURL(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.in, func(t *testing.T) {
-			if got := isHTTPSURL(tc.in); got != tc.want {
-				t.Fatalf("isHTTPSURL(%q) = %v, want %v", tc.in, got, tc.want)
-			}
+			assert.Equal(t, tc.want, isHTTPSURL(tc.in))
 		})
 	}
 }
@@ -128,16 +119,12 @@ func TestResolveStoredTemplate(t *testing.T) {
 
 	t.Run("returns decoded base64 literal", func(t *testing.T) {
 		got := resolveStoredTemplate(context.Background(), "base64://SGVsbG8=", "previous")
-		if got != "Hello" {
-			t.Fatalf("got %q want %q", got, "Hello")
-		}
+		assert.Equal(t, "Hello", got)
 	})
 
 	t.Run("returns plain literal as-is", func(t *testing.T) {
 		got := resolveStoredTemplate(context.Background(), "literal value", "previous")
-		if got != "literal value" {
-			t.Fatalf("got %q want %q", got, "literal value")
-		}
+		assert.Equal(t, "literal value", got)
 	})
 
 	t.Run("non-https URL is treated as literal not fetched", func(t *testing.T) {
@@ -145,15 +132,13 @@ func TestResolveStoredTemplate(t *testing.T) {
 		// `isHTTPSURL` returns false so we surface the raw value.
 		origFetcher := urlContentFetcher
 		urlContentFetcher = func(_ context.Context, _ string) (string, error) {
-			t.Fatal("fetcher must not be called for non-HTTPS schemes")
+			require.FailNow(t, "fetcher must not be called for non-HTTPS schemes")
 			return "", nil
 		}
 		defer func() { urlContentFetcher = origFetcher }()
 
 		got := resolveStoredTemplate(context.Background(), "http://example.com/foo", "previous")
-		if got != "http://example.com/foo" {
-			t.Fatalf("got %q want literal http URL", got)
-		}
+		assert.Equal(t, "http://example.com/foo", got, "want literal http URL")
 	})
 
 	t.Run("hash matches state preserves state without fetching", func(t *testing.T) {
@@ -166,12 +151,8 @@ func TestResolveStoredTemplate(t *testing.T) {
 		defer func() { urlContentFetcher = origFetcher }()
 
 		got := resolveStoredTemplate(context.Background(), matchingURL, content)
-		if got != content {
-			t.Fatalf("got %q want %q", got, content)
-		}
-		if fetchCalled {
-			t.Fatal("fetcher should not be called when hash matches state")
-		}
+		assert.Equal(t, content, got)
+		assert.False(t, fetchCalled, "fetcher should not be called when hash matches state")
 	})
 
 	t.Run("hash mismatch fetches and returns body", func(t *testing.T) {
@@ -184,12 +165,8 @@ func TestResolveStoredTemplate(t *testing.T) {
 		defer func() { urlContentFetcher = origFetcher }()
 
 		got := resolveStoredTemplate(context.Background(), driftedURL, content)
-		if got != "OTHER VALUE" {
-			t.Fatalf("got %q want %q", got, "OTHER VALUE")
-		}
-		if fetchedURL != driftedURL {
-			t.Fatalf("fetcher called with %q, want %q", fetchedURL, driftedURL)
-		}
+		assert.Equal(t, "OTHER VALUE", got)
+		assert.Equal(t, driftedURL, fetchedURL, "fetcher should be called with drifted URL")
 	})
 
 	t.Run("fetch failure falls back to state", func(t *testing.T) {
@@ -200,15 +177,11 @@ func TestResolveStoredTemplate(t *testing.T) {
 		defer func() { urlContentFetcher = origFetcher }()
 
 		got := resolveStoredTemplate(context.Background(), driftedURL, content)
-		if got != content {
-			t.Fatalf("on fetch failure expected state %q got %q", content, got)
-		}
+		assert.Equal(t, content, got, "on fetch failure expected state")
 	})
 
 	t.Run("empty api value clears state", func(t *testing.T) {
 		got := resolveStoredTemplate(context.Background(), "", "state value")
-		if got != "" {
-			t.Fatalf("got %q want empty (Console reset must surface as drift)", got)
-		}
+		assert.Empty(t, got, "Console reset must surface as drift")
 	})
 }

--- a/internal/resources/emailtemplate/resource_test.go
+++ b/internal/resources/emailtemplate/resource_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	ory "github.com/ory/client-go"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ory/terraform-provider-ory/internal/acctest"
 )
@@ -115,9 +116,7 @@ func rewriteRecoveryCodeSubjectOutOfBand(t *testing.T, newSubject string) func()
 	t.Helper()
 	return func() {
 		c, err := acctest.GetOryClient()
-		if err != nil {
-			t.Fatalf("Failed to create Ory client: %v", err)
-		}
+		require.NoError(t, err, "Failed to create Ory client")
 		projectID := acctest.GetTestProjectID(t)
 		encoded := "base64://" + base64.StdEncoding.EncodeToString([]byte(newSubject))
 		patches := []ory.JsonPatch{
@@ -127,9 +126,8 @@ func rewriteRecoveryCodeSubjectOutOfBand(t *testing.T, newSubject string) func()
 				Value: encoded,
 			},
 		}
-		if _, err := c.PatchProject(context.Background(), projectID, patches); err != nil {
-			t.Fatalf("Failed to rewrite subject out-of-band: %v", err)
-		}
+		_, err = c.PatchProject(context.Background(), projectID, patches)
+		require.NoError(t, err, "Failed to rewrite subject out-of-band")
 		t.Logf("Rewrote subject out-of-band to %q", newSubject)
 	}
 }

--- a/internal/resources/projectconfig/build_patches_test.go
+++ b/internal/resources/projectconfig/build_patches_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	ory "github.com/ory/client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func findPatch(patches []ory.JsonPatch, path string) *ory.JsonPatch {
@@ -25,12 +27,8 @@ func TestBuildPatches_EmptyDefaultReturnURL(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/default_browser_return_url")
-	if p == nil {
-		t.Fatal("expected a patch for default_browser_return_url, got none")
-	}
-	if p.Op != "remove" {
-		t.Errorf("expected op 'remove' for empty default_return_url, got %q", p.Op)
-	}
+	require.NotNil(t, p, "expected a patch for default_browser_return_url")
+	assert.Equal(t, "remove", p.Op, "expected op 'remove' for empty default_return_url")
 }
 
 func TestBuildPatches_NonEmptyDefaultReturnURL(t *testing.T) {
@@ -41,12 +39,8 @@ func TestBuildPatches_NonEmptyDefaultReturnURL(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/default_browser_return_url")
-	if p == nil {
-		t.Fatal("expected a patch for default_browser_return_url, got none")
-	}
-	if p.Op != "replace" {
-		t.Errorf("expected op 'replace' for non-empty default_return_url, got %q", p.Op)
-	}
+	require.NotNil(t, p, "expected a patch for default_browser_return_url")
+	assert.Equal(t, "replace", p.Op, "expected op 'replace' for non-empty default_return_url")
 }
 
 func TestBuildPatches_NullDefaultReturnURL(t *testing.T) {
@@ -57,9 +51,7 @@ func TestBuildPatches_NullDefaultReturnURL(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/default_browser_return_url")
-	if p != nil {
-		t.Error("expected no patch for null default_return_url")
-	}
+	assert.Nil(t, p, "expected no patch for null default_return_url")
 }
 
 func TestBuildPatches_EmptyAllowedReturnURLs(t *testing.T) {
@@ -71,12 +63,8 @@ func TestBuildPatches_EmptyAllowedReturnURLs(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/allowed_return_urls")
-	if p == nil {
-		t.Fatal("expected a patch for allowed_return_urls, got none")
-	}
-	if p.Op != "remove" {
-		t.Errorf("expected op 'remove' for empty allowed_return_urls, got %q", p.Op)
-	}
+	require.NotNil(t, p, "expected a patch for allowed_return_urls")
+	assert.Equal(t, "remove", p.Op, "expected op 'remove' for empty allowed_return_urls")
 }
 
 func TestBuildPatches_NonEmptyAllowedReturnURLs(t *testing.T) {
@@ -88,12 +76,8 @@ func TestBuildPatches_NonEmptyAllowedReturnURLs(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/allowed_return_urls")
-	if p == nil {
-		t.Fatal("expected a patch for allowed_return_urls, got none")
-	}
-	if p.Op != "replace" {
-		t.Errorf("expected op 'replace' for non-empty allowed_return_urls, got %q", p.Op)
-	}
+	require.NotNil(t, p, "expected a patch for allowed_return_urls")
+	assert.Equal(t, "replace", p.Op, "expected op 'replace' for non-empty allowed_return_urls")
 }
 
 func TestBuildPatches_NullAllowedReturnURLs(t *testing.T) {
@@ -104,9 +88,7 @@ func TestBuildPatches_NullAllowedReturnURLs(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/allowed_return_urls")
-	if p != nil {
-		t.Error("expected no patch for null allowed_return_urls")
-	}
+	assert.Nil(t, p, "expected no patch for null allowed_return_urls")
 }
 
 func TestBuildPatches_OAuth2IssuerURL(t *testing.T) {
@@ -117,15 +99,9 @@ func TestBuildPatches_OAuth2IssuerURL(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/oauth2/config/urls/self/issuer")
-	if p == nil {
-		t.Fatal("expected a patch for oauth2_issuer_url, got none")
-	}
-	if p.Op != "replace" {
-		t.Errorf("expected op 'replace', got %q", p.Op)
-	}
-	if p.Value != "https://auth.example.com" {
-		t.Errorf("expected value 'https://auth.example.com', got %v", p.Value)
-	}
+	require.NotNil(t, p, "expected a patch for oauth2_issuer_url")
+	assert.Equal(t, "replace", p.Op)
+	assert.Equal(t, "https://auth.example.com", p.Value)
 }
 
 func TestBuildPatches_OAuth2CookiesSameSiteMode(t *testing.T) {
@@ -136,12 +112,8 @@ func TestBuildPatches_OAuth2CookiesSameSiteMode(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/oauth2/config/serve/cookies/same_site_mode")
-	if p == nil {
-		t.Fatal("expected a patch for oauth2_cookies_same_site_mode, got none")
-	}
-	if p.Value != "Strict" {
-		t.Errorf("expected value 'Strict', got %v", p.Value)
-	}
+	require.NotNil(t, p, "expected a patch for oauth2_cookies_same_site_mode")
+	assert.Equal(t, "Strict", p.Value)
 }
 
 func TestBuildPatches_OAuth2CookiesSameSiteLegacyWorkaround(t *testing.T) {
@@ -152,12 +124,8 @@ func TestBuildPatches_OAuth2CookiesSameSiteLegacyWorkaround(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/oauth2/config/serve/cookies/same_site_legacy_workaround")
-	if p == nil {
-		t.Fatal("expected a patch for oauth2_cookies_same_site_legacy_workaround, got none")
-	}
-	if p.Value != true {
-		t.Errorf("expected value true, got %v", p.Value)
-	}
+	require.NotNil(t, p, "expected a patch for oauth2_cookies_same_site_legacy_workaround")
+	assert.Equal(t, true, p.Value)
 }
 
 func TestBuildPatches_NullOAuth2IssuerURL(t *testing.T) {
@@ -168,9 +136,7 @@ func TestBuildPatches_NullOAuth2IssuerURL(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/oauth2/config/urls/self/issuer")
-	if p != nil {
-		t.Error("expected no patch for null oauth2_issuer_url")
-	}
+	assert.Nil(t, p, "expected no patch for null oauth2_issuer_url")
 }
 
 func TestBuildPatches_LoginStyle(t *testing.T) {
@@ -181,15 +147,9 @@ func TestBuildPatches_LoginStyle(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/flows/login/style")
-	if p == nil {
-		t.Fatal("expected a patch for login_style, got none")
-	}
-	if p.Op != "replace" {
-		t.Errorf("expected op 'replace', got %q", p.Op)
-	}
-	if p.Value != "identifier_first" {
-		t.Errorf("expected value 'identifier_first', got %v", p.Value)
-	}
+	require.NotNil(t, p, "expected a patch for login_style")
+	assert.Equal(t, "replace", p.Op)
+	assert.Equal(t, "identifier_first", p.Value)
 }
 
 func TestBuildPatches_LoginStyleUnified(t *testing.T) {
@@ -200,12 +160,8 @@ func TestBuildPatches_LoginStyleUnified(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/flows/login/style")
-	if p == nil {
-		t.Fatal("expected a patch for login_style, got none")
-	}
-	if p.Value != "unified" {
-		t.Errorf("expected value 'unified', got %v", p.Value)
-	}
+	require.NotNil(t, p, "expected a patch for login_style")
+	assert.Equal(t, "unified", p.Value)
 }
 
 func TestBuildPatches_NullLoginStyle(t *testing.T) {
@@ -216,9 +172,7 @@ func TestBuildPatches_NullLoginStyle(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/flows/login/style")
-	if p != nil {
-		t.Error("expected no patch for null login_style")
-	}
+	assert.Nil(t, p, "expected no patch for null login_style")
 }
 
 func TestBuildPatches_EnableProfile(t *testing.T) {
@@ -229,15 +183,9 @@ func TestBuildPatches_EnableProfile(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/methods/profile/enabled")
-	if p == nil {
-		t.Fatal("expected a patch for enable_profile, got none")
-	}
-	if p.Op != "replace" {
-		t.Errorf("expected op 'replace', got %q", p.Op)
-	}
-	if p.Value != true {
-		t.Errorf("expected value true, got %v", p.Value)
-	}
+	require.NotNil(t, p, "expected a patch for enable_profile")
+	assert.Equal(t, "replace", p.Op)
+	assert.Equal(t, true, p.Value)
 }
 
 func TestBuildPatches_NullEnableProfile(t *testing.T) {
@@ -248,9 +196,7 @@ func TestBuildPatches_NullEnableProfile(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/methods/profile/enabled")
-	if p != nil {
-		t.Error("expected no patch for null enable_profile")
-	}
+	assert.Nil(t, p, "expected no patch for null enable_profile")
 }
 
 func TestBuildPatches_CodeLifespan(t *testing.T) {
@@ -261,15 +207,9 @@ func TestBuildPatches_CodeLifespan(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/methods/code/config/lifespan")
-	if p == nil {
-		t.Fatal("expected a patch for code_lifespan, got none")
-	}
-	if p.Op != "replace" {
-		t.Errorf("expected op 'replace', got %q", p.Op)
-	}
-	if p.Value != "15m0s" {
-		t.Errorf("expected value '15m0s', got %v", p.Value)
-	}
+	require.NotNil(t, p, "expected a patch for code_lifespan")
+	assert.Equal(t, "replace", p.Op)
+	assert.Equal(t, "15m0s", p.Value)
 }
 
 func TestBuildPatches_NullCodeLifespan(t *testing.T) {
@@ -280,9 +220,7 @@ func TestBuildPatches_NullCodeLifespan(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/methods/code/config/lifespan")
-	if p != nil {
-		t.Error("expected no patch for null code_lifespan")
-	}
+	assert.Nil(t, p, "expected no patch for null code_lifespan")
 }
 
 func TestBuildPatches_CodeMissingCredentialFallbackEnabled(t *testing.T) {
@@ -293,15 +231,9 @@ func TestBuildPatches_CodeMissingCredentialFallbackEnabled(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/methods/code/config/missing_credential_fallback_enabled")
-	if p == nil {
-		t.Fatal("expected a patch for code_missing_credential_fallback_enabled, got none")
-	}
-	if p.Op != "replace" {
-		t.Errorf("expected op 'replace', got %q", p.Op)
-	}
-	if p.Value != true {
-		t.Errorf("expected value true, got %v", p.Value)
-	}
+	require.NotNil(t, p, "expected a patch for code_missing_credential_fallback_enabled")
+	assert.Equal(t, "replace", p.Op)
+	assert.Equal(t, true, p.Value)
 }
 
 func TestBuildPatches_NullCodeMissingCredentialFallbackEnabled(t *testing.T) {
@@ -312,9 +244,7 @@ func TestBuildPatches_NullCodeMissingCredentialFallbackEnabled(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/methods/code/config/missing_credential_fallback_enabled")
-	if p != nil {
-		t.Error("expected no patch for null code_missing_credential_fallback_enabled")
-	}
+	assert.Nil(t, p, "expected no patch for null code_missing_credential_fallback_enabled")
 }
 
 func TestBuildPatches_SettingsLifespan(t *testing.T) {
@@ -325,15 +255,9 @@ func TestBuildPatches_SettingsLifespan(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/flows/settings/lifespan")
-	if p == nil {
-		t.Fatal("expected a patch for settings_lifespan, got none")
-	}
-	if p.Op != "replace" {
-		t.Errorf("expected op 'replace', got %q", p.Op)
-	}
-	if p.Value != "30m0s" {
-		t.Errorf("expected value '30m0s', got %v", p.Value)
-	}
+	require.NotNil(t, p, "expected a patch for settings_lifespan")
+	assert.Equal(t, "replace", p.Op)
+	assert.Equal(t, "30m0s", p.Value)
 }
 
 func TestBuildPatches_NullSettingsLifespan(t *testing.T) {
@@ -344,9 +268,7 @@ func TestBuildPatches_NullSettingsLifespan(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/flows/settings/lifespan")
-	if p != nil {
-		t.Error("expected no patch for null settings_lifespan")
-	}
+	assert.Nil(t, p, "expected no patch for null settings_lifespan")
 }
 
 func TestBuildPatches_SettingsPrivilegedSessionMaxAge(t *testing.T) {
@@ -357,15 +279,9 @@ func TestBuildPatches_SettingsPrivilegedSessionMaxAge(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/flows/settings/privileged_session_max_age")
-	if p == nil {
-		t.Fatal("expected a patch for settings_privileged_session_max_age, got none")
-	}
-	if p.Op != "replace" {
-		t.Errorf("expected op 'replace', got %q", p.Op)
-	}
-	if p.Value != "15m0s" {
-		t.Errorf("expected value '15m0s', got %v", p.Value)
-	}
+	require.NotNil(t, p, "expected a patch for settings_privileged_session_max_age")
+	assert.Equal(t, "replace", p.Op)
+	assert.Equal(t, "15m0s", p.Value)
 }
 
 func TestBuildPatches_NullSettingsPrivilegedSessionMaxAge(t *testing.T) {
@@ -376,9 +292,7 @@ func TestBuildPatches_NullSettingsPrivilegedSessionMaxAge(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/flows/settings/privileged_session_max_age")
-	if p != nil {
-		t.Error("expected no patch for null settings_privileged_session_max_age")
-	}
+	assert.Nil(t, p, "expected no patch for null settings_privileged_session_max_age")
 }
 
 func TestBuildPatches_VerificationUse(t *testing.T) {
@@ -389,15 +303,9 @@ func TestBuildPatches_VerificationUse(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/flows/verification/use")
-	if p == nil {
-		t.Fatal("expected a patch for verification_use, got none")
-	}
-	if p.Op != "replace" {
-		t.Errorf("expected op 'replace', got %q", p.Op)
-	}
-	if p.Value != "code" {
-		t.Errorf("expected value 'code', got %v", p.Value)
-	}
+	require.NotNil(t, p, "expected a patch for verification_use")
+	assert.Equal(t, "replace", p.Op)
+	assert.Equal(t, "code", p.Value)
 }
 
 func TestBuildPatches_NullVerificationUse(t *testing.T) {
@@ -408,9 +316,7 @@ func TestBuildPatches_NullVerificationUse(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/flows/verification/use")
-	if p != nil {
-		t.Error("expected no patch for null verification_use")
-	}
+	assert.Nil(t, p, "expected no patch for null verification_use")
 }
 
 func TestBuildPatches_VerificationLifespan(t *testing.T) {
@@ -421,15 +327,9 @@ func TestBuildPatches_VerificationLifespan(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/flows/verification/lifespan")
-	if p == nil {
-		t.Fatal("expected a patch for verification_lifespan, got none")
-	}
-	if p.Op != "replace" {
-		t.Errorf("expected op 'replace', got %q", p.Op)
-	}
-	if p.Value != "30m0s" {
-		t.Errorf("expected value '30m0s', got %v", p.Value)
-	}
+	require.NotNil(t, p, "expected a patch for verification_lifespan")
+	assert.Equal(t, "replace", p.Op)
+	assert.Equal(t, "30m0s", p.Value)
 }
 
 func TestBuildPatches_NullVerificationLifespan(t *testing.T) {
@@ -440,9 +340,7 @@ func TestBuildPatches_NullVerificationLifespan(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/flows/verification/lifespan")
-	if p != nil {
-		t.Error("expected no patch for null verification_lifespan")
-	}
+	assert.Nil(t, p, "expected no patch for null verification_lifespan")
 }
 
 func TestBuildPatches_VerificationNotifyUnknownRecipients(t *testing.T) {
@@ -453,15 +351,9 @@ func TestBuildPatches_VerificationNotifyUnknownRecipients(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/flows/verification/notify_unknown_recipients")
-	if p == nil {
-		t.Fatal("expected a patch for verification_notify_unknown_recipients, got none")
-	}
-	if p.Op != "replace" {
-		t.Errorf("expected op 'replace', got %q", p.Op)
-	}
-	if p.Value != true {
-		t.Errorf("expected value true, got %v", p.Value)
-	}
+	require.NotNil(t, p, "expected a patch for verification_notify_unknown_recipients")
+	assert.Equal(t, "replace", p.Op)
+	assert.Equal(t, true, p.Value)
 }
 
 func TestBuildPatches_NullVerificationNotifyUnknownRecipients(t *testing.T) {
@@ -472,9 +364,7 @@ func TestBuildPatches_NullVerificationNotifyUnknownRecipients(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/flows/verification/notify_unknown_recipients")
-	if p != nil {
-		t.Error("expected no patch for null verification_notify_unknown_recipients")
-	}
+	assert.Nil(t, p, "expected no patch for null verification_notify_unknown_recipients")
 }
 
 // projectWithIdentityConfig wraps an identity config map in the *ory.Project
@@ -510,29 +400,15 @@ func TestBuildShowVerificationUIHookPatches_AddPreservesOtherHooks(t *testing.T)
 	})
 
 	patches := buildShowVerificationUIHookPatches(plan, current)
-	if len(patches) != 1 {
-		t.Fatalf("expected 1 patch, got %d", len(patches))
-	}
+	require.Len(t, patches, 1)
 	p := patches[0]
-	if p.Op != "replace" {
-		t.Errorf("expected op 'replace', got %q", p.Op)
-	}
-	if p.Path != "/services/identity/config/selfservice/flows/registration/after/password/hooks" {
-		t.Errorf("unexpected patch path: %s", p.Path)
-	}
+	assert.Equal(t, "replace", p.Op)
+	assert.Equal(t, "/services/identity/config/selfservice/flows/registration/after/password/hooks", p.Path)
 	hooks, ok := p.Value.([]map[string]interface{})
-	if !ok {
-		t.Fatalf("expected []map[string]interface{} value, got %T", p.Value)
-	}
-	if len(hooks) != 2 {
-		t.Fatalf("expected 2 hooks (show_verification_ui + organization), got %d", len(hooks))
-	}
-	if hooks[0]["hook"] != "show_verification_ui" {
-		t.Errorf("expected show_verification_ui first, got %v", hooks[0]["hook"])
-	}
-	if hooks[1]["hook"] != "organization" {
-		t.Errorf("expected organization preserved, got %v", hooks[1]["hook"])
-	}
+	require.True(t, ok, "expected []map[string]interface{} value, got %T", p.Value)
+	require.Len(t, hooks, 2, "expected 2 hooks (show_verification_ui + organization)")
+	assert.Equal(t, "show_verification_ui", hooks[0]["hook"], "expected show_verification_ui first")
+	assert.Equal(t, "organization", hooks[1]["hook"], "expected organization preserved")
 }
 
 func TestBuildShowVerificationUIHookPatches_RemoveKeepsOthers(t *testing.T) {
@@ -557,19 +433,11 @@ func TestBuildShowVerificationUIHookPatches_RemoveKeepsOthers(t *testing.T) {
 	})
 
 	patches := buildShowVerificationUIHookPatches(plan, current)
-	if len(patches) != 1 {
-		t.Fatalf("expected 1 patch, got %d", len(patches))
-	}
+	require.Len(t, patches, 1)
 	hooks, ok := patches[0].Value.([]map[string]interface{})
-	if !ok {
-		t.Fatalf("expected []map[string]interface{} value, got %T", patches[0].Value)
-	}
-	if len(hooks) != 1 {
-		t.Fatalf("expected 1 remaining hook, got %d", len(hooks))
-	}
-	if hooks[0]["hook"] != "organization" {
-		t.Errorf("expected organization to remain, got %v", hooks[0]["hook"])
-	}
+	require.True(t, ok, "expected []map[string]interface{} value, got %T", patches[0].Value)
+	require.Len(t, hooks, 1, "expected 1 remaining hook")
+	assert.Equal(t, "organization", hooks[0]["hook"], "expected organization to remain")
 }
 
 func TestBuildShowVerificationUIHookPatches_AddIdempotent(t *testing.T) {
@@ -595,21 +463,15 @@ func TestBuildShowVerificationUIHookPatches_AddIdempotent(t *testing.T) {
 
 	patches := buildShowVerificationUIHookPatches(plan, current)
 	hooks, _ := patches[0].Value.([]map[string]interface{})
-	if len(hooks) != 2 {
-		t.Fatalf("expected 2 hooks (no duplicate), got %d: %v", len(hooks), hooks)
-	}
+	require.Len(t, hooks, 2, "expected 2 hooks (no duplicate): %v", hooks)
 	seen := map[string]int{}
 	for _, h := range hooks {
 		if name, ok := h["hook"].(string); ok {
 			seen[name]++
 		}
 	}
-	if seen["show_verification_ui"] != 1 {
-		t.Errorf("expected exactly one show_verification_ui, got %d", seen["show_verification_ui"])
-	}
-	if seen["session"] != 1 {
-		t.Errorf("expected session preserved, got %d", seen["session"])
-	}
+	assert.Equal(t, 1, seen["show_verification_ui"], "expected exactly one show_verification_ui")
+	assert.Equal(t, 1, seen["session"], "expected session preserved")
 }
 
 func TestBuildShowVerificationUIHookPatches_NullSkipped(t *testing.T) {
@@ -617,9 +479,7 @@ func TestBuildShowVerificationUIHookPatches_NullSkipped(t *testing.T) {
 	current := projectWithIdentityConfig(map[string]interface{}{})
 
 	patches := buildShowVerificationUIHookPatches(plan, current)
-	if len(patches) != 0 {
-		t.Errorf("expected no patches when all hook attrs are null, got %d", len(patches))
-	}
+	assert.Empty(t, patches, "expected no patches when all hook attrs are null")
 }
 
 func TestBuildShowVerificationUIHookPatches_NilCurrentProject(t *testing.T) {
@@ -627,9 +487,7 @@ func TestBuildShowVerificationUIHookPatches_NilCurrentProject(t *testing.T) {
 		SelfserviceFlowsRegistrationAfterPasswordHookShowVerificationUI: types.BoolValue(true),
 	}
 	patches := buildShowVerificationUIHookPatches(plan, nil)
-	if len(patches) != 0 {
-		t.Errorf("expected no patches when currentProject is nil, got %d", len(patches))
-	}
+	assert.Empty(t, patches, "expected no patches when currentProject is nil")
 }
 
 func TestBuildShowVerificationUIHookPatches_MissingHooksPathIsEmptyArray(t *testing.T) {
@@ -639,16 +497,11 @@ func TestBuildShowVerificationUIHookPatches_MissingHooksPathIsEmptyArray(t *test
 	current := projectWithIdentityConfig(map[string]interface{}{})
 
 	patches := buildShowVerificationUIHookPatches(plan, current)
-	if len(patches) != 1 {
-		t.Fatalf("expected 1 patch even with empty config, got %d", len(patches))
-	}
+	require.Len(t, patches, 1, "expected 1 patch even with empty config")
 	hooks, ok := patches[0].Value.([]map[string]interface{})
-	if !ok || len(hooks) != 1 {
-		t.Fatalf("expected single show_verification_ui hook, got %v", patches[0].Value)
-	}
-	if hooks[0]["hook"] != "show_verification_ui" {
-		t.Errorf("expected show_verification_ui hook, got %v", hooks[0])
-	}
+	require.True(t, ok, "expected []map[string]interface{} value, got %T", patches[0].Value)
+	require.Len(t, hooks, 1, "expected single show_verification_ui hook")
+	assert.Equal(t, "show_verification_ui", hooks[0]["hook"])
 }
 
 func TestNeedsHookPrefetch(t *testing.T) {
@@ -686,9 +539,7 @@ func TestNeedsHookPrefetch(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := needsHookPrefetch(&tc.plan); got != tc.want {
-				t.Errorf("needsHookPrefetch() = %v, want %v", got, tc.want)
-			}
+			assert.Equal(t, tc.want, needsHookPrefetch(&tc.plan))
 		})
 	}
 }

--- a/internal/resources/projectconfig/generated_test.go
+++ b/internal/resources/projectconfig/generated_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestGeneratedPatchEntries_ValidAndUnique verifies that every generated patch
@@ -18,16 +20,12 @@ func TestGeneratedPatchEntries_ValidAndUnique(t *testing.T) {
 
 	checkEntry := func(typeName, path string, field interface{}) {
 		t.Helper()
+		assert.NotEmpty(t, path, "%s patch entry has empty path", typeName)
 		if path == "" {
-			t.Errorf("%s patch entry has empty path", typeName)
 			return
 		}
-		if field == nil {
-			t.Errorf("%s patch entry %q has nil field pointer", typeName, path)
-		}
-		if seen[path] {
-			t.Errorf("%s patch entry %q: duplicate path (already seen)", typeName, path)
-		}
+		assert.NotNil(t, field, "%s patch entry %q has nil field pointer", typeName, path)
+		assert.False(t, seen[path], "%s patch entry %q: duplicate path (already seen)", typeName, path)
 		seen[path] = true
 	}
 
@@ -61,10 +59,7 @@ func TestGeneratedPatchEntries_PathFormat(t *testing.T) {
 
 	checkPath := func(path string) {
 		t.Helper()
-		if !strings.HasPrefix(path, "/") {
-			t.Errorf("patch path %q does not start with /", path)
-			return
-		}
+		require.True(t, strings.HasPrefix(path, "/"), "patch path %q does not start with /", path)
 		valid := false
 		for _, prefix := range validPrefixes {
 			if strings.HasPrefix(path, prefix) {
@@ -72,9 +67,7 @@ func TestGeneratedPatchEntries_PathFormat(t *testing.T) {
 				break
 			}
 		}
-		if !valid {
-			t.Errorf("patch path %q does not match any known service prefix", path)
-		}
+		assert.True(t, valid, "patch path %q does not match any known service prefix", path)
 	}
 
 	for _, e := range simpleStringPatchEntries(plan) {
@@ -121,9 +114,7 @@ func TestGeneratedStringPatch_NullSkipped(t *testing.T) {
 	patches := r.buildPatches(context.Background(), plan)
 
 	for _, p := range patches {
-		if generatedPaths[p.Path] {
-			t.Errorf("unexpected patch for null generated field: %s", p.Path)
-		}
+		assert.False(t, generatedPaths[p.Path], "unexpected patch for null generated field: %s", p.Path)
 	}
 }
 
@@ -136,15 +127,9 @@ func TestGeneratedStringPatch_SetValue(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/selfservice/flows/login/lifespan")
-	if p == nil {
-		t.Fatal("expected patch for selfservice_flows_login_lifespan")
-	}
-	if p.Op != "replace" {
-		t.Errorf("expected op 'replace', got %q", p.Op)
-	}
-	if p.Value != "30m0s" {
-		t.Errorf("expected value '30m0s', got %v", p.Value)
-	}
+	require.NotNil(t, p, "expected patch for selfservice_flows_login_lifespan")
+	assert.Equal(t, "replace", p.Op)
+	assert.Equal(t, "30m0s", p.Value)
 }
 
 // TestGeneratedBoolPatch_SetValue verifies a set bool field produces correct patch.
@@ -156,12 +141,8 @@ func TestGeneratedBoolPatch_SetValue(t *testing.T) {
 
 	patches := r.buildPatches(context.Background(), plan)
 	p := findPatch(patches, "/services/identity/config/feature_flags/cacheable_sessions")
-	if p == nil {
-		t.Fatal("expected patch for feature_flags_cacheable_sessions")
-	}
-	if p.Value != true {
-		t.Errorf("expected value true, got %v", p.Value)
-	}
+	require.NotNil(t, p, "expected patch for feature_flags_cacheable_sessions")
+	assert.Equal(t, true, p.Value)
 }
 
 // TestGeneratedReadEntries_AllFieldsExist verifies read entries reference real struct fields.
@@ -170,46 +151,30 @@ func TestGeneratedReadEntries_AllFieldsExist(t *testing.T) {
 
 	checkStringEntries := func(name string, entries []StringReadEntry) {
 		for _, e := range entries {
-			if e.Field == nil {
-				t.Errorf("%s: string read entry with keys %v has nil field", name, e.Keys)
-			}
-			if len(e.Keys) == 0 {
-				t.Errorf("%s: string read entry has empty keys", name)
-			}
+			assert.NotNil(t, e.Field, "%s: string read entry with keys %v has nil field", name, e.Keys)
+			assert.NotEmpty(t, e.Keys, "%s: string read entry has empty keys", name)
 		}
 	}
 	checkBoolEntries := func(name string, entries []BoolReadEntry) {
 		for _, e := range entries {
-			if e.Field == nil {
-				t.Errorf("%s: bool read entry with keys %v has nil field", name, e.Keys)
-			}
+			assert.NotNil(t, e.Field, "%s: bool read entry with keys %v has nil field", name, e.Keys)
 		}
 	}
 	checkInt64Entries := func(name string, entries []Int64ReadEntry) {
 		for _, e := range entries {
-			if e.Field == nil {
-				t.Errorf("%s: int64 read entry with keys %v has nil field", name, e.Keys)
-			}
+			assert.NotNil(t, e.Field, "%s: int64 read entry with keys %v has nil field", name, e.Keys)
 		}
 	}
 	checkListStringEntries := func(name string, entries []ListStringReadEntry) {
 		for _, e := range entries {
-			if e.Field == nil {
-				t.Errorf("%s: list_string read entry with keys %v has nil field", name, e.Keys)
-			}
-			if len(e.Keys) == 0 {
-				t.Errorf("%s: list_string read entry has empty keys", name)
-			}
+			assert.NotNil(t, e.Field, "%s: list_string read entry with keys %v has nil field", name, e.Keys)
+			assert.NotEmpty(t, e.Keys, "%s: list_string read entry has empty keys", name)
 		}
 	}
 	checkMapStringEntries := func(name string, entries []MapStringReadEntry) {
 		for _, e := range entries {
-			if e.Field == nil {
-				t.Errorf("%s: map_string read entry with keys %v has nil field", name, e.Keys)
-			}
-			if len(e.Keys) == 0 {
-				t.Errorf("%s: map_string read entry has empty keys", name)
-			}
+			assert.NotNil(t, e.Field, "%s: map_string read entry with keys %v has nil field", name, e.Keys)
+			assert.NotEmpty(t, e.Keys, "%s: map_string read entry has empty keys", name)
 		}
 	}
 
@@ -274,18 +239,10 @@ func TestGeneratedReadRoundTrip(t *testing.T) {
 	}
 
 	// Verify values were read correctly
-	if state.SelfserviceFlowsLoginLifespan.ValueString() != "30m0s" {
-		t.Errorf("expected login lifespan '30m0s', got %q", state.SelfserviceFlowsLoginLifespan.ValueString())
-	}
-	if state.SelfserviceFlowsRecoveryUse.ValueString() != "code" {
-		t.Errorf("expected recovery use 'code', got %q", state.SelfserviceFlowsRecoveryUse.ValueString())
-	}
-	if state.SelfserviceFlowsRecoveryNotifyUnknownRecipients.ValueBool() != true {
-		t.Error("expected recovery notify_unknown_recipients true")
-	}
-	if state.FeatureFlagsCacheableSessions.ValueBool() != true {
-		t.Error("expected cacheable_sessions true")
-	}
+	assert.Equal(t, "30m0s", state.SelfserviceFlowsLoginLifespan.ValueString(), "login lifespan")
+	assert.Equal(t, "code", state.SelfserviceFlowsRecoveryUse.ValueString(), "recovery use")
+	assert.True(t, state.SelfserviceFlowsRecoveryNotifyUnknownRecipients.ValueBool(), "recovery notify_unknown_recipients")
+	assert.True(t, state.FeatureFlagsCacheableSessions.ValueBool(), "cacheable_sessions")
 }
 
 // TestGeneratedSchemaAttributes_Count verifies generation produced a non-trivial
@@ -293,9 +250,7 @@ func TestGeneratedReadRoundTrip(t *testing.T) {
 // this test catches catastrophic generation failures (e.g., empty output).
 func TestGeneratedSchemaAttributes_Count(t *testing.T) {
 	attrs := simpleSchemaAttributes()
-	if len(attrs) == 0 {
-		t.Fatal("simpleSchemaAttributes() returned 0 attributes — generation likely failed")
-	}
+	require.NotEmpty(t, attrs, "simpleSchemaAttributes() returned 0 attributes — generation likely failed")
 }
 
 // TestGeneratedSchemaAttributes_AllOptional verifies all generated attributes are optional.
@@ -315,11 +270,9 @@ func TestGeneratedSchemaAttributes_AllOptional(t *testing.T) {
 		case schema.MapAttribute:
 			optional = a.Optional
 		default:
-			t.Errorf("attribute %q has unexpected type %T", name, attr)
+			assert.Failf(t, "unexpected attribute type", "attribute %q has unexpected type %T", name, attr)
 			continue
 		}
-		if !optional {
-			t.Errorf("attribute %q is not optional", name)
-		}
+		assert.True(t, optional, "attribute %q is not optional", name)
 	}
 }

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	ory "github.com/ory/client-go"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ory/terraform-provider-ory/internal/acctest"
 	"github.com/ory/terraform-provider-ory/internal/testutil"
@@ -340,9 +341,7 @@ func clearTokenizerTemplatesOutOfBand(t *testing.T) func() {
 	t.Helper()
 	return func() {
 		c, err := acctest.GetOryClient()
-		if err != nil {
-			t.Fatalf("Failed to create Ory client: %v", err)
-		}
+		require.NoError(t, err, "Failed to create Ory client")
 		projectID := acctest.GetTestProjectID(t)
 		patches := []ory.JsonPatch{
 			{
@@ -351,9 +350,8 @@ func clearTokenizerTemplatesOutOfBand(t *testing.T) func() {
 				Value: map[string]interface{}{},
 			},
 		}
-		if _, err := c.PatchProject(context.Background(), projectID, patches); err != nil {
-			t.Fatalf("Failed to clear tokenizer templates out-of-band: %v", err)
-		}
+		_, err = c.PatchProject(context.Background(), projectID, patches)
+		require.NoError(t, err, "Failed to clear tokenizer templates out-of-band")
 		t.Log("Cleared tokenizer templates out-of-band to simulate drift")
 	}
 }

--- a/internal/resources/samlprovider/resource_test.go
+++ b/internal/resources/samlprovider/resource_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ory/terraform-provider-ory/internal/acctest"
 )
@@ -26,9 +27,7 @@ func buildTestMetadataXML(t *testing.T) string {
 	t.Helper()
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatalf("failed to generate test signing key: %v", err)
-	}
+	require.NoError(t, err, "failed to generate test signing key")
 	tmpl := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		Subject:      pkix.Name{CommonName: "idp.example.com"},
@@ -37,9 +36,7 @@ func buildTestMetadataXML(t *testing.T) string {
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 	}
 	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	if err != nil {
-		t.Fatalf("failed to create test certificate: %v", err)
-	}
+	require.NoError(t, err, "failed to create test certificate")
 	certB64 := base64.StdEncoding.EncodeToString(certDER)
 
 	metadata := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>

--- a/internal/resources/samlprovider/validate_config_test.go
+++ b/internal/resources/samlprovider/validate_config_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func tfStringValue(v types.String) tftypes.Value {
@@ -71,9 +73,7 @@ func TestValidateConfig_EmptyProviderID(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(context.Background(), req, &resp)
 
-	if !resp.Diagnostics.HasError() {
-		t.Fatalf("expected validation error for empty provider_id, got none")
-	}
+	require.True(t, resp.Diagnostics.HasError(), "expected validation error for empty provider_id")
 }
 
 func TestValidateConfig_EmptyMetadata(t *testing.T) {
@@ -87,9 +87,7 @@ func TestValidateConfig_EmptyMetadata(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(context.Background(), req, &resp)
 
-	if !resp.Diagnostics.HasError() {
-		t.Fatalf("expected validation error for empty raw_idp_metadata_xml, got none")
-	}
+	require.True(t, resp.Diagnostics.HasError(), "expected validation error for empty raw_idp_metadata_xml")
 }
 
 func TestValidateConfig_Valid(t *testing.T) {
@@ -103,9 +101,7 @@ func TestValidateConfig_Valid(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(context.Background(), req, &resp)
 
-	if resp.Diagnostics.HasError() {
-		t.Fatalf("unexpected validation error: %v", resp.Diagnostics)
-	}
+	assert.False(t, resp.Diagnostics.HasError(), "unexpected validation error: %v", resp.Diagnostics)
 }
 
 func TestValidateConfig_EmptyOptionalFields(t *testing.T) {
@@ -137,9 +133,7 @@ func TestValidateConfig_EmptyOptionalFields(t *testing.T) {
 			r := &SAMLProviderResource{}
 			var resp resource.ValidateConfigResponse
 			r.ValidateConfig(context.Background(), req, &resp)
-			if !resp.Diagnostics.HasError() {
-				t.Fatalf("expected validation error for empty %s, got none", name)
-			}
+			require.True(t, resp.Diagnostics.HasError(), "expected validation error for empty %s", name)
 		})
 	}
 }

--- a/internal/resources/socialprovider/resource_test.go
+++ b/internal/resources/socialprovider/resource_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ory/terraform-provider-ory/internal/acctest"
 )
@@ -81,13 +82,9 @@ func TestAccSocialProviderResource_basic(t *testing.T) {
 func generateTestPrivateKey(t *testing.T) string {
 	t.Helper()
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("failed to generate test private key: %v", err)
-	}
+	require.NoError(t, err, "failed to generate test private key")
 	der, err := x509.MarshalPKCS8PrivateKey(key)
-	if err != nil {
-		t.Fatalf("failed to marshal test private key: %v", err)
-	}
+	require.NoError(t, err, "failed to marshal test private key")
 	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
 }
 

--- a/internal/resources/socialprovider/validate_config_test.go
+++ b/internal/resources/socialprovider/validate_config_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
 )
 
 // buildTestConfig creates a ValidateConfigRequest from a SocialProviderResourceModel.
@@ -118,9 +119,7 @@ func TestValidateConfig_UnknownClientSecret_SkipsValidation(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if resp.Diagnostics.HasError() {
-		t.Errorf("expected no errors for unknown client_secret, got: %s", resp.Diagnostics.Errors()[0].Detail())
-	}
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for unknown client_secret: %v", resp.Diagnostics.Errors())
 }
 
 func TestValidateConfig_UnknownAppleFields_SkipsValidation(t *testing.T) {
@@ -138,9 +137,7 @@ func TestValidateConfig_UnknownAppleFields_SkipsValidation(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if resp.Diagnostics.HasError() {
-		t.Errorf("expected no errors for unknown apple fields, got: %s", resp.Diagnostics.Errors()[0].Detail())
-	}
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for unknown apple fields: %v", resp.Diagnostics.Errors())
 }
 
 func TestValidateConfig_KnownClientSecret_Passes(t *testing.T) {
@@ -156,9 +153,7 @@ func TestValidateConfig_KnownClientSecret_Passes(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if resp.Diagnostics.HasError() {
-		t.Errorf("expected no errors for known client_secret, got: %s", resp.Diagnostics.Errors()[0].Detail())
-	}
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for known client_secret: %v", resp.Diagnostics.Errors())
 }
 
 func TestValidateConfig_MissingClientSecret_Fails(t *testing.T) {
@@ -174,9 +169,7 @@ func TestValidateConfig_MissingClientSecret_Fails(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if !resp.Diagnostics.HasError() {
-		t.Error("expected error for missing client_secret, got none")
-	}
+	assert.True(t, resp.Diagnostics.HasError(), "expected error for missing client_secret")
 }
 
 func TestValidateConfig_EmptyClientSecret_Fails(t *testing.T) {
@@ -192,9 +185,7 @@ func TestValidateConfig_EmptyClientSecret_Fails(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if !resp.Diagnostics.HasError() {
-		t.Error("expected error for empty client_secret, got none")
-	}
+	assert.True(t, resp.Diagnostics.HasError(), "expected error for empty client_secret")
 }
 
 func TestValidateConfig_UnknownProviderType_SkipsValidation(t *testing.T) {
@@ -210,7 +201,5 @@ func TestValidateConfig_UnknownProviderType_SkipsValidation(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if resp.Diagnostics.HasError() {
-		t.Errorf("expected no errors for unknown provider_type, got: %s", resp.Diagnostics.Errors()[0].Detail())
-	}
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for unknown provider_type: %v", resp.Diagnostics.Errors())
 }


### PR DESCRIPTION
## Description

Refactor all Go tests to use `require` and `assert` from `github.com/stretchr/testify` instead of hand-rolled `if`/`t.Errorf` blocks. Document the convention in CONTRIBUTING.md so new contributors follow the same style.

- `require.X` aborts the test immediately on failure — used for setup steps and preconditions where continuing would produce misleading errors (e.g. `require.NoError(t, err)` after creating a client).
- `assert.X` records the failure but lets the test keep running — used for independent checks so a single run surfaces every problem at once.

Net change across 20 files: **385 insertions, 974 deletions (-589 lines)**. `testify` was already in `go.sum` as an indirect dependency and is now promoted to a direct one.

## Related Issues

N/A — code-style cleanup driven by reviewer feedback.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [ ] Acceptance tests
- [ ] Manual testing

`make test-short` passes for every package. `make format` produces no diff and `golangci-lint --fix` reports 0 issues. `make sec` (govulncheck + gosec + gitleaks) all pass. Acceptance tests build cleanly (`go vet -tags=acceptance ./...`) but were not executed since this PR only changes test assertion style and does not touch any resource logic.

## Screenshots/Output

```
$ make test-short
ok  	github.com/ory/terraform-provider-ory/internal/client
ok  	github.com/ory/terraform-provider-ory/internal/codegen/cmd/generate
ok  	github.com/ory/terraform-provider-ory/internal/datasources/identityschema
ok  	github.com/ory/terraform-provider-ory/internal/helpers
ok  	github.com/ory/terraform-provider-ory/internal/provider
ok  	github.com/ory/terraform-provider-ory/internal/resources/action
ok  	github.com/ory/terraform-provider-ory/internal/resources/emailtemplate
ok  	github.com/ory/terraform-provider-ory/internal/resources/projectconfig
ok  	github.com/ory/terraform-provider-ory/internal/resources/samlprovider
ok  	github.com/ory/terraform-provider-ory/internal/resources/socialprovider
```