### PR TITLE
feat: add selfservice_methods_deviceauthn_enabled to project config

### DIFF
--- a/docs/resources/project_config.md
+++ b/docs/resources/project_config.md
@@ -638,6 +638,7 @@ terraform plan  # verify no changes
 - `selfservice_methods_code_mfa_enabled` (Boolean) Enable the code method as a second factor for MFA. When enabled, users can use one-time codes as a second authentication factor.
 - `selfservice_methods_code_passwordless_enabled` (Boolean) Enable passwordless login via the code method.
 - `selfservice_methods_code_passwordless_login_fallback_enabled` (Boolean) Allow code-based login as a fallback for users registered with other methods.
+- `selfservice_methods_deviceauthn_enabled` (Boolean) Enable device authentication.
 - `selfservice_methods_link_config_base_url` (String) Base URL for recovery, verification, and login links. Leave empty for automatic detection.
 - `selfservice_methods_link_config_lifespan` (String) Lifespan of magic links (e.g. '1h').
 - `selfservice_methods_link_enabled` (Boolean) Enable the magic link authentication method.

--- a/internal/codegen/mappings.yaml
+++ b/internal/codegen/mappings.yaml
@@ -351,6 +351,12 @@ attributes:
     deprecated_name: enable_passkey
     deprecated_go_field: EnablePasskey
 
+  - name: selfservice_methods_deviceauthn_enabled
+    go_field: SelfserviceMethodsDeviceauthnEnabled
+    type: bool
+    openapi_property: kratos_selfservice_methods_deviceauthn_enabled
+    description: "Enable device authentication."
+
   - name: selfservice_methods_lookup_secret_enabled
     go_field: SelfserviceMethodsLookupSecretEnabled
     type: bool

--- a/internal/resources/projectconfig/patches_gen.go
+++ b/internal/resources/projectconfig/patches_gen.go
@@ -177,6 +177,7 @@ func simpleBoolPatchEntries(plan *ProjectConfigResourceModel) []BoolPatchEntry {
 		{&plan.SelfserviceMethodsTOTPEnabled, &plan.EnableTOTP, "/services/identity/config/selfservice/methods/totp/enabled"},
 		{&plan.SelfserviceMethodsWebAuthnEnabled, &plan.EnableWebAuthn, "/services/identity/config/selfservice/methods/webauthn/enabled"},
 		{&plan.SelfserviceMethodsPasskeyEnabled, &plan.EnablePasskey, "/services/identity/config/selfservice/methods/passkey/enabled"},
+		{&plan.SelfserviceMethodsDeviceauthnEnabled, nil, "/services/identity/config/selfservice/methods/deviceauthn/enabled"},
 		{&plan.SelfserviceMethodsLookupSecretEnabled, &plan.EnableLookupSecret, "/services/identity/config/selfservice/methods/lookup_secret/enabled"},
 		{&plan.SelfserviceMethodsProfileEnabled, &plan.EnableProfile, "/services/identity/config/selfservice/methods/profile/enabled"},
 		{&plan.SelfserviceMethodsCodeConfigMissingCredentialFallbackEnabled, &plan.CodeMissingCredentialFallbackEnabled, "/services/identity/config/selfservice/methods/code/config/missing_credential_fallback_enabled"},

--- a/internal/resources/projectconfig/read_gen.go
+++ b/internal/resources/projectconfig/read_gen.go
@@ -443,6 +443,7 @@ func identityBoolReadEntries(state *ProjectConfigResourceModel) []BoolReadEntry 
 		{&state.SelfserviceMethodsTOTPEnabled, &state.EnableTOTP, []string{"selfservice", "methods", "totp", "enabled"}},
 		{&state.SelfserviceMethodsWebAuthnEnabled, &state.EnableWebAuthn, []string{"selfservice", "methods", "webauthn", "enabled"}},
 		{&state.SelfserviceMethodsPasskeyEnabled, &state.EnablePasskey, []string{"selfservice", "methods", "passkey", "enabled"}},
+		{&state.SelfserviceMethodsDeviceauthnEnabled, nil, []string{"selfservice", "methods", "deviceauthn", "enabled"}},
 		{&state.SelfserviceMethodsLookupSecretEnabled, &state.EnableLookupSecret, []string{"selfservice", "methods", "lookup_secret", "enabled"}},
 		{&state.SelfserviceMethodsProfileEnabled, &state.EnableProfile, []string{"selfservice", "methods", "profile", "enabled"}},
 		{&state.SelfserviceMethodsCodeConfigMissingCredentialFallbackEnabled, &state.CodeMissingCredentialFallbackEnabled, []string{"selfservice", "methods", "code", "config", "missing_credential_fallback_enabled"}},

--- a/internal/resources/projectconfig/resource.go
+++ b/internal/resources/projectconfig/resource.go
@@ -364,6 +364,7 @@ type ProjectConfigResourceModel struct {
 	SelfserviceMethodsTOTPEnabled              types.Bool `tfsdk:"selfservice_methods_totp_enabled"`
 	SelfserviceMethodsWebAuthnEnabled          types.Bool `tfsdk:"selfservice_methods_webauthn_enabled"`
 	SelfserviceMethodsPasskeyEnabled           types.Bool `tfsdk:"selfservice_methods_passkey_enabled"`
+	SelfserviceMethodsDeviceauthnEnabled       types.Bool `tfsdk:"selfservice_methods_deviceauthn_enabled"`
 	SelfserviceMethodsLookupSecretEnabled      types.Bool `tfsdk:"selfservice_methods_lookup_secret_enabled"`
 	SelfserviceMethodsProfileEnabled           types.Bool `tfsdk:"selfservice_methods_profile_enabled"`
 

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -259,6 +259,49 @@ func TestAccProjectConfigResource_codeMFA(t *testing.T) {
 	})
 }
 
