### PR TITLE
feat(social_provider): add fedcm_config_url attribute

### DIFF
--- a/docs/resources/social_provider.md
+++ b/docs/resources/social_provider.md
@@ -78,6 +78,16 @@ resource "ory_social_provider" "google_labeled" {
   account_linking_mode = "automatic"
 }
 
+# Google Sign-In with FedCM (browser Federated Credential Management)
+resource "ory_social_provider" "google_fedcm" {
+  provider_id      = "google-fedcm"
+  provider_type    = "google"
+  client_id        = var.google_client_id
+  client_secret    = var.google_client_secret
+  scope            = ["email", "profile"]
+  fedcm_config_url = "https://accounts.google.com/gsi/fedcm.json"
+}
+
 # Generic OIDC with a custom base redirect URI (e.g., when using a custom domain)
 resource "ory_social_provider" "corporate_sso_custom_domain" {
   provider_id       = "corporate-sso-custom-domain"
@@ -344,6 +354,23 @@ resource "ory_social_provider" "google" {
 }
 ```
 
+## FedCM (Federated Credential Management)
+
+The `fedcm_config_url` attribute enables sign-in with this provider through the browser's [FedCM API](https://developer.mozilla.org/en-US/docs/Web/API/FedCM_API) instead of a full-page OAuth2 redirect. Set it to the URL of the provider's FedCM configuration file. For Google, this is `https://accounts.google.com/gsi/fedcm.json`.
+
+```hcl
+resource "ory_social_provider" "google" {
+  provider_id      = "google"
+  provider_type    = "google"
+  client_id        = var.google_client_id
+  client_secret    = var.google_client_secret
+  scope            = ["email", "profile"]
+  fedcm_config_url = "https://accounts.google.com/gsi/fedcm.json"
+}
+```
+
+Leave the attribute unset to disable FedCM for the provider. Removing it from your configuration clears the value server-side.
+
 ## Base Redirect URI
 
 The `base_redirect_uri` attribute overrides the base URL Ory uses when constructing OIDC callback URLs. Use this when your project is accessible under a custom domain and you want callbacks to go to that domain rather than the default Ory project URL.
@@ -403,6 +430,7 @@ The `provider_id` is the unique identifier you chose when creating the provider.
 - `auto_link` (Boolean) Enable automatic account linking for this provider. When true, if an identity with the same identifier (e.g., email) already exists, the social sign-in will automatically link to that identity instead of failing. Requires enable_oidc_auto_link_policy to be true in the project config (ory_project_config). This attribute is write-only — the API accepts it on create/update but does not return it on read, so Terraform preserves the value from state. On import, the value will not be populated. Removing this attribute from your configuration will automatically disable auto-linking server-side.
 - `base_redirect_uri` (String, Deprecated) Override the base redirect URI for OIDC callbacks (e.g., "https://iam.example.com"). When set, Ory constructs callback URLs using this base instead of the default project domain. This is a global OIDC config setting — if multiple social providers set different values, the last applied value wins.
 - `client_secret` (String, Sensitive) OAuth2 client secret from the provider. Required for all providers except Apple (where Ory generates the secret from apple_team_id, apple_private_key_id, and apple_private_key).
+- `fedcm_config_url` (String) URL of the provider's FedCM (Federated Credential Management) configuration file. When set, Ory can use the browser's FedCM API for sign-in with this provider instead of a full-page redirect. For example, Google's FedCM configuration is served at "https://accounts.google.com/gsi/fedcm.json". Leave unset to disable FedCM for this provider.
 - `issuer_url` (String) OIDC issuer URL (required for generic providers).
 - `label` (String) Human-readable label for the provider, displayed on the login button (e.g., "Sign in with Corporate SSO").
 - `mapper_url` (String) Jsonnet mapper URL for claims mapping. Can be a URL or base64-encoded Jsonnet (base64://...). If not set, a default mapper that extracts email from claims will be used.

--- a/examples/resources/ory_social_provider/resource.tf
+++ b/examples/resources/ory_social_provider/resource.tf
@@ -28,6 +28,16 @@ resource "ory_social_provider" "google_labeled" {
   account_linking_mode = "automatic"
 }
 
+# Google Sign-In with FedCM (browser Federated Credential Management)
+resource "ory_social_provider" "google_fedcm" {
+  provider_id      = "google-fedcm"
+  provider_type    = "google"
+  client_id        = var.google_client_id
+  client_secret    = var.google_client_secret
+  scope            = ["email", "profile"]
+  fedcm_config_url = "https://accounts.google.com/gsi/fedcm.json"
+}
+
 # Generic OIDC with a custom base redirect URI (e.g., when using a custom domain)
 resource "ory_social_provider" "corporate_sso_custom_domain" {
   provider_id       = "corporate-sso-custom-domain"

--- a/internal/resources/socialprovider/resource.go
+++ b/internal/resources/socialprovider/resource.go
@@ -80,6 +80,7 @@ type SocialProviderResourceModel struct {
 	Aal2AcrValues              types.List   `tfsdk:"aal2_acr_values"`
 	Aal2AmrValues              types.List   `tfsdk:"aal2_amr_values"`
 	Pkce                       types.String `tfsdk:"pkce"`
+	FedcmConfigURL             types.String `tfsdk:"fedcm_config_url"`
 }
 
 func (r *SocialProviderResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -214,6 +215,10 @@ func (r *SocialProviderResource) Schema(ctx context.Context, req resource.Schema
 					stringvalidator.OneOf("auto", "force", "never"),
 				},
 			},
+			"fedcm_config_url": schema.StringAttribute{
+				Description: "URL of the provider's FedCM (Federated Credential Management) configuration file. When set, Ory can use the browser's FedCM API for sign-in with this provider instead of a full-page redirect. For example, Google's FedCM configuration is served at \"https://accounts.google.com/gsi/fedcm.json\". Leave unset to disable FedCM for this provider.",
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -287,6 +292,9 @@ func (r *SocialProviderResource) ValidateConfig(ctx context.Context, req resourc
 	}
 	if !config.BaseRedirectURI.IsNull() && !config.BaseRedirectURI.IsUnknown() && config.BaseRedirectURI.ValueString() == "" {
 		resp.Diagnostics.AddAttributeError(path.Root("base_redirect_uri"), "Invalid Attribute Value", "base_redirect_uri must not be an empty string.")
+	}
+	if !config.FedcmConfigURL.IsNull() && !config.FedcmConfigURL.IsUnknown() && config.FedcmConfigURL.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(path.Root("fedcm_config_url"), "Invalid Attribute Value", "fedcm_config_url must not be an empty string.")
 	}
 
 	if providerType == "apple" {
@@ -403,6 +411,12 @@ func (r *SocialProviderResource) buildProviderConfig(ctx context.Context, plan *
 
 	if !plan.Pkce.IsNull() && !plan.Pkce.IsUnknown() {
 		config["pkce"] = plan.Pkce.ValueString()
+	}
+
+	// fedcm_config_url — only send when set to a non-empty value. Omitting it on
+	// the full-object replace performed by Update clears it server-side.
+	if !plan.FedcmConfigURL.IsNull() && !plan.FedcmConfigURL.IsUnknown() && plan.FedcmConfigURL.ValueString() != "" {
+		config["fedcm_config_url"] = plan.FedcmConfigURL.ValueString()
 	}
 
 	// Apple-specific fields — skip empty strings to avoid sending blank credentials
@@ -776,6 +790,14 @@ func (r *SocialProviderResource) Read(ctx context.Context, req resource.ReadRequ
 		state.Pkce = types.StringValue(pkce)
 	} else {
 		state.Pkce = types.StringNull()
+	}
+
+	// Read fedcm_config_url from the API (returned on read), clearing stale state
+	// when the API omits it.
+	if fedcmURL, ok := provider["fedcm_config_url"].(string); ok && fedcmURL != "" {
+		state.FedcmConfigURL = types.StringValue(fedcmURL)
+	} else {
+		state.FedcmConfigURL = types.StringNull()
 	}
 
 	// Read Apple-specific fields, clearing stale state when not returned by the API

--- a/internal/resources/socialprovider/resource_test.go
+++ b/internal/resources/socialprovider/resource_test.go
@@ -381,6 +381,68 @@ func TestAccSocialProviderResource_pkce(t *testing.T) {
 	})
 }
 
+// TestAccSocialProviderResource_fedcmConfigURL exercises fedcm_config_url across
+// create, update (changed URL), removal, and import. The value is an opaque URL
+// stored on the provider config; the API stores and returns it verbatim, so the
+// test asserts on string equality and on clearing when the attribute is removed.
+func TestAccSocialProviderResource_fedcmConfigURL(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.AccPreCheck(t)
+			acctest.RequireSocialProviderTests(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create with fedcm_config_url set
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_fedcm.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_social_provider.test", "id"),
+					resource.TestCheckResourceAttr("ory_social_provider.test", "provider_id", "test-google-fedcm"),
+					resource.TestCheckResourceAttr("ory_social_provider.test", "fedcm_config_url", "https://accounts.google.com/gsi/fedcm.json"),
+				),
+			},
+			// Verify no perpetual diff
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/with_fedcm.tf.tmpl", nil),
+				PlanOnly: true,
+			},
+			// Update fedcm_config_url to a different URL
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_fedcm_updated.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_social_provider.test", "fedcm_config_url", "https://accounts.example.com/fedcm/config.json"),
+				),
+			},
+			// Verify no perpetual diff after update
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/with_fedcm_updated.tf.tmpl", nil),
+				PlanOnly: true,
+			},
+			// Remove fedcm_config_url from config — should clear it server-side
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_fedcm_removed.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("ory_social_provider.test", "fedcm_config_url"),
+				),
+			},
+			// Verify no diff after removal
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/with_fedcm_removed.tf.tmpl", nil),
+				PlanOnly: true,
+			},
+			// ImportState
+			{
+				ResourceName:            "ory_social_provider.test",
+				ImportState:             true,
+				ImportStateId:           "test-google-fedcm",
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"client_secret"},
+			},
+		},
+	})
+}
+
 // TestAccSocialProviderResource_aal2Values exercises aal2_acr_values and
 // aal2_amr_values across create, update (changed list contents), removal, and
 // import. Values are opaque strings stored on the provider config — the API

