### PR TITLE
fix(action): store verification/recovery after-hooks in the flat hooks path

### DIFF
--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -52,12 +52,13 @@ resource "ory_action" "audit_log" {
 }
 
 # Post-verification sync
+# The verification (and recovery) flow is not scoped by authentication method,
+# so auth_method is omitted here — the hook always runs after verification.
 resource "ory_action" "sync_verified" {
-  flow        = "verification"
-  timing      = "after"
-  auth_method = "code"
-  url         = "https://api.example.com/webhooks/user-verified"
-  method      = "POST"
+  flow   = "verification"
+  timing = "after"
+  url    = "https://api.example.com/webhooks/user-verified"
+  method = "POST"
 }
 
 # Post-registration enrichment (parse response to modify identity)
@@ -106,7 +107,7 @@ resource "ory_action" "with_api_key" {
 
 ## Authentication Methods
 
-The `auth_method` attribute specifies which authentication method triggers the webhook. This is only used for `timing = "after"` webhooks.
+The `auth_method` attribute specifies which authentication method triggers the webhook. It applies only to `timing = "after"` webhooks on the `login`, `registration`, and `settings` flows.
 
 | Value | Description |
 |-------|-------------|
@@ -118,7 +119,7 @@ The `auth_method` attribute specifies which authentication method triggers the w
 | `totp` | Time-based one-time password |
 | `lookup_secret` | Recovery/backup codes |
 
-~> **Note:** `auth_method` is only used for `timing = "after"` webhooks. For `timing = "before"` hooks, the webhook runs before any authentication method is invoked.
+~> **Note:** `auth_method` only applies to `timing = "after"` webhooks on the `login`, `registration`, and `settings` flows. The `recovery` and `verification` flows are **not** scoped by authentication method — their after-hooks always run — so `auth_method` is ignored for them and should be omitted. For `timing = "before"` hooks, the webhook runs before any authentication method is invoked.
 
 ## Webhook Authentication
 
@@ -213,7 +214,7 @@ terraform import ory_action.validate \
 1. **project_id**: Settings → General → Project ID
 2. **flow**: The flow type (login, registration, recovery, settings, verification)
 3. **timing**: "before" or "after"
-4. **auth_method** (for "after" only): password, oidc, code, webauthn, passkey, totp, lookup_secret
+4. **auth_method**: for `login`/`registration`/`settings` "after" hooks, one of password, oidc, code, webauthn, passkey, totp, lookup_secret. For `recovery`/`verification` "after" hooks it is ignored — use `password` as a placeholder.
 5. **method**: The HTTP method (POST, GET, PUT, PATCH, DELETE)
 6. **url**: The exact webhook URL - must match exactly including protocol and trailing slashes
 
@@ -238,7 +239,7 @@ Common issues:
 
 ### Optional
 
-- `auth_method` (String) Authentication method that triggers the webhook. In the Ory Console UI, this is the "Method" selector. Valid values: `password` (default), `oidc` (social login), `code` (magic link/OTP), `webauthn`, `passkey`, `totp`, `lookup_secret`. Only used for `timing = "after"` webhooks.
+- `auth_method` (String) Authentication method that triggers the webhook. In the Ory Console UI, this is the "Method" selector. Valid values: `password` (default), `oidc` (social login), `code` (magic link/OTP), `webauthn`, `passkey`, `totp`, `lookup_secret`. Only applies to `timing = "after"` webhooks on the `login`, `registration`, and `settings` flows; it is ignored for the `recovery` and `verification` flows.
 - `body` (String) Jsonnet template for the request body.
 - `can_interrupt` (Boolean) Allow webhook to interrupt/block the flow (default: false).
 - `method` (String) HTTP method (default: POST).

--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -214,7 +214,7 @@ terraform import ory_action.validate \
 1. **project_id**: Settings → General → Project ID
 2. **flow**: The flow type (login, registration, recovery, settings, verification)
 3. **timing**: "before" or "after"
-4. **auth_method**: for `login`/`registration`/`settings` "after" hooks, one of password, oidc, code, webauthn, passkey, totp, lookup_secret. For `recovery`/`verification` "after" hooks it is ignored — use `password` as a placeholder.
+4. **auth_method**: for `login`/`registration`/`settings` "after" hooks, one of password, oidc, code, webauthn, passkey, totp, lookup_secret. For `recovery`/`verification` "after" hooks the value is ignored, but the import ID format still requires this segment — use `password` to match the provider default and avoid a post-import diff (keep `auth_method` omitted from the resource configuration itself).
 5. **method**: The HTTP method (POST, GET, PUT, PATCH, DELETE)
 6. **url**: The exact webhook URL - must match exactly including protocol and trailing slashes
 

--- a/examples/resources/ory_action/resource.tf
+++ b/examples/resources/ory_action/resource.tf
@@ -34,12 +34,13 @@ resource "ory_action" "audit_log" {
 }
 
 # Post-verification sync
+# The verification (and recovery) flow is not scoped by authentication method,
+# so auth_method is omitted here — the hook always runs after verification.
 resource "ory_action" "sync_verified" {
-  flow        = "verification"
-  timing      = "after"
-  auth_method = "code"
-  url         = "https://api.example.com/webhooks/user-verified"
-  method      = "POST"
+  flow   = "verification"
+  timing = "after"
+  url    = "https://api.example.com/webhooks/user-verified"
+  method = "POST"
 }
 
 # Post-registration enrichment (parse response to modify identity)

--- a/internal/resources/action/hooks_test.go
+++ b/internal/resources/action/hooks_test.go
@@ -1,0 +1,168 @@
+package action
+
+import (
+	"testing"
+
+	ory "github.com/ory/client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// actionTestProject wraps an identity config map in an *ory.Project so the hook
+// read helpers can be exercised without hitting the API.
+func actionTestProject(identityConfig map[string]interface{}) *ory.Project {
+	return &ory.Project{
+		Services: ory.ProjectServices{
+			Identity: &ory.ProjectServiceIdentity{
+				Config: identityConfig,
+			},
+		},
+	}
+}
+
+func actionTestWebhook(url string) map[string]interface{} {
+	return map[string]interface{}{
+		"hook": "web_hook",
+		"config": map[string]interface{}{
+			"url":    url,
+			"method": "POST",
+		},
+	}
+}
+
+// afterConfig builds selfservice.flows.<flow>.after with the given after-block contents.
+func afterConfig(flow string, after map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"selfservice": map[string]interface{}{
+			"flows": map[string]interface{}{
+				flow: map[string]interface{}{
+					"after": after,
+				},
+			},
+		},
+	}
+}
+
+func TestFlowSupportsAuthMethod(t *testing.T) {
+	cases := map[string]bool{
+		"login":        true,
+		"registration": true,
+		"settings":     true,
+		"recovery":     false,
+		"verification": false,
+		"unknown":      false,
+	}
+	for flow, want := range cases {
+		assert.Equalf(t, want, flowSupportsAuthMethod(flow), "flowSupportsAuthMethod(%q)", flow)
+	}
+}
+
+func TestHookPath(t *testing.T) {
+	r := &ActionResource{}
+	tests := []struct {
+		name       string
+		flow       string
+		timing     string
+		authMethod string
+		want       string
+	}{
+		{
+			name: "login after is auth-method scoped", flow: "login", timing: "after", authMethod: "password",
+			want: "/services/identity/config/selfservice/flows/login/after/password/hooks",
+		},
+		{
+			name: "registration after is auth-method scoped", flow: "registration", timing: "after", authMethod: "oidc",
+			want: "/services/identity/config/selfservice/flows/registration/after/oidc/hooks",
+		},
+		{
+			name: "settings after is auth-method scoped", flow: "settings", timing: "after", authMethod: "password",
+			want: "/services/identity/config/selfservice/flows/settings/after/password/hooks",
+		},
+		{
+			// Regression for issue #241: verification has no auth-method level.
+			name: "verification after is flat", flow: "verification", timing: "after", authMethod: "password",
+			want: "/services/identity/config/selfservice/flows/verification/after/hooks",
+		},
+		{
+			name: "recovery after is flat", flow: "recovery", timing: "after", authMethod: "password",
+			want: "/services/identity/config/selfservice/flows/recovery/after/hooks",
+		},
+		{
+			name: "before timing is always flat", flow: "login", timing: "before", authMethod: "password",
+			want: "/services/identity/config/selfservice/flows/login/before/hooks",
+		},
+		{
+			name: "verification before is flat", flow: "verification", timing: "before", authMethod: "password",
+			want: "/services/identity/config/selfservice/flows/verification/before/hooks",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, r.hookPath(tt.flow, tt.timing, tt.authMethod))
+		})
+	}
+}
+
+// TestGetHooksFromProject_VerificationReadsFlatHooks is the read-side regression
+// for issue #241: verification/recovery "after" hooks live in a flat array, so
+// getHooksFromProject must read .../after/hooks and ignore auth_method.
+func TestGetHooksFromProject_VerificationReadsFlatHooks(t *testing.T) {
+	r := &ActionResource{}
+
+	for _, flow := range []string{"verification", "recovery"} {
+		t.Run(flow, func(t *testing.T) {
+			cfg := afterConfig(flow, map[string]interface{}{
+				"hooks": []interface{}{actionTestWebhook("https://example.com/" + flow)},
+			})
+			hooks := r.getHooksFromProject(actionTestProject(cfg), flow, "after", "password")
+			require.Len(t, hooks, 1)
+			config, _ := hooks[0]["config"].(map[string]interface{})
+			assert.Equal(t, "https://example.com/"+flow, config["url"])
+		})
+	}
+}
+
+// TestGetHooksFromProject_AuthScopedFlows verifies that login/registration/settings
+// "after" hooks are read from the auth-method-scoped path and do not fall back to
+// the flat array (which would mix hooks across methods).
+func TestGetHooksFromProject_AuthScopedFlows(t *testing.T) {
+	r := &ActionResource{}
+
+	// Hook nested under the password method is found for auth_method=password.
+	scoped := afterConfig("login", map[string]interface{}{
+		"password": map[string]interface{}{
+			"hooks": []interface{}{actionTestWebhook("https://example.com/login-password")},
+		},
+	})
+	hooks := r.getHooksFromProject(actionTestProject(scoped), "login", "after", "password")
+	require.Len(t, hooks, 1)
+	config, _ := hooks[0]["config"].(map[string]interface{})
+	assert.Equal(t, "https://example.com/login-password", config["url"])
+
+	// A flat hook is NOT returned when reading the password-scoped path.
+	flatOnly := afterConfig("login", map[string]interface{}{
+		"hooks": []interface{}{actionTestWebhook("https://example.com/login-global")},
+	})
+	hooks = r.getHooksFromProject(actionTestProject(flatOnly), "login", "after", "password")
+	assert.Empty(t, hooks, "auth-scoped read must not pick up flat after-hooks")
+}
+
+// TestGetHooksFromProject_BeforeTiming verifies before-hooks are read flat for all flows.
+func TestGetHooksFromProject_BeforeTiming(t *testing.T) {
+	r := &ActionResource{}
+	cfg := map[string]interface{}{
+		"selfservice": map[string]interface{}{
+			"flows": map[string]interface{}{
+				"login": map[string]interface{}{
+					"before": map[string]interface{}{
+						"hooks": []interface{}{actionTestWebhook("https://example.com/pre-login")},
+					},
+				},
+			},
+		},
+	}
+	hooks := r.getHooksFromProject(actionTestProject(cfg), "login", "before", "password")
+	require.Len(t, hooks, 1)
+	config, _ := hooks[0]["config"].(map[string]interface{})
+	assert.Equal(t, "https://example.com/pre-login", config["url"])
+}

