### PR TITLE
fix: apply account experience logo, favicon, and theme variables correctly

### DIFF
--- a/docs/resources/project_config.md
+++ b/docs/resources/project_config.md
@@ -98,8 +98,18 @@ resource "ory_project_config" "secure" {
   ]
 
   # Account Experience Branding
-  # (removed: account_experience_name, account_experience_logo_url, account_experience_favicon_url)
+  # Logos/favicons must be inline data URIs (the API does not fetch remote
+  # URLs), e.g. "data:image/png;base64,${filebase64("logo.png")}".
+  # Theme variables are maps of color tokens (see the AccountExperienceColors
+  # API model) to CSS color values.
   account_experience_default_locale = "en"
+  # account_experience_logo_light    = "data:image/png;base64,${filebase64("${path.module}/assets/logo.png")}"
+  # account_experience_favicon_light = "data:image/png;base64,${filebase64("${path.module}/assets/favicon.png")}"
+  # account_experience_theme_variables_light = {
+  #   ax_background_default             = "#fafafa"
+  #   brand_500                         = "#0066ff"
+  #   button_primary_background_default = "#0066ff"
+  # }
 
   # OAuth2 Token Lifespans
   oauth2_ttl_access_token          = "1h0m0s"
@@ -386,6 +396,40 @@ When `true`, the provider adds the `show_verification_ui` hook to the correspond
 
 To require a verified address before a user can log in (the "Require verified address for login" toggle in the Ory Console), set `feature_flags_legacy_require_verified_login_error = true`. When that flag is `false`, an unverified user is shown the `show_verification_ui` continuation step instead of receiving a form error.
 