+func TestAccProjectConfigResource_deviceAuthn(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create with device authentication enabled
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/deviceauthn.tf.tmpl", map[string]string{"DeviceAuthnEnabled": "true"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_project_config.test", "id"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_methods_deviceauthn_enabled", "true"),
+				),
+			},
+			// ImportState — config fields are ignored because import only sets
+			// id/project_id; Read only refreshes fields that are non-null in
+			// state, so config attributes won't be populated until apply.
+			{
+				ResourceName:      "ory_project_config.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"selfservice_methods_deviceauthn_enabled",
+					"cors_enabled",
+					"smtp_connection_uri",
+				},
+			},
+			// Update to disabled
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/deviceauthn.tf.tmpl", map[string]string{"DeviceAuthnEnabled": "false"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_methods_deviceauthn_enabled", "false"),
+				),
+			},
+			// Verify no perpetual diff
+			{
+				Config:             acctest.LoadTestConfig(t, "testdata/deviceauthn.tf.tmpl", map[string]string{"DeviceAuthnEnabled": "false"}),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestAccProjectConfigResource_oidc(t *testing.T) {
 	acctest.RequireSocialProviderTests(t)
 	resource.Test(t, resource.TestCase{

--- a/internal/resources/projectconfig/schema_gen.go
+++ b/internal/resources/projectconfig/schema_gen.go
@@ -347,6 +347,10 @@ func simpleSchemaAttributes() map[string]schema.Attribute {
 			Optional:           true,
 			DeprecationMessage: "Use selfservice_methods_passkey_enabled instead. This attribute will be removed in a future major version.",
 		},
+		"selfservice_methods_deviceauthn_enabled": schema.BoolAttribute{
+			Description: "Enable device authentication.",
+			Optional:    true,
+		},
 		"selfservice_methods_lookup_secret_enabled": schema.BoolAttribute{
 			Description: "Enable backup/recovery codes.",
 			Optional:    true,

--- a/internal/resources/projectconfig/testdata/deviceauthn.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/deviceauthn.tf.tmpl
@@ -1,0 +1,3 @@
+resource "ory_project_config" "test" {
+  selfservice_methods_deviceauthn_enabled = [[ .DeviceAuthnEnabled ]]
+}


### PR DESCRIPTION
## Description

Adds the `selfservice_methods_deviceauthn_enabled` boolean attribute to the `ory_project_config` resource. It maps to the Ory Kratos `selfservice.methods.deviceauthn.enabled` setting via the JSON Patch path `/services/identity/config/selfservice/methods/deviceauthn/enabled`.

The property was surfaced by the OpenAPI codegen drift detection. This change adds the `mappings.yaml` entry and the `ProjectConfigResourceModel` field, regenerates the schema/patch/read tables, refreshes the generated docs, and adds acceptance test coverage. It completes the review checklist (attribute naming, description, type, and tests) left open by the auto-generated #247, which it supersedes.

## Related Issues

Supersedes #247.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

First verified directly against the staging Console API that a JSON Patch to `/services/identity/config/selfservice/methods/deviceauthn/enabled` persists the value. Then added and ran `TestAccProjectConfigResource_deviceAuthn` against a live project, covering create, import, update, and a plan-only no-drift check. Unit tests (`make test-short`), `golangci-lint`, `govulncheck`, `gosec`, and `gitleaks` all pass. Test resources were reset to their original state afterward.

## Screenshots/Output

```
--- PASS: TestAccProjectConfigResource_deviceAuthn (9.74s)
PASS
ok      github.com/ory/terraform-provider-ory/internal/resources/projectconfig  10.463s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added configurable device authentication support, enabling users to toggle device authentication methods within project settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->