--- a/internal/resources/action/resource.go
+++ b/internal/resources/action/resource.go
@@ -126,7 +126,7 @@ The ` + "`auth_method`" + ` attribute specifies which authentication method trig
 | ` + "`totp`" + ` | Time-based one-time password | "TOTP" |
 | ` + "`lookup_secret`" + ` | Recovery/backup codes | "Backup Codes" |
 
-**Note:** ` + "`auth_method`" + ` is only used for ` + "`timing = \"after\"`" + ` webhooks. For ` + "`timing = \"before\"`" + ` hooks, the webhook runs before any authentication method.
+**Note:** ` + "`auth_method`" + ` only applies to ` + "`timing = \"after\"`" + ` webhooks on the ` + "`login`" + `, ` + "`registration`" + `, and ` + "`settings`" + ` flows. The ` + "`recovery`" + ` and ` + "`verification`" + ` flows are not scoped by authentication method, so ` + "`auth_method`" + ` is ignored for them and should be omitted. For ` + "`timing = \"before\"`" + ` hooks, the webhook runs before any authentication method.
 
 ## Webhook Authentication
 
@@ -242,8 +242,8 @@ func (r *ActionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"auth_method": schema.StringAttribute{
-				Description:         "Authentication method to hook into (password, oidc, code, webauthn, passkey, totp, lookup_secret). Required for 'after' timing. Defaults to 'password'.",
-				MarkdownDescription: "Authentication method that triggers the webhook. In the Ory Console UI, this is the \"Method\" selector. Valid values: `password` (default), `oidc` (social login), `code` (magic link/OTP), `webauthn`, `passkey`, `totp`, `lookup_secret`. Only used for `timing = \"after\"` webhooks.",
+				Description:         "Authentication method to hook into (password, oidc, code, webauthn, passkey, totp, lookup_secret). Defaults to 'password'. Only applies to 'after' timing on the login, registration, and settings flows; ignored for the recovery and verification flows.",
+				MarkdownDescription: "Authentication method that triggers the webhook. In the Ory Console UI, this is the \"Method\" selector. Valid values: `password` (default), `oidc` (social login), `code` (magic link/OTP), `webauthn`, `passkey`, `totp`, `lookup_secret`. Only applies to `timing = \"after\"` webhooks on the `login`, `registration`, and `settings` flows; it is ignored for the `recovery` and `verification` flows.",
 				Optional:            true,
 				Computed:            true,
 				Default:             stringdefault.StaticString("password"),