+## Account Experience Branding
+
+The hosted Account Experience pages (login, registration, recovery, ...) can be branded with a logo, favicon, and theme colors.
+
+**Logos and favicons** (`account_experience_logo_light`, `account_experience_logo_dark`, `account_experience_favicon_light`, `account_experience_favicon_dark`) must be provided as an inline data URI — the Ory API does not fetch remote URLs. Use [`filebase64`](https://developer.hashicorp.com/terraform/language/functions/filebase64) to embed a local image:
+
+```hcl
+resource "ory_project_config" "main" {
+  account_experience_logo_light    = "data:image/png;base64,${filebase64("${path.module}/assets/logo.png")}"
+  account_experience_favicon_light = "data:image/png;base64,${filebase64("${path.module}/assets/favicon.png")}"
+}
+```
+
+Supported content types: `image/png`, `image/svg+xml`, `image/x-icon`, `image/vnd.microsoft.icon`, `image/gif`, `image/jpeg`, `image/webp`. The API uploads the image and serves it from a content-addressed storage URL; the provider compares that URL's content hash against your data URI, so an unchanged image never shows a diff. Set the attribute to an empty string (`""`) to remove the image.
+
+**Theme colors** (`account_experience_theme_variables_light`, `account_experience_theme_variables_dark`) are maps of color tokens to CSS color values:
+
+```hcl
+resource "ory_project_config" "main" {
+  account_experience_theme_variables_light = {
+    ax_background_default             = "#fafafa"
+    brand_500                         = "#0066ff"
+    button_primary_background_default = "#0066ff"
+    button_primary_background_hover   = "#0052cc"
+  }
+}
+```
+
+Valid tokens are the fields of the [`AccountExperienceColors`](https://github.com/ory/client-go/blob/master/docs/AccountExperienceColors.md) API model (for example `ax_background_default`, `brand_50` through `brand_950`, `button_primary_*`, `input_*`, `interface_*`). The Ory Console theme editor (Branding → Theme) is an easy way to discover token names: configure colors there, then run `ory get project <id> --format json` and copy the `theme_variables_light`/`theme_variables_dark` objects.
+
+~> **Note:** The API silently discards unrecognized color tokens. If a token you set keeps reappearing in `terraform plan`, check its spelling against the model linked above.
+
+Set a theme map to `{}` to reset all colors to the defaults.
+
 ## Clearing Return URLs
 
 To explicitly clear `default_return_url` and `allowed_return_urls` (e.g., for native-only flows with no browser redirects), set them to empty values:
@@ -428,15 +472,15 @@ terraform plan  # verify no changes
 
 - `account_experience_default_locale` (String) Default locale for the hosted login UI (e.g., 'en', 'de').
 - `account_experience_enabled_locales` (List of String) Enabled locales for the hosted login UI.
-- `account_experience_favicon_dark` (String) URL for the dark theme favicon in the hosted login UI.
-- `account_experience_favicon_light` (String) URL for the light theme favicon in the hosted login UI.
+- `account_experience_favicon_dark` (String) Favicon for the hosted Account Experience UI (dark theme). Must be an inline data URI (e.g. data:image/png;base64,...) or a storage URL previously returned by the API. The API uploads the image and serves it from a content-addressed storage URL; the provider matches that URL against the data URI by content hash to detect drift. Set to an empty string to remove.
+- `account_experience_favicon_light` (String) Favicon for the hosted Account Experience UI (light theme). Must be an inline data URI (e.g. data:image/png;base64,...) or a storage URL previously returned by the API. The API uploads the image and serves it from a content-addressed storage URL; the provider matches that URL against the data URI by content hash to detect drift. Set to an empty string to remove.
 - `account_experience_hide_ory_branding` (Boolean) Whether to hide the Ory branding badge on the account experience.
 - `account_experience_hide_registration_link` (Boolean) Whether to hide the registration link on the account experience login card.
 - `account_experience_locale_behavior` (String) Locale behavior: 'respect_accept_language' or 'force_default'.
-- `account_experience_logo_dark` (String) URL for the dark theme logo in the hosted login UI.
-- `account_experience_logo_light` (String) URL for the light theme logo in the hosted login UI.
-- `account_experience_theme_variables_dark` (String) URL for dark theme CSS variables in the hosted login UI.
-- `account_experience_theme_variables_light` (String) URL for light theme CSS variables in the hosted login UI.
+- `account_experience_logo_dark` (String) Logo for the hosted Account Experience UI (dark theme). Must be an inline data URI (e.g. data:image/png;base64,...) or a storage URL previously returned by the API. The API uploads the image and serves it from a content-addressed storage URL; the provider matches that URL against the data URI by content hash to detect drift. Set to an empty string to remove.
+- `account_experience_logo_light` (String) Logo for the hosted Account Experience UI (light theme). Must be an inline data URI (e.g. data:image/png;base64,...) or a storage URL previously returned by the API. The API uploads the image and serves it from a content-addressed storage URL; the provider matches that URL against the data URI by content hash to detect drift. Set to an empty string to remove.
+- `account_experience_theme_variables_dark` (Map of String) Theme color variables for the hosted Account Experience UI (dark theme). Map of color tokens (e.g. ax_background_default, brand_500, button_primary_background_default) to CSS color values. Keys not recognized by the API are discarded. Set to an empty map to reset.
+- `account_experience_theme_variables_light` (Map of String) Theme color variables for the hosted Account Experience UI (light theme). Map of color tokens (e.g. ax_background_default, brand_500, button_primary_background_default) to CSS color values. Keys not recognized by the API are discarded. Set to an empty map to reset.
 - `allowed_return_urls` (List of String) List of allowed return URLs.
 - `code_lifespan` (String, Deprecated) Lifespan of the code method's one-time codes (e.g., '15m0s'). Controls how long a code remains valid after being issued.
 - `code_mfa_enabled` (Boolean, Deprecated) Enable the code method as a second factor for MFA. When enabled, users can use one-time codes as a second authentication factor.

--- a/examples/resources/ory_project_config/resource.tf
+++ b/examples/resources/ory_project_config/resource.tf
@@ -75,8 +75,18 @@ resource "ory_project_config" "secure" {
   ]
 
   # Account Experience Branding
-  # (removed: account_experience_name, account_experience_logo_url, account_experience_favicon_url)
+  # Logos/favicons must be inline data URIs (the API does not fetch remote
+  # URLs), e.g. "data:image/png;base64,${filebase64("logo.png")}".
+  # Theme variables are maps of color tokens (see the AccountExperienceColors
+  # API model) to CSS color values.
   account_experience_default_locale = "en"
+  # account_experience_logo_light    = "data:image/png;base64,${filebase64("${path.module}/assets/logo.png")}"
+  # account_experience_favicon_light = "data:image/png;base64,${filebase64("${path.module}/assets/favicon.png")}"
+  # account_experience_theme_variables_light = {
+  #   ax_background_default             = "#fafafa"
+  #   brand_500                         = "#0066ff"
+  #   button_primary_background_default = "#0066ff"
+  # }
 
   # OAuth2 Token Lifespans
   oauth2_ttl_access_token          = "1h0m0s"

--- a/internal/codegen/cmd/generate/main.go
+++ b/internal/codegen/cmd/generate/main.go
@@ -870,6 +870,16 @@ func excludedProperties() map[string]bool {
 		"account_experience_default_locale":                     true, // → account_experience_default_locale (in mappings)
 		"kratos_oauth2_provider_headers":                        true, // → oauth2_provider_headers (in mappings)
 
+		// Account experience images — handled by custom code in resource.go.
+		// The spec's governs descriptions point at favicon_*/logo_* config keys,
+		// but the API stores them at favicon_*_url/logo_*_url, expects an inline
+		// data URI on write, and returns a content-addressed storage URL on read
+		// (filename is sha512 of the image bytes). See issue #250.
+		"account_experience_favicon_dark":  true, // → account_experience_favicon_dark (custom)
+		"account_experience_favicon_light": true, // → account_experience_favicon_light (custom)
+		"account_experience_logo_dark":     true, // → account_experience_logo_dark (custom)
+		"account_experience_logo_light":    true, // → account_experience_logo_light (custom)
+
 		// Courier templates — managed by the dedicated `ory_email_template`
 		// resource. They are not viable as simple-string codegen entries
 		// because writes require `base64://` encoding and reads return a

--- a/internal/codegen/mappings.yaml
+++ b/internal/codegen/mappings.yaml
@@ -1096,19 +1096,11 @@ attributes:
     openapi_property: account_experience_enabled_locales
     description: "Enabled locales for the hosted login UI."
 
-  - name: account_experience_favicon_dark
-    go_field: AccountExperienceFaviconDark
-    type: string
-    openapi_property: account_experience_favicon_dark
-    description: "URL for the dark theme favicon in the hosted login UI."
-    skip_empty_read: true
-
-  - name: account_experience_favicon_light
-    go_field: AccountExperienceFaviconLight
-    type: string
-    openapi_property: account_experience_favicon_light
-    description: "URL for the light theme favicon in the hosted login UI."
-    skip_empty_read: true
+  # account_experience_favicon_dark/light and account_experience_logo_dark/light
+  # are handled by custom code in resource.go. The spec's governs descriptions
+  # point at favicon_*/logo_* config keys, but the API actually stores them at
+  # favicon_*_url/logo_*_url, expects an inline data URI on write, and returns a
+  # content-addressed storage URL on read (sha512 of the image bytes).
 
   - name: account_experience_locale_behavior
     go_field: AccountExperienceLocaleBehavior
@@ -1117,33 +1109,17 @@ attributes:
     description: "Locale behavior: 'respect_accept_language' or 'force_default'."
     skip_empty_read: true
 
-  - name: account_experience_logo_dark
-    go_field: AccountExperienceLogoDark
-    type: string
-    openapi_property: account_experience_logo_dark
-    description: "URL for the dark theme logo in the hosted login UI."
-    skip_empty_read: true
-
-  - name: account_experience_logo_light
-    go_field: AccountExperienceLogoLight
-    type: string
-    openapi_property: account_experience_logo_light
-    description: "URL for the light theme logo in the hosted login UI."
-    skip_empty_read: true
-
   - name: account_experience_theme_variables_dark
     go_field: AccountExperienceThemeVariablesDark
-    type: string
+    type: map_string
     openapi_property: account_experience_theme_variables_dark
-    description: "URL for dark theme CSS variables in the hosted login UI."
-    skip_empty_read: true
+    description: "Theme color variables for the hosted Account Experience UI (dark theme). Map of color tokens (e.g. ax_background_default, brand_500, button_primary_background_default) to CSS color values. Keys not recognized by the API are discarded. Set to an empty map to reset."
 
   - name: account_experience_theme_variables_light
     go_field: AccountExperienceThemeVariablesLight
-    type: string
+    type: map_string
     openapi_property: account_experience_theme_variables_light
-    description: "URL for light theme CSS variables in the hosted login UI."
-    skip_empty_read: true
+    description: "Theme color variables for the hosted Account Experience UI (light theme). Map of color tokens (e.g. ax_background_default, brand_500, button_primary_background_default) to CSS color values. Keys not recognized by the API are discarded. Set to an empty map to reset."
 
   - name: disable_account_experience_welcome_screen
     go_field: DisableAccountExperienceWelcomeScreen

--- a/internal/helpers/contenthash.go
+++ b/internal/helpers/contenthash.go
@@ -1,0 +1,49 @@
+package helpers
+
+import (
+	"crypto/sha512"
+	"encoding/hex"
+	"net/url"
+	pathpkg "path"
+	"strings"
+)
+
+// HashFromURL extracts the hex hash portion from a storage URL filename.
+// The Ory backoffice stores uploaded content (email templates, account
+// experience images) at storage URLs whose filename is the lowercase hex
+// SHA-512 of the raw content plus an extension (.txt/.html/.png/...).
+// Returns ("", false) if the URL is not in the expected shape.
+func HashFromURL(rawURL string) (string, bool) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", false
+	}
+	base := pathpkg.Base(u.Path)
+	ext := pathpkg.Ext(base)
+	hash := strings.TrimSuffix(base, ext)
+	if len(hash) != 128 {
+		return "", false
+	}
+	for _, c := range hash {
+		switch {
+		case c >= '0' && c <= '9':
+		case c >= 'a' && c <= 'f':
+		case c >= 'A' && c <= 'F':
+		default:
+			return "", false
+		}
+	}
+	return hash, true
+}
+
+// URLHashMatchesContent reports whether the SHA-512 hex hash embedded in the
+// URL's filename matches the SHA-512 of the supplied content. When the hashes
+// match we know the API value equals `content` without an extra fetch.
+func URLHashMatchesContent(rawURL string, content []byte) bool {
+	hash, ok := HashFromURL(rawURL)
+	if !ok {
+		return false
+	}
+	sum := sha512.Sum512(content)
+	return strings.EqualFold(hash, hex.EncodeToString(sum[:]))
+}

--- a/internal/helpers/contenthash_test.go
+++ b/internal/helpers/contenthash_test.go
@@ -1,0 +1,89 @@
+package helpers
+
+import (
+	"crypto/sha512"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashFromURL(t *testing.T) {
+	t.Parallel()
+
+	hash128 := "3b22557ea88e8c133219b0706af495382d0b6df202966213ca9d72768f33cd22f58fa28297a0292b6dcc528705a43382d053f401f0568a77df96deeee3ef1e7d"
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+		ok   bool
+	}{
+		{
+			name: "txt-filename",
+			in:   "https://storage.example.com/templates/" + hash128 + ".txt",
+			want: hash128,
+			ok:   true,
+		},
+		{
+			name: "html-filename",
+			in:   "https://storage.example.com/templates/" + hash128 + ".html",
+			want: hash128,
+			ok:   true,
+		},
+		{
+			name: "png-filename",
+			in:   "https://storage.googleapis.com/bac-gcs-production/" + hash128 + ".png",
+			want: hash128,
+			ok:   true,
+		},
+		{
+			name: "uppercase-hex-accepted",
+			in:   "https://storage.example.com/" + "AB" + hash128[2:] + ".txt",
+			want: "AB" + hash128[2:],
+			ok:   true,
+		},
+		{
+			name: "not-a-url-style-string",
+			in:   "Hello world",
+			ok:   false,
+		},
+		{
+			name: "url-without-hash-filename",
+			in:   "https://storage.example.com/templates/some-other-file.txt",
+			ok:   false,
+		},
+		{
+			name: "short-hash",
+			in:   "https://storage.example.com/templates/" + hash128[:64] + ".txt",
+			ok:   false,
+		},
+		{
+			name: "non-hex-character",
+			in:   "https://storage.example.com/templates/" + "zz" + hash128[2:] + ".txt",
+			ok:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := HashFromURL(tc.in)
+			require.Equal(t, tc.ok, ok, "ok mismatch")
+			assert.Equal(t, tc.want, got, "hash mismatch")
+		})
+	}
+}
+
+func TestURLHashMatchesContent(t *testing.T) {
+	t.Parallel()
+
+	content := []byte("Hello {{ .Code }}")
+	sum := sha512.Sum512(content)
+	hexHash := hex.EncodeToString(sum[:])
+	url := "https://storage.example.com/templates/" + hexHash + ".txt"
+
+	assert.True(t, URLHashMatchesContent(url, content), "expected matching hash for known content")
+	assert.False(t, URLHashMatchesContent(url, []byte("different content")), "expected mismatch for different content")
+	assert.False(t, URLHashMatchesContent("not-a-storage-url", content), "expected mismatch for non-URL input")
+}