--- a/internal/resources/socialprovider/testdata/with_fedcm.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/with_fedcm.tf.tmpl
@@ -1,0 +1,8 @@
+resource "ory_social_provider" "test" {
+  provider_id      = "test-google-fedcm"
+  provider_type    = "google"
+  client_id        = "test-client-id.apps.googleusercontent.com"
+  client_secret    = "test-client-secret"
+  scope            = ["email", "profile"]
+  fedcm_config_url = "https://accounts.google.com/gsi/fedcm.json"
+}

--- a/internal/resources/socialprovider/testdata/with_fedcm_removed.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/with_fedcm_removed.tf.tmpl
@@ -1,0 +1,8 @@
+resource "ory_social_provider" "test" {
+  provider_id   = "test-google-fedcm"
+  provider_type = "google"
+  client_id     = "test-client-id.apps.googleusercontent.com"
+  client_secret = "test-client-secret"
+  scope         = ["email", "profile"]
+  # fedcm_config_url intentionally omitted to test removal
+}

--- a/internal/resources/socialprovider/testdata/with_fedcm_updated.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/with_fedcm_updated.tf.tmpl
@@ -1,0 +1,8 @@
+resource "ory_social_provider" "test" {
+  provider_id      = "test-google-fedcm"
+  provider_type    = "google"
+  client_id        = "test-client-id.apps.googleusercontent.com"
+  client_secret    = "test-client-secret"
+  scope            = ["email", "profile"]
+  fedcm_config_url = "https://accounts.example.com/fedcm/config.json"
+}