@@ -378,6 +378,21 @@ func (r *ActionResource) ValidateConfig(ctx context.Context, req resource.Valida
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// auth_method only scopes "after" hooks for the login, registration, and
+	// settings flows. The recovery and verification flows store their after-hooks
+	// in a single flat array, so auth_method is ignored for them. Warn when it is
+	// set explicitly so users aren't surprised that the value has no effect.
+	if !config.AuthMethod.IsNull() && !config.AuthMethod.IsUnknown() &&
+		!config.Flow.IsNull() && !config.Flow.IsUnknown() &&
+		!flowSupportsAuthMethod(config.Flow.ValueString()) {
+		resp.Diagnostics.AddAttributeWarning(
+			path.Root("auth_method"),
+			"auth_method has no effect for this flow",
+			fmt.Sprintf("The %q flow does not scope its hooks by authentication method, so auth_method is "+
+				"ignored. You can safely remove auth_method from this resource.", config.Flow.ValueString()),
+		)
 	}
 
 	if config.WebhookAuthType.IsNull() || config.WebhookAuthType.IsUnknown() {
@@ -549,8 +564,24 @@ func (r *ActionResource) findHookIndex(hooks []map[string]interface{}, url, meth
 	return -1
 }
 
+// flowSupportsAuthMethod reports whether a flow's "after" hooks are scoped by
+// authentication method (e.g. .../after/password/hooks). Only the login,
+// registration, and settings flows have method-scoped after-hooks in the Ory
+// Kratos config. The recovery and verification flows store their after-hooks in
+// a single flat array at .../after/hooks with no auth-method level, so PATCHing
+// to .../after/<auth_method>/hooks for them returns 200 but silently drops the
+// hook. See https://github.com/ory/terraform-provider-ory/issues/241
+func flowSupportsAuthMethod(flow string) bool {
+	switch flow {
+	case "login", "registration", "settings":
+		return true
+	default:
+		return false
+	}
+}
+
 func (r *ActionResource) hookPath(flow, timing, authMethod string) string {
-	if timing == timingAfter {
+	if timing == timingAfter && flowSupportsAuthMethod(flow) {
 		return fmt.Sprintf("/services/identity/config/selfservice/flows/%s/%s/%s/hooks", flow, timing, authMethod)
 	}
 	return fmt.Sprintf("/services/identity/config/selfservice/flows/%s/%s/hooks", flow, timing)
@@ -587,7 +618,7 @@ func (r *ActionResource) getHooksFromProject(project *ory.Project, flow, timing,
 	}
 
 	var hooks []interface{}
-	if timing == timingAfter {
+	if timing == timingAfter && flowSupportsAuthMethod(flow) {
 		authMethodConfig, ok := timingConfig[authMethod].(map[string]interface{})
 		if !ok {
 			return []map[string]interface{}{}

--- a/internal/resources/action/resource.go
+++ b/internal/resources/action/resource.go
@@ -380,19 +380,31 @@ func (r *ActionResource) ValidateConfig(ctx context.Context, req resource.Valida
 		return
 	}
 
-	// auth_method only scopes "after" hooks for the login, registration, and
-	// settings flows. The recovery and verification flows store their after-hooks
-	// in a single flat array, so auth_method is ignored for them. Warn when it is
-	// set explicitly so users aren't surprised that the value has no effect.
+	// auth_method only takes effect for "after" hooks on the login, registration,
+	// and settings flows. It is ignored for "before" hooks (all flows) and for the
+	// recovery and verification flows, which store their after-hooks in a single
+	// flat array. Warn when it is set explicitly but will have no effect, so users
+	// aren't surprised. Timing is only considered when known, to avoid false
+	// positives for auth-scoped flows whose timing is resolved at apply time.
 	if !config.AuthMethod.IsNull() && !config.AuthMethod.IsUnknown() &&
-		!config.Flow.IsNull() && !config.Flow.IsUnknown() &&
-		!flowSupportsAuthMethod(config.Flow.ValueString()) {
-		resp.Diagnostics.AddAttributeWarning(
-			path.Root("auth_method"),
-			"auth_method has no effect for this flow",
-			fmt.Sprintf("The %q flow does not scope its hooks by authentication method, so auth_method is "+
-				"ignored. You can safely remove auth_method from this resource.", config.Flow.ValueString()),
-		)
+		!config.Flow.IsNull() && !config.Flow.IsUnknown() {
+		flow := config.Flow.ValueString()
+		ignoredByFlow := !flowSupportsAuthMethod(flow)
+		ignoredByTiming := !config.Timing.IsNull() && !config.Timing.IsUnknown() &&
+			config.Timing.ValueString() != timingAfter
+		if ignoredByFlow || ignoredByTiming {
+			detail := fmt.Sprintf("The %q flow does not scope its hooks by authentication method, so "+
+				"auth_method is ignored. You can safely remove auth_method from this resource.", flow)
+			if !ignoredByFlow {
+				detail = "auth_method only applies to \"after\" hooks, so it is ignored for \"before\" hooks. " +
+					"You can safely remove auth_method from this resource."
+			}
+			resp.Diagnostics.AddAttributeWarning(
+				path.Root("auth_method"),
+				"auth_method has no effect for this configuration",
+				detail,
+			)
+		}
 	}
 
 	if config.WebhookAuthType.IsNull() || config.WebhookAuthType.IsUnknown() {

--- a/internal/resources/action/resource_test.go
+++ b/internal/resources/action/resource_test.go
@@ -132,6 +132,82 @@ func TestAccActionResource_basic(t *testing.T) {
 	})
 }
 
+// TestAccActionResource_verificationFlow is the regression test for issue #241:
+// the verification flow's "after" hooks are stored in a flat array at
+// .../verification/after/hooks (no auth_method level). Before the fix, the
+// provider PATCHed to .../verification/after/password/hooks, which the API
+// accepted with 200 but silently dropped — failing with "Hook not found in
+// PatchProject response". This exercises create, read, update, import, delete.
+func TestAccActionResource_verificationFlow(t *testing.T) {
+	hookPath := "/services/identity/config/selfservice/flows/verification/after/hooks"
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.AccPreCheck(t)
+			cleanupDanglingWebhook(t, hookPath, testutil.ExampleWebhookURL+"/verification-after")
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create and Read
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/verification.tf.tmpl", map[string]string{"WebhookURL": testutil.ExampleWebhookURL}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_action.test", "id"),
+					resource.TestCheckResourceAttr("ory_action.test", "flow", "verification"),
+					resource.TestCheckResourceAttr("ory_action.test", "timing", "after"),
+					resource.TestCheckResourceAttr("ory_action.test", "method", "POST"),
+					resource.TestCheckResourceAttr("ory_action.test", "response_ignore", "false"),
+				),
+			},
+			// Import (auth_method defaults to "password" in the composite ID but is ignored for this flow)
+			{
+				ResourceName:      "ory_action.test",
+				ImportState:       true,
+				ImportStateIdFunc: actionImportStateIDFunc,
+				ImportStateVerify: true,
+			},
+			// Update an in-place attribute
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/verification_updated.tf.tmpl", map[string]string{"WebhookURL": testutil.ExampleWebhookURL}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_action.test", "response_ignore", "true"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccActionResource_recoveryFlow verifies the recovery flow (also flat,
+// no auth_method level) creates, reads, and imports correctly. See issue #241.
+func TestAccActionResource_recoveryFlow(t *testing.T) {
+	hookPath := "/services/identity/config/selfservice/flows/recovery/after/hooks"
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.AccPreCheck(t)
+			cleanupDanglingWebhook(t, hookPath, testutil.ExampleWebhookURL+"/recovery-after")
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create and Read
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/recovery.tf.tmpl", map[string]string{"WebhookURL": testutil.ExampleWebhookURL}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_action.test", "id"),
+					resource.TestCheckResourceAttr("ory_action.test", "flow", "recovery"),
+					resource.TestCheckResourceAttr("ory_action.test", "timing", "after"),
+					resource.TestCheckResourceAttr("ory_action.test", "method", "POST"),
+				),
+			},
+			// Import
+			{
+				ResourceName:      "ory_action.test",
+				ImportState:       true,
+				ImportStateIdFunc: actionImportStateIDFunc,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func actionImportStateIDFunc(s *terraform.State) (string, error) {
 	rs, ok := s.RootModule().Resources["ory_action.test"]
 	if !ok {

--- a/internal/resources/action/testdata/recovery.tf.tmpl
+++ b/internal/resources/action/testdata/recovery.tf.tmpl
@@ -1,0 +1,6 @@
+resource "ory_action" "test" {
+  flow   = "recovery"
+  timing = "after"
+  url    = "[[ .WebhookURL ]]/recovery-after"
+  method = "POST"
+}

--- a/internal/resources/action/testdata/verification.tf.tmpl
+++ b/internal/resources/action/testdata/verification.tf.tmpl
@@ -1,0 +1,6 @@
+resource "ory_action" "test" {
+  flow   = "verification"
+  timing = "after"
+  url    = "[[ .WebhookURL ]]/verification-after"
+  method = "POST"
+}

--- a/internal/resources/action/testdata/verification_updated.tf.tmpl
+++ b/internal/resources/action/testdata/verification_updated.tf.tmpl
@@ -1,0 +1,7 @@
+resource "ory_action" "test" {
+  flow            = "verification"
+  timing          = "after"
+  url             = "[[ .WebhookURL ]]/verification-after"
+  method          = "POST"
+  response_ignore = true
+}

--- a/internal/resources/action/validate_config_test.go
+++ b/internal/resources/action/validate_config_test.go
@@ -83,10 +83,10 @@ func tfActionStringValue(v types.String) tftypes.Value {
 	return tftypes.NewValue(tftypes.String, v.ValueString())
 }
 
-// TestValidateConfig_AuthMethodOnFlowlessFlow_Warns verifies that explicitly
+// TestValidateConfig_AuthMethodOnUnsupportedFlow_Warns verifies that explicitly
 // setting auth_method on the recovery/verification flows (which have no
 // auth-method-scoped hooks) produces a warning. Regression for issue #241.
-func TestValidateConfig_AuthMethodOnFlowlessFlow_Warns(t *testing.T) {
+func TestValidateConfig_AuthMethodOnUnsupportedFlow_Warns(t *testing.T) {
 	for _, flow := range []string{"verification", "recovery"} {
 		t.Run(flow, func(t *testing.T) {
 			r := &ActionResource{}
@@ -127,6 +127,26 @@ func TestValidateConfig_AuthMethodOnAuthScopedFlow_NoWarn(t *testing.T) {
 			assert.Empty(t, resp.Diagnostics.Warnings(), "did not expect a warning for auth_method on %s flow: %v", flow, resp.Diagnostics.Warnings())
 		})
 	}
+}
+
+// TestValidateConfig_AuthMethodOnBeforeTiming_Warns verifies that auth_method set
+// on a "before" hook warns even for an auth-scoped flow, since auth_method only
+// applies to "after" hooks. Covers the timing dimension of the warning.
+func TestValidateConfig_AuthMethodOnBeforeTiming_Warns(t *testing.T) {
+	r := &ActionResource{}
+	ctx := context.Background()
+
+	req := buildActionTestConfig(t, ActionResourceModel{
+		Flow:       types.StringValue("login"),
+		Timing:     types.StringValue("before"),
+		AuthMethod: types.StringValue("password"),
+		URL:        types.StringValue("https://example.com/webhook"),
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "auth_method on a before hook must not be an error: %v", resp.Diagnostics.Errors())
+	assert.NotEmpty(t, resp.Diagnostics.Warnings(), "expected a warning for auth_method on a before hook")
 }
 
 // TestValidateConfig_NoAuthMethodOnVerification_NoWarn verifies that the common

--- a/internal/resources/action/validate_config_test.go
+++ b/internal/resources/action/validate_config_test.go
@@ -83,6 +83,71 @@ func tfActionStringValue(v types.String) tftypes.Value {
 	return tftypes.NewValue(tftypes.String, v.ValueString())
 }
 
+// TestValidateConfig_AuthMethodOnFlowlessFlow_Warns verifies that explicitly
+// setting auth_method on the recovery/verification flows (which have no
+// auth-method-scoped hooks) produces a warning. Regression for issue #241.
+func TestValidateConfig_AuthMethodOnFlowlessFlow_Warns(t *testing.T) {
+	for _, flow := range []string{"verification", "recovery"} {
+		t.Run(flow, func(t *testing.T) {
+			r := &ActionResource{}
+			ctx := context.Background()
+
+			req := buildActionTestConfig(t, ActionResourceModel{
+				Flow:       types.StringValue(flow),
+				Timing:     types.StringValue("after"),
+				AuthMethod: types.StringValue("code"),
+				URL:        types.StringValue("https://example.com/webhook"),
+			})
+			var resp resource.ValidateConfigResponse
+			r.ValidateConfig(ctx, req, &resp)
+
+			assert.False(t, resp.Diagnostics.HasError(), "auth_method on %s must not be an error: %v", flow, resp.Diagnostics.Errors())
+			assert.NotEmpty(t, resp.Diagnostics.Warnings(), "expected a warning for auth_method on %s flow", flow)
+		})
+	}
+}
+
+// TestValidateConfig_AuthMethodOnAuthScopedFlow_NoWarn verifies that setting
+// auth_method on login/registration/settings does not warn.
+func TestValidateConfig_AuthMethodOnAuthScopedFlow_NoWarn(t *testing.T) {
+	for _, flow := range []string{"login", "registration", "settings"} {
+		t.Run(flow, func(t *testing.T) {
+			r := &ActionResource{}
+			ctx := context.Background()
+
+			req := buildActionTestConfig(t, ActionResourceModel{
+				Flow:       types.StringValue(flow),
+				Timing:     types.StringValue("after"),
+				AuthMethod: types.StringValue("password"),
+				URL:        types.StringValue("https://example.com/webhook"),
+			})
+			var resp resource.ValidateConfigResponse
+			r.ValidateConfig(ctx, req, &resp)
+
+			assert.Empty(t, resp.Diagnostics.Warnings(), "did not expect a warning for auth_method on %s flow: %v", flow, resp.Diagnostics.Warnings())
+		})
+	}
+}
+
+// TestValidateConfig_NoAuthMethodOnVerification_NoWarn verifies that the common
+// case (auth_method unset, defaulted by the schema) does not warn — only an
+// explicit value does.
+func TestValidateConfig_NoAuthMethodOnVerification_NoWarn(t *testing.T) {
+	r := &ActionResource{}
+	ctx := context.Background()
+
+	req := buildActionTestConfig(t, ActionResourceModel{
+		Flow:   types.StringValue("verification"),
+		Timing: types.StringValue("after"),
+		URL:    types.StringValue("https://example.com/webhook"),
+		// AuthMethod left null — the schema default applies after validation.
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.Empty(t, resp.Diagnostics.Warnings(), "did not expect a warning when auth_method is unset: %v", resp.Diagnostics.Warnings())
+}
+
 // TestValidateConfig_NoWebhookAuth passes when no webhook auth is configured.
 func TestValidateConfig_NoWebhookAuth(t *testing.T) {
 	r := &ActionResource{}

--- a/templates/resources/action.md.tmpl
+++ b/templates/resources/action.md.tmpl
@@ -126,7 +126,7 @@ terraform import ory_action.validate \
 1. **project_id**: Settings → General → Project ID
 2. **flow**: The flow type (login, registration, recovery, settings, verification)
 3. **timing**: "before" or "after"
-4. **auth_method**: for `login`/`registration`/`settings` "after" hooks, one of password, oidc, code, webauthn, passkey, totp, lookup_secret. For `recovery`/`verification` "after" hooks it is ignored — use `password` as a placeholder.
+4. **auth_method**: for `login`/`registration`/`settings` "after" hooks, one of password, oidc, code, webauthn, passkey, totp, lookup_secret. For `recovery`/`verification` "after" hooks the value is ignored, but the import ID format still requires this segment — use `password` to match the provider default and avoid a post-import diff (keep `auth_method` omitted from the resource configuration itself).
 5. **method**: The HTTP method (POST, GET, PUT, PATCH, DELETE)
 6. **url**: The exact webhook URL - must match exactly including protocol and trailing slashes
 

--- a/templates/resources/action.md.tmpl
+++ b/templates/resources/action.md.tmpl
@@ -19,7 +19,7 @@ Actions allow you to trigger webhooks at specific points in identity flows (logi
 
 ## Authentication Methods
 
-The `auth_method` attribute specifies which authentication method triggers the webhook. This is only used for `timing = "after"` webhooks.
+The `auth_method` attribute specifies which authentication method triggers the webhook. It applies only to `timing = "after"` webhooks on the `login`, `registration`, and `settings` flows.
 
 | Value | Description |
 |-------|-------------|
@@ -31,7 +31,7 @@ The `auth_method` attribute specifies which authentication method triggers the w
 | `totp` | Time-based one-time password |
 | `lookup_secret` | Recovery/backup codes |
 
-~> **Note:** `auth_method` is only used for `timing = "after"` webhooks. For `timing = "before"` hooks, the webhook runs before any authentication method is invoked.
+~> **Note:** `auth_method` only applies to `timing = "after"` webhooks on the `login`, `registration`, and `settings` flows. The `recovery` and `verification` flows are **not** scoped by authentication method — their after-hooks always run — so `auth_method` is ignored for them and should be omitted. For `timing = "before"` hooks, the webhook runs before any authentication method is invoked.
 
 ## Webhook Authentication
 
@@ -126,7 +126,7 @@ terraform import ory_action.validate \
 1. **project_id**: Settings → General → Project ID
 2. **flow**: The flow type (login, registration, recovery, settings, verification)
 3. **timing**: "before" or "after"
-4. **auth_method** (for "after" only): password, oidc, code, webauthn, passkey, totp, lookup_secret
+4. **auth_method**: for `login`/`registration`/`settings` "after" hooks, one of password, oidc, code, webauthn, passkey, totp, lookup_secret. For `recovery`/`verification` "after" hooks it is ignored — use `password` as a placeholder.
 5. **method**: The HTTP method (POST, GET, PUT, PATCH, DELETE)
 6. **url**: The exact webhook URL - must match exactly including protocol and trailing slashes
 


### PR DESCRIPTION
## Description

`ory_action` resources for the `verification` and `recovery` flows with `timing = "after"` always failed to create with:

```
Error: Error Verifying Action

Hook not found in PatchProject response for verification/after/password with URL https://.../webhook/verification/after
```

The `password` segment is surprising because the configuration never sets `auth_method`.

**Root cause:** `auth_method` defaults to `"password"`, and for `timing = "after"` the provider built the hook path with the auth-method level baked in (`.../flows/<flow>/after/<auth_method>/hooks`). That layout only exists for the `login`, `registration`, and `settings` flows. The `recovery` and `verification` flows have no per-auth-method `after` sub-objects — their after-hooks live in a single flat array at `.../<flow>/after/hooks`. When the provider PATCHed to `.../verification/after/password/hooks`, the Ory API returned `200 OK` but silently dropped the unknown `password` sub-key, so the webhook was never persisted. The subsequent verify read could not find the hook and reported `Hook not found in PatchProject response`.

**Fix:**
- Make `hookPath` and `getHooksFromProject` flow-aware via a new `flowSupportsAuthMethod` helper. The `recovery` and `verification` flows now read and write `.../after/hooks` and ignore `auth_method`. The `login`, `registration`, and `settings` flows are unchanged.
- Add a `ValidateConfig` warning when `auth_method` is set explicitly on a flow that does not support it, so users are not surprised that the value is ignored.
- Fix the bundled `sync_verified` example (it demonstrated the broken usage `flow = "verification"` with `auth_method = "code"`) and clarify the docs and attribute description.

## Related Issues

Fixes #241

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

**Unit tests** (`internal/resources/action`): added `hooks_test.go` covering `flowSupportsAuthMethod`, `hookPath`, and `getHooksFromProject` for all flow/timing combinations, plus `ValidateConfig` warning tests.

**Acceptance tests** (run against a live staging project): added `TestAccActionResource_verificationFlow` (create, read, update, import, delete) and `TestAccActionResource_recoveryFlow` (create, read, import). All existing action tests continue to pass.

```
--- PASS: TestAccActionResource_verificationFlow (10.61s)
--- PASS: TestAccActionResource_recoveryFlow (7.60s)
ok  github.com/ory/terraform-provider-ory/internal/resources/action  78.932s
```

**Manual API verification:** confirmed against the Console API that `verification.after`/`recovery.after` expose only a flat `hooks` array, that a PATCH to `.../verification/after/password/hooks` returns `200` but drops the hook, and that a PATCH to `.../verification/after/hooks` persists it correctly.

## Screenshots/Output

Flow structure from a live project (note `recovery`/`verification` have no auth-method keys):

```
login.after        -> code, hooks, lookup_secret, oidc, passkey, password, saml, totp, webauthn
registration.after -> code, hooks, oidc, passkey, password, saml, webauthn
settings.after     -> hooks, lookup_secret, oidc, passkey, password, profile, saml, totp, webauthn
recovery.after     -> hooks
verification.after -> hooks
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of `auth_method` attribute for recovery and verification webhooks. The attribute is now correctly ignored for these flows, and validation warnings alert users when explicitly set on unsupported flows.

* **Documentation**
  * Updated documentation and examples to clarify that `auth_method` only applies to `login`, `registration`, and `settings` flows. Recovery and verification flows no longer require this attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->