--- a/internal/resources/emailtemplate/resolve_test.go
+++ b/internal/resources/emailtemplate/resolve_test.go
@@ -11,78 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHashFromURL(t *testing.T) {
-	t.Parallel()
-
-	hash128 := "3b22557ea88e8c133219b0706af495382d0b6df202966213ca9d72768f33cd22f58fa28297a0292b6dcc528705a43382d053f401f0568a77df96deeee3ef1e7d"
-
-	cases := []struct {
-		name string
-		in   string
-		want string
-		ok   bool
-	}{
-		{
-			name: "txt-filename",
-			in:   "https://storage.example.com/templates/" + hash128 + ".txt",
-			want: hash128,
-			ok:   true,
-		},
-		{
-			name: "html-filename",
-			in:   "https://storage.example.com/templates/" + hash128 + ".html",
-			want: hash128,
-			ok:   true,
-		},
-		{
-			name: "uppercase-hex-accepted",
-			in:   "https://storage.example.com/" + "AB" + hash128[2:] + ".txt",
-			want: "AB" + hash128[2:],
-			ok:   true,
-		},
-		{
-			name: "not-a-url-style-string",
-			in:   "Hello world",
-			ok:   false,
-		},
-		{
-			name: "url-without-hash-filename",
-			in:   "https://storage.example.com/templates/some-other-file.txt",
-			ok:   false,
-		},
-		{
-			name: "short-hash",
-			in:   "https://storage.example.com/templates/" + hash128[:64] + ".txt",
-			ok:   false,
-		},
-		{
-			name: "non-hex-character",
-			in:   "https://storage.example.com/templates/" + "zz" + hash128[2:] + ".txt",
-			ok:   false,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got, ok := hashFromURL(tc.in)
-			require.Equal(t, tc.ok, ok, "ok mismatch")
-			assert.Equal(t, tc.want, got, "hash mismatch")
-		})
-	}
-}
-
-func TestUrlHashMatchesContent(t *testing.T) {
-	t.Parallel()
-
-	content := "Hello {{ .Code }}"
-	sum := sha512.Sum512([]byte(content))
-	hexHash := hex.EncodeToString(sum[:])
-	url := "https://storage.example.com/templates/" + hexHash + ".txt"
-
-	assert.True(t, urlHashMatchesContent(url, content), "expected matching hash for known content")
-	assert.False(t, urlHashMatchesContent(url, "different content"), "expected mismatch for different content")
-	assert.False(t, urlHashMatchesContent("not-a-storage-url", content), "expected mismatch for non-URL input")
-}
+// Tests for the storage-URL hash helpers live in internal/helpers
+// (contenthash_test.go) since the logic moved there to be shared with
+// the project_config account experience image handling.
 
 func TestIsHTTPSURL(t *testing.T) {
 	t.Parallel()

--- a/internal/resources/emailtemplate/resource.go
+++ b/internal/resources/emailtemplate/resource.go
@@ -2,13 +2,10 @@ package emailtemplate
 
 import (
 	"context"
-	"crypto/sha512"
 	"encoding/base64"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/url"
-	pathpkg "path"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -273,45 +270,6 @@ var urlContentFetcher = func(ctx context.Context, rawURL string) (string, error)
 	return string(body), nil
 }
 
-// urlHashMatchesContent reports whether the SHA-512 hex hash embedded in the
-// URL's filename matches the SHA-512 of the supplied content. The Ory backoffice
-// stores template values at storage URLs whose filename is the lowercase hex
-// SHA-512 of the raw content plus a known extension (.txt/.html). When the
-// hashes match we know the API value equals `content` without an extra fetch.
-func urlHashMatchesContent(rawURL, content string) bool {
-	hash, ok := hashFromURL(rawURL)
-	if !ok {
-		return false
-	}
-	sum := sha512.Sum512([]byte(content))
-	return strings.EqualFold(hash, hex.EncodeToString(sum[:]))
-}
-
-// hashFromURL extracts the hex hash portion from a storage URL filename.
-// Returns ("", false) if the URL is not in the expected shape.
-func hashFromURL(rawURL string) (string, bool) {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return "", false
-	}
-	base := pathpkg.Base(u.Path)
-	ext := pathpkg.Ext(base)
-	hash := strings.TrimSuffix(base, ext)
-	if len(hash) != 128 {
-		return "", false
-	}
-	for _, c := range hash {
-		switch {
-		case c >= '0' && c <= '9':
-		case c >= 'a' && c <= 'f':
-		case c >= 'A' && c <= 'F':
-		default:
-			return "", false
-		}
-	}
-	return hash, true
-}
-
 // resolveStoredTemplate returns the canonical decoded template value for a
 // field returned by the API. Behavior:
 //   - If the API returned an empty value, return "" so an out-of-band reset
@@ -336,7 +294,7 @@ func resolveStoredTemplate(ctx context.Context, apiValue, stateValue string) str
 	if !isHTTPSURL(apiValue) {
 		return apiValue
 	}