--- a/internal/resources/socialprovider/validate_config_test.go
+++ b/internal/resources/socialprovider/validate_config_test.go
@@ -45,6 +45,7 @@ func buildTestConfig(t *testing.T, model SocialProviderResourceModel) resource.V
 		"aal2_acr_values":               tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
 		"aal2_amr_values":               tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
 		"pkce":                          tfStringValue(model.Pkce),
+		"fedcm_config_url":              tfStringValue(model.FedcmConfigURL),
 	}
 
 	objType := tftypes.Object{
@@ -72,6 +73,7 @@ func buildTestConfig(t *testing.T, model SocialProviderResourceModel) resource.V
 			"aal2_acr_values":               tftypes.List{ElementType: tftypes.String},
 			"aal2_amr_values":               tftypes.List{ElementType: tftypes.String},
 			"pkce":                          tftypes.String,
+			"fedcm_config_url":              tftypes.String,
 		},
 	}
 
@@ -186,6 +188,23 @@ func TestValidateConfig_EmptyClientSecret_Fails(t *testing.T) {
 	r.ValidateConfig(ctx, req, &resp)
 
 	assert.True(t, resp.Diagnostics.HasError(), "expected error for empty client_secret")
+}
+
+func TestValidateConfig_EmptyFedcmConfigURL_Fails(t *testing.T) {
+	r := &SocialProviderResource{}
+	ctx := context.Background()
+
+	req := buildTestConfig(t, SocialProviderResourceModel{
+		ProviderID:     types.StringValue("google"),
+		ProviderType:   types.StringValue("generic"),
+		ClientID:       types.StringValue("my-client-id"),
+		ClientSecret:   types.StringValue("my-secret"),
+		FedcmConfigURL: types.StringValue(""), // empty string — should fail
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.True(t, resp.Diagnostics.HasError(), "expected error for empty fedcm_config_url")
 }
 
 func TestValidateConfig_UnknownProviderType_SkipsValidation(t *testing.T) {

--- a/templates/resources/social_provider.md.tmpl
+++ b/templates/resources/social_provider.md.tmpl
@@ -157,6 +157,23 @@ resource "ory_social_provider" "google" {
 }
 ```
 
+## FedCM (Federated Credential Management)
+
+The `fedcm_config_url` attribute enables sign-in with this provider through the browser's [FedCM API](https://developer.mozilla.org/en-US/docs/Web/API/FedCM_API) instead of a full-page OAuth2 redirect. Set it to the URL of the provider's FedCM configuration file. For Google, this is `https://accounts.google.com/gsi/fedcm.json`.
+
+```hcl
+resource "ory_social_provider" "google" {
+  provider_id      = "google"
+  provider_type    = "google"
+  client_id        = var.google_client_id
+  client_secret    = var.google_client_secret
+  scope            = ["email", "profile"]
+  fedcm_config_url = "https://accounts.google.com/gsi/fedcm.json"
+}
+```
+
+Leave the attribute unset to disable FedCM for the provider. Removing it from your configuration clears the value server-side.
+
 ## Base Redirect URI
 
 The `base_redirect_uri` attribute overrides the base URL Ory uses when constructing OIDC callback URLs. Use this when your project is accessible under a custom domain and you want callbacks to go to that domain rather than the default Ory project URL.


### PR DESCRIPTION
## Description

Adds an optional `fedcm_config_url` attribute to the `ory_social_provider` resource so FedCM ([Federated Credential Management](https://www.ory.sh/docs/kratos/social-signin/fedcm)) sign-in can be configured per provider through Terraform.

Previously there was no way to configure FedCM settings via the provider. FedCM is configured per social sign-in provider in the Ory API (`fedcm_config_url` on each OIDC provider entry), not on the OAuth2 client. The new attribute maps directly to that field:

- Optional string; when set, Ory can use the browser FedCM API for the provider (for Google, `https://accounts.google.com/gsi/fedcm.json`).
- Returned on read and reconciled into state.
- Nullable in the API: omitting/removing the attribute clears it server-side (the resource already replaces the full provider object on update).
- Empty strings are rejected by config validation, consistent with the existing handling of other optional URL attributes.

## Related Issues

Closes #263

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

- Verified the API round-trip directly against a live project first: setting `fedcm_config_url` on an OIDC provider persists and is returned, and replacing the provider object without the field clears it.
- Added a unit test (`TestValidateConfig_EmptyFedcmConfigURL_Fails`) for the empty-string guard.
- Added an acceptance test (`TestAccSocialProviderResource_fedcmConfigURL`) covering create, no-op plan, update, clear-on-removal, and import.
- Ran the full `ory_social_provider` acceptance suite (10 tests) to confirm no regressions.
- `make format`, `make test-short`, and `make sec` (govulncheck, gosec, gitleaks) all pass.

## Screenshots/Output

```
--- PASS: TestAccSocialProviderResource_fedcmConfigURL (23.17s)
ok  github.com/ory/terraform-provider-ory/internal/resources/socialprovider  117.203s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FedCM (Federated Credential Management) support for Google social provider via the new `fedcm_config_url` attribute, enabling browser-based sign-in via the FedCM API instead of full-page OAuth redirects.

* **Documentation**
  * Added comprehensive documentation and configuration examples for setting up and managing FedCM-based authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->