-	if stateValue != "" && urlHashMatchesContent(apiValue, stateValue) {
+	if stateValue != "" && helpers.URLHashMatchesContent(apiValue, []byte(stateValue)) {
 		return stateValue
 	}
 	fetched, err := urlContentFetcher(ctx, apiValue)

--- a/internal/resources/projectconfig/account_experience.go
+++ b/internal/resources/projectconfig/account_experience.go
@@ -32,8 +32,24 @@ import (
 // account experience logos and favicons (from the API's validation error).
 const axImageMIMETypes = `png|svg\+xml|x-icon|vnd\.microsoft\.icon|gif|jpeg|webp`
 
+// axImageValueRegex accepts the three shapes the Ory API allows for an account
+// experience image:
+//
+//   - an empty string (clears the image);
+//   - an inline data URI of a supported image type, which the API uploads;
+//   - a storage URL the API has already returned, whose filename stem is the
+//     lowercase hex SHA-512 of the image bytes (see helpers.HashFromURL).
+//
+// Plain remote URLs are rejected by the API (it sniffs the value's content
+// type rather than fetching the URL), so we reject them here too — surfacing
+// the error at plan time instead of deferring it to apply.
+const axStorageURLPattern = `https://[^\s]+/[0-9a-fA-F]{128}(\.[A-Za-z0-9]+)?(\?[^\s]*)?`
+
 var axImageValueRegex = regexp.MustCompile(
-	`^(|https://.+|data:image/(` + axImageMIMETypes + `);base64,[A-Za-z0-9+/]+={0,2})$`,
+	`^(` +
+		`|` + axStorageURLPattern +
+		`|data:image/(` + axImageMIMETypes + `);base64,[A-Za-z0-9+/]+={0,2}` +
+		`)$`,
 )
 
 // axImageField pairs a state/plan field with its config key under
@@ -66,8 +82,10 @@ func accountExperienceImageSchemaAttrs() map[string]schema.Attribute {
 			Validators: []validator.String{
 				stringvalidator.RegexMatches(
 					axImageValueRegex,
-					"must be empty, an https:// URL, or a data:image/<type>;base64,<data> URI "+
-						"(supported types: png, svg+xml, x-icon, vnd.microsoft.icon, gif, jpeg, webp)",
+					"must be empty, a storage URL previously returned by the Ory API, or a "+
+						"data:image/<type>;base64,<data> URI (supported types: png, svg+xml, "+
+						"x-icon, vnd.microsoft.icon, gif, jpeg, webp). Plain remote URLs are not "+
+						"accepted — embed the image as a data URI, e.g. with filebase64()",
 				),
 			},
 		}

--- a/internal/resources/projectconfig/account_experience.go
+++ b/internal/resources/projectconfig/account_experience.go
@@ -1,0 +1,152 @@
+package projectconfig
+
+import (
+	"encoding/base64"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	ory "github.com/ory/client-go"
+
+	"github.com/ory/terraform-provider-ory/internal/helpers"
+)
+
+// Account experience images (logo/favicon, light/dark) need custom handling
+// that the codegen can't express:
+//
+//   - The OpenAPI spec's governs descriptions point at favicon_*/logo_* config
+//     keys, but the API actually stores the values at favicon_*_url/logo_*_url.
+//     Patching the governs-derived paths succeeds (HTTP 200) but is silently
+//     ignored — the root cause of issue #250.
+//   - Writes must be an inline data URI (data:image/png;base64,...); plain
+//     remote URLs are rejected because the API sniffs the value's content type.
+//   - Reads return a content-addressed storage URL whose filename is the
+//     SHA-512 of the raw image bytes, so state (the data URI) never equals the
+//     API value. Drift is detected by comparing that hash against the hash of
+//     the data URI payload, mirroring ory_email_template.
+
+// axImageMIMETypes are the image content types accepted by the Ory API for
+// account experience logos and favicons (from the API's validation error).
+const axImageMIMETypes = `png|svg\+xml|x-icon|vnd\.microsoft\.icon|gif|jpeg|webp`
+
+var axImageValueRegex = regexp.MustCompile(
+	`^(|https://.+|data:image/(` + axImageMIMETypes + `);base64,[A-Za-z0-9+/]+={0,2})$`,
+)
+
+// axImageField pairs a state/plan field with its config key under
+// /services/account_experience/config/.
+type axImageField struct {
+	field *types.String
+	key   string
+}
+
+func accountExperienceImageFields(m *ProjectConfigResourceModel) []axImageField {
+	return []axImageField{
+		{&m.AccountExperienceFaviconDark, "favicon_dark_url"},
+		{&m.AccountExperienceFaviconLight, "favicon_light_url"},
+		{&m.AccountExperienceLogoDark, "logo_dark_url"},
+		{&m.AccountExperienceLogoLight, "logo_light_url"},
+	}
+}
+
+// accountExperienceImageSchemaAttrs returns the hand-written schema attributes
+// for the account experience image fields.
+func accountExperienceImageSchemaAttrs() map[string]schema.Attribute {
+	imageAttr := func(what, theme string) schema.StringAttribute {
+		return schema.StringAttribute{
+			Description: what + " for the hosted Account Experience UI (" + theme + " theme). " +
+				"Must be an inline data URI (e.g. data:image/png;base64,...) or a storage URL " +
+				"previously returned by the API. The API uploads the image and serves it from a " +
+				"content-addressed storage URL; the provider matches that URL against the data URI " +
+				"by content hash to detect drift. Set to an empty string to remove.",
+			Optional: true,
+			Validators: []validator.String{
+				stringvalidator.RegexMatches(
+					axImageValueRegex,
+					"must be empty, an https:// URL, or a data:image/<type>;base64,<data> URI "+
+						"(supported types: png, svg+xml, x-icon, vnd.microsoft.icon, gif, jpeg, webp)",
+				),
+			},
+		}
+	}
+	return map[string]schema.Attribute{
+		"account_experience_favicon_dark":  imageAttr("Favicon", "dark"),
+		"account_experience_favicon_light": imageAttr("Favicon", "light"),
+		"account_experience_logo_dark":     imageAttr("Logo", "dark"),
+		"account_experience_logo_light":    imageAttr("Logo", "light"),
+	}
+}
+
+// accountExperienceImagePatches returns the JSON Patch operations for the
+// account experience image fields. Values pass through unchanged: the API
+// accepts a data URI (which it uploads) or one of its own storage URLs, and
+// an empty string clears the image.
+func accountExperienceImagePatches(plan *ProjectConfigResourceModel) []ory.JsonPatch {
+	var patches []ory.JsonPatch
+	for _, e := range accountExperienceImageFields(plan) {
+		if !e.field.IsNull() && !e.field.IsUnknown() {
+			patches = append(patches, ory.JsonPatch{
+				Op:    "replace",
+				Path:  "/services/account_experience/config/" + e.key,
+				Value: e.field.ValueString(),
+			})
+		}
+	}
+	return patches
+}
+
+// readAccountExperienceImages reads the image fields from the API response
+// into state, using content-hash matching to avoid perpetual diffs.
+func readAccountExperienceImages(project *ory.Project, state *ProjectConfigResourceModel) {
+	if project.Services.AccountExperience == nil {
+		return
+	}
+	axConfig := project.Services.AccountExperience.Config
+	for _, e := range accountExperienceImageFields(state) {
+		if e.field.IsNull() {
+			continue // attribute not managed in this configuration
+		}
+		if apiValue, ok := getNestedString(axConfig, e.key); ok {
+			*e.field = resolveAccountExperienceImage(apiValue, e.field.ValueString())
+		}
+	}
+}
+
+// resolveAccountExperienceImage returns the state value to store for an image
+// field given the API value and the previous state value:
+//
+//   - API value equals state (storage-URL passthrough, or both empty): keep state.
+//   - State holds a data URI whose payload hash matches the hash embedded in
+//     the API's storage URL filename: the image is unchanged, keep state.
+//   - Anything else (cleared in Console, replaced out-of-band, malformed state):
+//     surface the API value so the next plan shows the drift.
+func resolveAccountExperienceImage(apiValue, stateValue string) types.String {
+	if apiValue == stateValue {
+		return types.StringValue(stateValue)
+	}
+	if payload, ok := dataURIPayload(stateValue); ok && helpers.URLHashMatchesContent(apiValue, payload) {
+		return types.StringValue(stateValue)
+	}
+	return types.StringValue(apiValue)
+}
+
+// dataURIPayload decodes the base64 payload of a data URI
+// (data:<mediatype>;base64,<data>). Returns (nil, false) when the value is
+// not a base64 data URI or the payload fails to decode.
+func dataURIPayload(s string) ([]byte, bool) {
+	if !strings.HasPrefix(s, "data:") {
+		return nil, false
+	}
+	meta, data, found := strings.Cut(s[len("data:"):], ",")
+	if !found || !strings.HasSuffix(meta, ";base64") {
+		return nil, false
+	}
+	decoded, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return nil, false
+	}
+	return decoded, true
+}

--- a/internal/resources/projectconfig/account_experience_test.go
+++ b/internal/resources/projectconfig/account_experience_test.go
@@ -1,0 +1,170 @@
+package projectconfig
+
+import (
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tinyPNG is a 1x1 transparent PNG used as image content in tests.
+var tinyPNG = mustDecodeBase64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==")
+
+func mustDecodeBase64(s string) []byte {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func storageURLFor(content []byte) string {
+	sum := sha512.Sum512(content)
+	return "https://storage.googleapis.com/bac-gcs-production/" + hex.EncodeToString(sum[:]) + ".png"
+}
+
+func dataURIFor(content []byte) string {
+	return "data:image/png;base64," + base64.StdEncoding.EncodeToString(content)
+}
+
+func TestDataURIPayload(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid png data uri decodes", func(t *testing.T) {
+		payload, ok := dataURIPayload(dataURIFor(tinyPNG))
+		require.True(t, ok)
+		assert.Equal(t, tinyPNG, payload)
+	})
+
+	t.Run("not a data uri", func(t *testing.T) {
+		_, ok := dataURIPayload("https://example.com/logo.png")
+		assert.False(t, ok)
+	})
+
+	t.Run("missing comma", func(t *testing.T) {
+		_, ok := dataURIPayload("data:image/png;base64")
+		assert.False(t, ok)
+	})
+
+	t.Run("not base64 encoded marker", func(t *testing.T) {
+		_, ok := dataURIPayload("data:image/svg+xml,<svg/>")
+		assert.False(t, ok)
+	})
+
+	t.Run("invalid base64 payload", func(t *testing.T) {
+		_, ok := dataURIPayload("data:image/png;base64,!!!not-base64!!!")
+		assert.False(t, ok)
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		_, ok := dataURIPayload("")
+		assert.False(t, ok)
+	})
+}
+
+func TestResolveAccountExperienceImage(t *testing.T) {
+	t.Parallel()
+
+	dataURI := dataURIFor(tinyPNG)
+	matchingURL := storageURLFor(tinyPNG)
+	otherURL := storageURLFor([]byte("different image bytes"))
+
+	t.Run("api equals state keeps state", func(t *testing.T) {
+		got := resolveAccountExperienceImage(matchingURL, matchingURL)
+		assert.Equal(t, types.StringValue(matchingURL), got)
+	})
+
+	t.Run("both empty keeps empty", func(t *testing.T) {
+		got := resolveAccountExperienceImage("", "")
+		assert.Equal(t, types.StringValue(""), got)
+	})
+
+	t.Run("storage url hash matches data uri keeps state", func(t *testing.T) {
+		got := resolveAccountExperienceImage(matchingURL, dataURI)
+		assert.Equal(t, types.StringValue(dataURI), got, "matching content hash must not produce drift")
+	})
+
+	t.Run("storage url hash mismatch surfaces api value", func(t *testing.T) {
+		got := resolveAccountExperienceImage(otherURL, dataURI)
+		assert.Equal(t, types.StringValue(otherURL), got, "image replaced out-of-band must surface drift")
+	})
+
+	t.Run("cleared in console surfaces empty", func(t *testing.T) {
+		got := resolveAccountExperienceImage("", dataURI)
+		assert.Equal(t, types.StringValue(""), got, "image cleared out-of-band must surface drift")
+	})
+
+	t.Run("state url differs from api url surfaces api value", func(t *testing.T) {
+		got := resolveAccountExperienceImage(otherURL, matchingURL)
+		assert.Equal(t, types.StringValue(otherURL), got)
+	})
+
+	t.Run("malformed state value surfaces api value", func(t *testing.T) {
+		got := resolveAccountExperienceImage(matchingURL, "data:image/png;base64,!!!")
+		assert.Equal(t, types.StringValue(matchingURL), got)
+	})
+}
+
+func TestAccountExperienceImagePatches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("null fields produce no patches", func(t *testing.T) {
+		plan := &ProjectConfigResourceModel{}
+		assert.Empty(t, accountExperienceImagePatches(plan))
+	})
+
+	t.Run("set fields patch the *_url config keys", func(t *testing.T) {
+		dataURI := dataURIFor(tinyPNG)
+		plan := &ProjectConfigResourceModel{
+			AccountExperienceLogoLight:   types.StringValue(dataURI),
+			AccountExperienceFaviconDark: types.StringValue(""),
+		}
+
+		patches := accountExperienceImagePatches(plan)
+		require.Len(t, patches, 2)
+
+		byPath := map[string]interface{}{}
+		for _, p := range patches {
+			assert.Equal(t, "replace", p.Op)
+			byPath[p.Path] = p.Value
+		}
+		assert.Equal(t, dataURI, byPath["/services/account_experience/config/logo_light_url"])
+		assert.Equal(t, "", byPath["/services/account_experience/config/favicon_dark_url"])
+	})
+}
+
+func TestAXImageValueRegex(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{
+		"",
+		"data:image/png;base64," + base64.StdEncoding.EncodeToString(tinyPNG),
+		"data:image/svg+xml;base64,PHN2Zy8+",
+		"data:image/x-icon;base64,AAAB",
+		"data:image/vnd.microsoft.icon;base64,AAAB",
+		"data:image/jpeg;base64,/9j/4A==",
+		"data:image/webp;base64,UklGRg==",
+		"data:image/gif;base64,R0lGODsbAAAA",
+		"https://storage.googleapis.com/bucket/abc.png",
+	}
+	for _, v := range valid {
+		assert.True(t, axImageValueRegex.MatchString(v), "expected valid: %q", v)
+	}
+
+	invalid := []string{
+		"http://example.com/logo.png",            // plain http
+		"iVBORw0KGgo=",                           // raw base64 without data: prefix
+		"data:image/png,plain",                   // not base64-encoded
+		"data:application/json;base64,e30=",      // not an image type
+		"data:image/tiff;base64,AAAB",            // unsupported image type
+		"data:image/png;base64,not base64 data!", // invalid base64 alphabet
+		"ftp://example.com/logo.png",
+	}
+	for _, v := range invalid {
+		assert.False(t, axImageValueRegex.MatchString(v), "expected invalid: %q", v)
+	}
+}

--- a/internal/resources/projectconfig/account_experience_test.go
+++ b/internal/resources/projectconfig/account_experience_test.go
@@ -149,14 +149,18 @@ func TestAXImageValueRegex(t *testing.T) {
 		"data:image/jpeg;base64,/9j/4A==",
 		"data:image/webp;base64,UklGRg==",
 		"data:image/gif;base64,R0lGODsbAAAA",
-		"https://storage.googleapis.com/bucket/abc.png",
+		// Storage URLs the API returns: filename stem is the sha512 hash.
+		storageURLFor(tinyPNG),
+		storageURLFor([]byte("another image")) + "?GoogleAccessId=x&Expires=1",
 	}
 	for _, v := range valid {
 		assert.True(t, axImageValueRegex.MatchString(v), "expected valid: %q", v)
 	}
 
 	invalid := []string{
-		"http://example.com/logo.png",            // plain http
+		"http://example.com/logo.png",                          // plain http
+		"https://example.com/logo.png",                         // generic remote URL, not a storage URL
+		"https://storage.googleapis.com/bucket/not-a-hash.png", // storage host but no sha512 filename
 		"iVBORw0KGgo=",                           // raw base64 without data: prefix
 		"data:image/png,plain",                   // not base64-encoded
 		"data:application/json;base64,e30=",      // not an image type

--- a/internal/resources/projectconfig/patches_gen.go
+++ b/internal/resources/projectconfig/patches_gen.go
@@ -143,13 +143,7 @@ func simpleStringPatchEntries(plan *ProjectConfigResourceModel) []StringPatchEnt
 		{&plan.SelfserviceMethodsPasskeyConfigRPDisplayName, nil, "/services/identity/config/selfservice/methods/passkey/config/rp/display_name"},
 		{&plan.SelfserviceMethodsPasskeyConfigRPID, nil, "/services/identity/config/selfservice/methods/passkey/config/rp/id"},
 		{&plan.SelfserviceMethodsWebAuthnConfigRPIcon, nil, "/services/identity/config/selfservice/methods/webauthn/config/rp/icon"},
-		{&plan.AccountExperienceFaviconDark, nil, "/services/account_experience/config/favicon_dark"},
-		{&plan.AccountExperienceFaviconLight, nil, "/services/account_experience/config/favicon_light"},
 		{&plan.AccountExperienceLocaleBehavior, nil, "/services/account_experience/config/locale_behavior"},
-		{&plan.AccountExperienceLogoDark, nil, "/services/account_experience/config/logo_dark"},
-		{&plan.AccountExperienceLogoLight, nil, "/services/account_experience/config/logo_light"},
-		{&plan.AccountExperienceThemeVariablesDark, nil, "/services/account_experience/config/theme_variables_dark"},
-		{&plan.AccountExperienceThemeVariablesLight, nil, "/services/account_experience/config/theme_variables_light"},
 		{&plan.KetoNamespaceConfiguration, nil, "/services/permission/config/namespaces/location"},
 		{&plan.PreviewDefaultReadConsistencyLevel, nil, "/services/identity/config/preview/default_read_consistency_level"},
 		{&plan.SelfserviceMethodsCaptchaConfigCFTurnstileSecret, nil, "/services/identity/config/selfservice/methods/captcha/config/cf_turnstile/secret"},
@@ -259,6 +253,8 @@ func simpleListStringPatchEntries(plan *ProjectConfigResourceModel) []ListString
 // simpleMapStringPatchEntries returns all simple map(string) attribute patch mappings.
 func simpleMapStringPatchEntries(plan *ProjectConfigResourceModel) []MapStringPatchEntry {
 	return []MapStringPatchEntry{
+		{&plan.AccountExperienceThemeVariablesDark, nil, "/services/account_experience/config/theme_variables_dark"},
+		{&plan.AccountExperienceThemeVariablesLight, nil, "/services/account_experience/config/theme_variables_light"},
 		{&plan.OAuth2ProviderHeaders, nil, "/services/identity/config/oauth2_provider/headers"},
 		{&plan.SMTPHeaders, nil, "/services/identity/config/courier/smtp/headers"},
 	}

--- a/internal/resources/projectconfig/read_gen.go
+++ b/internal/resources/projectconfig/read_gen.go
@@ -112,6 +112,34 @@ func readSimpleFields(ctx context.Context, project *ory.Project, state *ProjectC
 				}
 			}
 		}
+		for _, e := range account_experienceMapStringReadEntries(state) {
+			target := e.Field
+			if target.IsNull() && e.Deprecated != nil && !e.Deprecated.IsNull() {
+				target = e.Deprecated
+			}
+			if !target.IsNull() {
+				if v := getNestedValue(accountExperienceConfig, e.Keys...); v != nil {
+					if m, ok := v.(map[string]interface{}); ok {
+						strMap := make(map[string]attr.Value, len(m))
+						allStrings := true
+						for k, val := range m {
+							if s, ok := val.(string); ok {
+								strMap[k] = types.StringValue(s)
+							} else {
+								allStrings = false
+								break
+							}
+						}
+						if allStrings {
+							mapVal, diags := types.MapValue(types.StringType, strMap)
+							if !diags.HasError() {
+								*target = mapVal
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 	if project.Services.Identity != nil {
 		identityConfig := project.Services.Identity.Config
@@ -326,13 +354,7 @@ func readSimpleFields(ctx context.Context, project *ory.Project, state *ProjectC
 func account_experienceStringReadEntries(state *ProjectConfigResourceModel) []StringReadEntry {
 	return []StringReadEntry{
 		{&state.AccountExperienceLocale, nil, []string{"default_locale"}, true},
-		{&state.AccountExperienceFaviconDark, nil, []string{"favicon_dark"}, true},
-		{&state.AccountExperienceFaviconLight, nil, []string{"favicon_light"}, true},
 		{&state.AccountExperienceLocaleBehavior, nil, []string{"locale_behavior"}, true},
-		{&state.AccountExperienceLogoDark, nil, []string{"logo_dark"}, true},
-		{&state.AccountExperienceLogoLight, nil, []string{"logo_light"}, true},
-		{&state.AccountExperienceThemeVariablesDark, nil, []string{"theme_variables_dark"}, true},
-		{&state.AccountExperienceThemeVariablesLight, nil, []string{"theme_variables_light"}, true},
 	}
 }
 
@@ -348,6 +370,13 @@ func account_experienceBoolReadEntries(state *ProjectConfigResourceModel) []Bool
 func account_experienceListStringReadEntries(state *ProjectConfigResourceModel) []ListStringReadEntry {
 	return []ListStringReadEntry{
 		{&state.AccountExperienceEnabledLocales, nil, []string{"enabled_locales"}},
+	}
+}
+
+func account_experienceMapStringReadEntries(state *ProjectConfigResourceModel) []MapStringReadEntry {
+	return []MapStringReadEntry{
+		{&state.AccountExperienceThemeVariablesDark, nil, []string{"theme_variables_dark"}},
+		{&state.AccountExperienceThemeVariablesLight, nil, []string{"theme_variables_light"}},
 	}
 }
 

--- a/internal/resources/projectconfig/resource.go
+++ b/internal/resources/projectconfig/resource.go
@@ -265,8 +265,8 @@ type ProjectConfigResourceModel struct {
 	AccountExperienceLocaleBehavior       types.String `tfsdk:"account_experience_locale_behavior"`
 	AccountExperienceLogoDark             types.String `tfsdk:"account_experience_logo_dark"`
 	AccountExperienceLogoLight            types.String `tfsdk:"account_experience_logo_light"`
-	AccountExperienceThemeVariablesDark   types.String `tfsdk:"account_experience_theme_variables_dark"`
-	AccountExperienceThemeVariablesLight  types.String `tfsdk:"account_experience_theme_variables_light"`
+	AccountExperienceThemeVariablesDark   types.Map    `tfsdk:"account_experience_theme_variables_dark"`
+	AccountExperienceThemeVariablesLight  types.Map    `tfsdk:"account_experience_theme_variables_light"`
 	DisableAccountExperienceWelcomeScreen types.Bool   `tfsdk:"disable_account_experience_welcome_screen"`
 	EnableAXV2                            types.Bool   `tfsdk:"enable_ax_v2"`
 
@@ -594,6 +594,11 @@ func (r *ProjectConfigResource) Schema(ctx context.Context, req resource.SchemaR
 	//   session_tokenizer_templates: nested object schema
 	//   courier_channels:           nested objects with sub-config
 	//   courier_http_request_config: nested object (url/method/headers/body/auth)
+	//   account_experience images (4): data URI upload + storage-URL drift detection
+
+	for name, attr := range accountExperienceImageSchemaAttrs() {
+		attrs[name] = attr
+	}
 
 	attrs["keto_namespaces"] = schema.ListAttribute{
 		Description: "List of Keto namespace names to configure for Ory Permissions. " +
@@ -939,6 +944,10 @@ func (r *ProjectConfigResource) buildPatches(ctx context.Context, plan *ProjectC
 	}
 
 	// --- Custom patches for complex types ---
+
+	// Account experience images (logo/favicon): stored at *_url config keys,
+	// written as data URIs. See account_experience.go.
+	patches = append(patches, accountExperienceImagePatches(plan)...)
 
 	// Keto/Permissions Namespaces
 	if !plan.KetoNamespaces.IsNull() && !plan.KetoNamespaces.IsUnknown() {
@@ -1452,6 +1461,11 @@ func (r *ProjectConfigResource) readProjectConfig(ctx context.Context, project *
 	readSimpleFields(ctx, project, state)
 
 	// --- Custom reads for complex types ---
+
+	// Account experience images (logo/favicon): the API returns a
+	// content-addressed storage URL; match it against the data URI in state
+	// by hash to avoid perpetual diffs. See account_experience.go.
+	readAccountExperienceImages(project, state)
 
 	// CORS (Public) — uses project struct, not config map
 	if project.CorsPublic != nil {

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -301,12 +301,16 @@ func TestAccProjectConfigResource_accountExperience(t *testing.T) {
 
 	createData := map[string]string{
 		"LogoLight":    logoRed,
+		"LogoDark":     logoBlue,
 		"FaviconLight": logoRed,
+		"FaviconDark":  logoBlue,
 		"BrandColor":   "#0066ff",
 	}
 	updateData := map[string]string{
 		"LogoLight":    logoBlue,
+		"LogoDark":     logoRed,
 		"FaviconLight": logoRed,
+		"FaviconDark":  logoBlue,
 		"BrandColor":   "#22cc88",
 	}
 
@@ -324,7 +328,9 @@ func TestAccProjectConfigResource_accountExperience(t *testing.T) {
 					resource.TestCheckResourceAttrSet("ory_project_config.test", "id"),
 					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_default_locale", "en"),
 					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_logo_light", logoRed),
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_logo_dark", logoBlue),
 					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_favicon_light", logoRed),
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_favicon_dark", logoBlue),
 					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_theme_variables_light.ax_background_default", "#fafafa"),
 					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_theme_variables_light.brand_500", "#0066ff"),
 					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_theme_variables_dark.ax_background_default", "#0a0a0a"),
@@ -342,7 +348,9 @@ func TestAccProjectConfigResource_accountExperience(t *testing.T) {
 				Config: acctest.LoadTestConfig(t, "testdata/account_experience.tf.tmpl", updateData),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_logo_light", logoBlue),
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_logo_dark", logoRed),
 					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_favicon_light", logoRed),
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_favicon_dark", logoBlue),
 					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_theme_variables_light.brand_500", "#22cc88"),
 				),
 			},
@@ -360,7 +368,9 @@ func TestAccProjectConfigResource_accountExperience(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"account_experience_default_locale",
 					"account_experience_logo_light",
+					"account_experience_logo_dark",
 					"account_experience_favicon_light",
+					"account_experience_favicon_dark",
 					"account_experience_theme_variables_light",
 					"account_experience_theme_variables_dark",
 					"cors_enabled",
@@ -373,7 +383,9 @@ func TestAccProjectConfigResource_accountExperience(t *testing.T) {
 				Config: acctest.LoadTestConfig(t, "testdata/account_experience_cleared.tf.tmpl", nil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_logo_light", ""),
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_logo_dark", ""),
 					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_favicon_light", ""),
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_favicon_dark", ""),
 					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_theme_variables_light.%", "0"),
 					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_theme_variables_dark.%", "0"),
 				),

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -294,16 +294,94 @@ func TestAccProjectConfigResource_oidcAutoLinkPolicy(t *testing.T) {
 }
 
 func TestAccProjectConfigResource_accountExperience(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	// Two distinct 1x1 PNGs (red and blue pixels) so the update step changes
+	// the image content hash.
+	logoRed := "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg=="
+	logoBlue := "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYPj/HwADAgH/5ncLrgAAAABJRU5ErkJggg=="
+
+	createData := map[string]string{
+		"LogoLight":    logoRed,
+		"FaviconLight": logoRed,
+		"BrandColor":   "#0066ff",
+	}
+	updateData := map[string]string{
+		"LogoLight":    logoBlue,
+		"FaviconLight": logoRed,
+		"BrandColor":   "#22cc88",
+	}
+
+	acctest.RunTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
 		Steps: []resource.TestStep{
+			// Step 1: Create with branding configured. Regression for issue
+			// #250: the logo previously failed to apply (silently ignored
+			// config key) and theme variables returned HTTP 500 (string sent
+			// where the API expects a map of color tokens).
 			{
-				Config: acctest.LoadTestConfig(t, "testdata/account_experience.tf.tmpl", nil),
+				Config: acctest.LoadTestConfig(t, "testdata/account_experience.tf.tmpl", createData),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ory_project_config.test", "id"),
 					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_default_locale", "en"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_logo_light", logoRed),
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_favicon_light", logoRed),
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_theme_variables_light.ax_background_default", "#fafafa"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_theme_variables_light.brand_500", "#0066ff"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_theme_variables_dark.ax_background_default", "#0a0a0a"),
 				),
+			},
+			// Step 2: No perpetual diff — the API stores the image at a
+			// content-addressed storage URL; the provider must match it
+			// against the configured data URI by content hash.
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/account_experience.tf.tmpl", createData),
+				PlanOnly: true,
+			},
+			// Step 3: Update the logo image and a theme color.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/account_experience.tf.tmpl", updateData),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_logo_light", logoBlue),
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_favicon_light", logoRed),
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_theme_variables_light.brand_500", "#22cc88"),
+				),
+			},
+			// Step 4: No perpetual diff after the update.
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/account_experience.tf.tmpl", updateData),
+				PlanOnly: true,
+			},
+			// Step 5: ImportState — import only sets id/project_id, so config
+			// fields stay null until the next apply and are ignored.
+			{
+				ResourceName:      "ory_project_config.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"account_experience_default_locale",
+					"account_experience_logo_light",
+					"account_experience_favicon_light",
+					"account_experience_theme_variables_light",
+					"account_experience_theme_variables_dark",
+					"cors_enabled",
+					"smtp_connection_uri",
+				},
+			},
+			// Step 6: Clear all branding again (also restores the shared
+			// test project to its pre-test state).
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/account_experience_cleared.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_logo_light", ""),
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_favicon_light", ""),
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_theme_variables_light.%", "0"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "account_experience_theme_variables_dark.%", "0"),
+				),
+			},
+			// Step 7: Cleared values round-trip without drift.
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/account_experience_cleared.tf.tmpl", nil),
+				PlanOnly: true,
 			},
 		},
 	})

--- a/internal/resources/projectconfig/schema_gen.go
+++ b/internal/resources/projectconfig/schema_gen.go
@@ -915,33 +915,19 @@ func simpleSchemaAttributes() map[string]schema.Attribute {
 			Optional:    true,
 			ElementType: types.StringType,
 		},
-		"account_experience_favicon_dark": schema.StringAttribute{
-			Description: "URL for the dark theme favicon in the hosted login UI.",
-			Optional:    true,
-		},
-		"account_experience_favicon_light": schema.StringAttribute{
-			Description: "URL for the light theme favicon in the hosted login UI.",
-			Optional:    true,
-		},
 		"account_experience_locale_behavior": schema.StringAttribute{
 			Description: "Locale behavior: 'respect_accept_language' or 'force_default'.",
 			Optional:    true,
 		},
-		"account_experience_logo_dark": schema.StringAttribute{
-			Description: "URL for the dark theme logo in the hosted login UI.",
+		"account_experience_theme_variables_dark": schema.MapAttribute{
+			Description: "Theme color variables for the hosted Account Experience UI (dark theme). Map of color tokens (e.g. ax_background_default, brand_500, button_primary_background_default) to CSS color values. Keys not recognized by the API are discarded. Set to an empty map to reset.",
 			Optional:    true,
+			ElementType: types.StringType,
 		},
-		"account_experience_logo_light": schema.StringAttribute{
-			Description: "URL for the light theme logo in the hosted login UI.",
+		"account_experience_theme_variables_light": schema.MapAttribute{
+			Description: "Theme color variables for the hosted Account Experience UI (light theme). Map of color tokens (e.g. ax_background_default, brand_500, button_primary_background_default) to CSS color values. Keys not recognized by the API are discarded. Set to an empty map to reset.",
 			Optional:    true,
-		},
-		"account_experience_theme_variables_dark": schema.StringAttribute{
-			Description: "URL for dark theme CSS variables in the hosted login UI.",
-			Optional:    true,
-		},
-		"account_experience_theme_variables_light": schema.StringAttribute{
-			Description: "URL for light theme CSS variables in the hosted login UI.",
-			Optional:    true,
+			ElementType: types.StringType,
 		},
 		"disable_account_experience_welcome_screen": schema.BoolAttribute{
 			Description: "Disable the account experience welcome screen at /ui/welcome.",

--- a/internal/resources/projectconfig/testdata/account_experience.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/account_experience.tf.tmpl
@@ -1,3 +1,16 @@
 resource "ory_project_config" "test" {
   account_experience_default_locale = "en"
+
+  account_experience_logo_light    = "[[ .LogoLight ]]"
+  account_experience_favicon_light = "[[ .FaviconLight ]]"
+
+  account_experience_theme_variables_light = {
+    ax_background_default             = "#fafafa"
+    brand_500                         = "[[ .BrandColor ]]"
+    button_primary_background_default = "[[ .BrandColor ]]"
+  }
+
+  account_experience_theme_variables_dark = {
+    ax_background_default = "#0a0a0a"
+  }
 }

--- a/internal/resources/projectconfig/testdata/account_experience.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/account_experience.tf.tmpl
@@ -2,7 +2,9 @@ resource "ory_project_config" "test" {
   account_experience_default_locale = "en"
 
   account_experience_logo_light    = "[[ .LogoLight ]]"
+  account_experience_logo_dark     = "[[ .LogoDark ]]"
   account_experience_favicon_light = "[[ .FaviconLight ]]"
+  account_experience_favicon_dark  = "[[ .FaviconDark ]]"
 
   account_experience_theme_variables_light = {
     ax_background_default             = "#fafafa"

--- a/internal/resources/projectconfig/testdata/account_experience_cleared.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/account_experience_cleared.tf.tmpl
@@ -1,0 +1,9 @@
+resource "ory_project_config" "test" {
+  account_experience_default_locale = "en"
+
+  account_experience_logo_light    = ""
+  account_experience_favicon_light = ""
+
+  account_experience_theme_variables_light = {}
+  account_experience_theme_variables_dark  = {}
+}

--- a/internal/resources/projectconfig/testdata/account_experience_cleared.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/account_experience_cleared.tf.tmpl
@@ -2,7 +2,9 @@ resource "ory_project_config" "test" {
   account_experience_default_locale = "en"
 
   account_experience_logo_light    = ""
+  account_experience_logo_dark     = ""
   account_experience_favicon_light = ""
+  account_experience_favicon_dark  = ""
 
   account_experience_theme_variables_light = {}
   account_experience_theme_variables_dark  = {}

--- a/templates/resources/project_config.md.tmpl
+++ b/templates/resources/project_config.md.tmpl
@@ -105,6 +105,40 @@ When `true`, the provider adds the `show_verification_ui` hook to the correspond
 
 To require a verified address before a user can log in (the "Require verified address for login" toggle in the Ory Console), set `feature_flags_legacy_require_verified_login_error = true`. When that flag is `false`, an unverified user is shown the `show_verification_ui` continuation step instead of receiving a form error.
 
+## Account Experience Branding
+
+The hosted Account Experience pages (login, registration, recovery, ...) can be branded with a logo, favicon, and theme colors.
+
+**Logos and favicons** (`account_experience_logo_light`, `account_experience_logo_dark`, `account_experience_favicon_light`, `account_experience_favicon_dark`) must be provided as an inline data URI — the Ory API does not fetch remote URLs. Use [`filebase64`](https://developer.hashicorp.com/terraform/language/functions/filebase64) to embed a local image:
+
+```hcl
+resource "ory_project_config" "main" {
+  account_experience_logo_light    = "data:image/png;base64,${filebase64("${path.module}/assets/logo.png")}"
+  account_experience_favicon_light = "data:image/png;base64,${filebase64("${path.module}/assets/favicon.png")}"
+}
+```
+
+Supported content types: `image/png`, `image/svg+xml`, `image/x-icon`, `image/vnd.microsoft.icon`, `image/gif`, `image/jpeg`, `image/webp`. The API uploads the image and serves it from a content-addressed storage URL; the provider compares that URL's content hash against your data URI, so an unchanged image never shows a diff. Set the attribute to an empty string (`""`) to remove the image.
+
+**Theme colors** (`account_experience_theme_variables_light`, `account_experience_theme_variables_dark`) are maps of color tokens to CSS color values:
+
+```hcl
+resource "ory_project_config" "main" {
+  account_experience_theme_variables_light = {
+    ax_background_default             = "#fafafa"
+    brand_500                         = "#0066ff"
+    button_primary_background_default = "#0066ff"
+    button_primary_background_hover   = "#0052cc"
+  }
+}
+```
+
+Valid tokens are the fields of the [`AccountExperienceColors`](https://github.com/ory/client-go/blob/master/docs/AccountExperienceColors.md) API model (for example `ax_background_default`, `brand_50` through `brand_950`, `button_primary_*`, `input_*`, `interface_*`). The Ory Console theme editor (Branding → Theme) is an easy way to discover token names: configure colors there, then run `ory get project <id> --format json` and copy the `theme_variables_light`/`theme_variables_dark` objects.
+
+~> **Note:** The API silently discards unrecognized color tokens. If a token you set keeps reappearing in `terraform plan`, check its spelling against the model linked above.
+
+Set a theme map to `{}` to reset all colors to the defaults.
+
 ## Clearing Return URLs
 
 To explicitly clear `default_return_url` and `allowed_return_urls` (e.g., for native-only flows with no browser redirects), set them to empty values:


### PR DESCRIPTION
## Description

The `account_experience_logo_*`, `account_experience_favicon_*`, and `account_experience_theme_variables_*` attributes of `ory_project_config` were unusable, as reported in #250:

- **Logos/favicons silently failed to apply.** The patch paths were derived from the OpenAPI spec's governs descriptions (`/services/account_experience/config/logo_light`), but the API actually stores these values at `logo_light_url`/`favicon_light_url`. The patch returned HTTP 200 and was silently discarded, so nothing changed in the Console or in `ory get project`.
- **Theme variables always returned HTTP 500.** The attributes were typed as strings, but the API expects an object of color tokens (`json: cannot unmarshal string into Go struct field DenormalizedAccountExperience.theme_variables_light of type ax.Colors`).

Both behaviors were reproduced and verified against the live API before and after the fix.

### Changes

- `account_experience_logo_light/dark` and `account_experience_favicon_light/dark` are now hand-written attributes (same approach as the courier email templates, which have identical API semantics) that patch the correct `*_url` config keys. They accept an inline data URI (e.g. `data:image/png;base64,${filebase64("logo.png")}`); the API uploads the image and replaces the value with a content-addressed storage URL whose filename is the SHA-512 of the image bytes. The read path compares that hash against the configured data URI, so an unchanged image produces no diff while out-of-band changes (e.g. via Console) surface as drift. A validator rejects values the API would reject (plain remote URLs are not fetched by the API).
- `account_experience_theme_variables_light/dark` changed from `string` to `map(string)` codegen entries, sending the color-token object the API expects (e.g. `{ ax_background_default = "#fafafa" }`). This is not a breaking change in practice: every possible string value previously failed with HTTP 500, so no existing configuration or state can hold these attributes.
- The storage-URL hash helpers were extracted from the email template resource into `internal/helpers` for reuse.
- New documentation section on Account Experience branding (data URI usage, theme token discovery via Console/`ory get project`, reset semantics).

## Related Issues

Fixes #250

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

Unit tests cover the data URI parsing, hash-based drift resolution, patch generation, and the value validator. `TestAccProjectConfigResource_accountExperience` now exercises create, no-diff plan, update (image bytes and theme color), import, clearing, and a no-diff plan of the cleared state against a real project. `TestAccEmailTemplate*` was re-run to cover the shared-helper refactor. Manual testing with the Terraform CLI against a staging project verified apply, plan idempotency, out-of-band drift detection (Console-style edits show key-level diffs and re-apply converges), import, and clearing; the stored values were confirmed via the project API after each step.

## Screenshots/Output

Before (reproducing #250 against the live API):

```
PATCH /services/account_experience/config/logo_light -> HTTP 200, value silently discarded
PATCH /services/account_experience/config/theme_variables_light (string) -> HTTP 500
  "json: cannot unmarshal string into Go struct field
   DenormalizedAccountExperience.theme_variables_light of type ax.Colors"
```

After:

```
$ terraform apply
ory_project_config.main: Creation complete after 2s

$ curl .../projects/$ORY_PROJECT_ID | jq .services.account_experience.config
  logo_light_url:    https://storage.googleapis.com/bac-gcs-staging/9ed3b602...c4f.png
  theme_variables_light: {"ax_background_default": "#fafafa", "brand_500": "#0066ff", ...}

$ terraform plan
No changes. Your infrastructure matches the configuration.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Account Experience branding: configure logos and favicons (light/dark) and theme color variables (token→CSS maps); empty maps/empty strings reset defaults.

* **Documentation**
  * Updated project configuration docs with Account Experience Branding guidance: supported image types, inline data-URI requirement for uploads, theme variable token mapping, and reset behavior.

* **Tests**
  * Expanded acceptance and unit tests covering branding lifecycle and image/hash handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->