### PR TITLE
feat(project_config): treat smtp_connection_uri as write-only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -328,6 +328,7 @@ That's it — the field appears in the Terraform schema, JSON Patch operations, 
 | `default_int64` | No | Static default for int64 attributes |
 | `sensitive` | No | If `true`, value is masked in Terraform output |
 | `skip_empty_read` | No | If `true`, skip reading empty strings from API (used for account_experience fields) |
+| `write_only` | No | If `true`, the attribute is sent on create/update but never read back from the API. Use for secrets the API does not return (or returns masked, e.g. `****`), so the configured value is always preserved and never produces a spurious diff |
 | `validators` | No | `one_of: [...]` or `regex: "..."` + `regex_message: "..."` |
 | `deprecated_name` | No | Old terraform attribute name (shows deprecation warning in Terraform) |
 | `deprecated_go_field` | No | Old Go struct field name for the deprecated attribute |
@@ -398,8 +399,13 @@ These require hand-written code in `resource.go` because they have non-trivial s
 - Courier channels (list of objects with discriminated auth config)
 - Courier HTTP request config (nested object with auth sub-object)
 - `default_return_url` / `allowed_return_urls` (remove-on-empty semantics)
-- `smtp_connection_uri` (sensitive, write-only — not read from API)
 - `mfa_enforcement` (maps string values to different API fields)
+
+> **Note:** `smtp_connection_uri` is fully codegen'd, but uses `write_only: true`
+> (see the mappings table above). The Ory API never returns the connection URI in
+> project-config responses, so the provider sends it on create/update but never
+> reads it back — this keeps it from showing a perpetual diff if the API returns an
+> empty value or a masked sentinel.
 
 ### Adding a New Resource
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,3 +28,18 @@ When using this provider:
 - API keys configured in the provider are passed to the Ory API
 
 Use Terraform's sensitive variable handling and state encryption to protect these values.
+
+### Write-only secrets
+
+Some secrets are **write-only**: the provider sends them to the Ory API on create
+and update, but the API does not return them in its responses, so the provider never
+reads them back from the API. The value configured in Terraform is the source of
+truth (and is still stored in state, masked as sensitive). Because the provider does
+not refresh these from the API, it tolerates the API omitting the value or returning
+a masked sentinel (such as `****`) without producing a spurious diff:
+
+- `smtp_connection_uri` in `ory_project_config`
+- `client_secret` and `apple_private_key` in `ory_social_provider`
+
+These values still originate from your configuration, so keep them in sensitive
+variables and protect your state as described above.

--- a/docs/resources/project_config.md
+++ b/docs/resources/project_config.md
@@ -382,6 +382,8 @@ The `smtp_connection_uri` attribute selects the SMTP security mode through the U
 
 -> **Credential encoding:** Usernames and passwords must be URI-encoded if they contain special characters (e.g., `@`, `:`, `/`, `?`, `#`). Use [`urlencode`](https://developer.hashicorp.com/terraform/language/functions/urlencode) in Terraform to encode them safely.
 
+-> **Write-only:** The Ory API does not return the SMTP connection URI in project-config responses (it contains credentials). The provider therefore treats `smtp_connection_uri` as write-only — it is sent on create and update but never read back, so the value in your configuration is authoritative. As a result, out-of-band changes to the SMTP URI are not detected, and the attribute will not show a diff if the API omits or masks the value.
+
 For more detail, see the [Ory Kratos SMTP documentation](https://www.ory.com/docs/kratos/emails-sms/sending-emails-smtp).
 
 ## Verification After Registration / Settings

--- a/internal/codegen/cmd/generate/main.go
+++ b/internal/codegen/cmd/generate/main.go
@@ -37,6 +37,7 @@ type Attribute struct {
 	DefaultInt64    *int64     `yaml:"default_int64"`
 	Sensitive       bool       `yaml:"sensitive"`
 	SkipEmptyRead   bool       `yaml:"skip_empty_read"`
+	WriteOnly       bool       `yaml:"write_only"` // omit from the API read path: sent on create/update but never read back into state (for secrets the API does not return, or returns masked)
 	Validators      *Validator `yaml:"validators"`
 
 	// Deprecated alias support: when set, generates a second schema attribute
@@ -1411,7 +1412,9 @@ func readSimpleFields(ctx context.Context, project *ory.Project, state *ProjectC
 func {{ $svc }}StringReadEntries(state *ProjectConfigResourceModel) []StringReadEntry {
 	return []StringReadEntry{
 {{- range $strings }}
+{{- if not .WriteOnly }}
 		{&state.{{ .GoField }}, {{ if .DeprecatedGoField }}&state.{{ .DeprecatedGoField }}{{ else }}nil{{ end }}, []string{ {{ readKeys .PatchPath }} }, {{ .SkipEmptyRead }}},
+{{- end }}
 {{- end }}
 	}
 }
@@ -1423,7 +1426,9 @@ func {{ $svc }}StringReadEntries(state *ProjectConfigResourceModel) []StringRead
 func {{ $svc }}BoolReadEntries(state *ProjectConfigResourceModel) []BoolReadEntry {
 	return []BoolReadEntry{
 {{- range $bools }}
+{{- if not .WriteOnly }}
 		{&state.{{ .GoField }}, {{ if .DeprecatedGoField }}&state.{{ .DeprecatedGoField }}{{ else }}nil{{ end }}, []string{ {{ readKeys .PatchPath }} }},
+{{- end }}
 {{- end }}
 	}
 }
@@ -1435,7 +1440,9 @@ func {{ $svc }}BoolReadEntries(state *ProjectConfigResourceModel) []BoolReadEntr
 func {{ $svc }}Int64ReadEntries(state *ProjectConfigResourceModel) []Int64ReadEntry {
 	return []Int64ReadEntry{
 {{- range $ints }}
+{{- if not .WriteOnly }}
 		{&state.{{ .GoField }}, {{ if .DeprecatedGoField }}&state.{{ .DeprecatedGoField }}{{ else }}nil{{ end }}, []string{ {{ readKeys .PatchPath }} }},
+{{- end }}
 {{- end }}
 	}
 }
@@ -1447,7 +1454,9 @@ func {{ $svc }}Int64ReadEntries(state *ProjectConfigResourceModel) []Int64ReadEn
 func {{ $svc }}ListStringReadEntries(state *ProjectConfigResourceModel) []ListStringReadEntry {
 	return []ListStringReadEntry{
 {{- range $listStrings }}
+{{- if not .WriteOnly }}
 		{&state.{{ .GoField }}, {{ if .DeprecatedGoField }}&state.{{ .DeprecatedGoField }}{{ else }}nil{{ end }}, []string{ {{ readKeys .PatchPath }} }},
+{{- end }}
 {{- end }}
 	}
 }
@@ -1459,7 +1468,9 @@ func {{ $svc }}ListStringReadEntries(state *ProjectConfigResourceModel) []ListSt
 func {{ $svc }}MapStringReadEntries(state *ProjectConfigResourceModel) []MapStringReadEntry {
 	return []MapStringReadEntry{
 {{- range $mapStrings }}
+{{- if not .WriteOnly }}
 		{&state.{{ .GoField }}, {{ if .DeprecatedGoField }}&state.{{ .DeprecatedGoField }}{{ else }}nil{{ end }}, []string{ {{ readKeys .PatchPath }} }},
+{{- end }}
 {{- end }}
 	}
 }

--- a/internal/codegen/mappings.yaml
+++ b/internal/codegen/mappings.yaml
@@ -1358,7 +1358,11 @@ attributes:
     openapi_property: kratos_courier_smtp_connection_uri
     description: "SMTP connection URI for sending emails. The URI scheme selects the security mode: `smtp://` uses STARTTLS (recommended for port 587), `smtps://` uses implicit TLS (recommended for port 465). Append `?disable_starttls=true` for cleartext or `?skip_ssl_verify=true` to skip certificate verification (development only). See the SMTP Security Modes section in the resource documentation for the full list."
     sensitive: true
-    skip_empty_read: true
+    # The API never returns the connection URI — it is stripped/masked server-side.
+    # Reading it back would clobber the configured value with an empty string or a
+    # sentinel (e.g. "****") and cause a perpetual diff, so it is write-only:
+    # sent on create/update, never read into state.
+    write_only: true
 
   # --- Auto-discovered entries (review names/descriptions before merging) ---
   - name: oauth2_preserve_ext_claims

--- a/internal/resources/projectconfig/generated_test.go
+++ b/internal/resources/projectconfig/generated_test.go
@@ -245,6 +245,47 @@ func TestGeneratedReadRoundTrip(t *testing.T) {
 	assert.True(t, state.FeatureFlagsCacheableSessions.ValueBool(), "cacheable_sessions")
 }
 
+// TestSMTPConnectionURI_WriteOnly verifies the SMTP connection URI is treated as
+// write-only: it is sent on create/update (it remains in the schema and patch
+// tables) but is never read back from the API. A value the API returns — empty,
+// a masked sentinel such as "****", or a partially-masked URI — must never
+// overwrite the configured value, otherwise every plan would show a perpetual
+// diff between the real URI in HCL and the masked value in state.
+//
+// This is the provider-side guard for the Ory API stripping SMTP credentials from
+// project-config responses.
+func TestSMTPConnectionURI_WriteOnly(t *testing.T) {
+	// A realistic SMTP URI whose credentials must never be clobbered by the API.
+	const configured = "smtps://user:secret@smtp.example.com:465" //nolint:gosec // G101 false positive: test fixture, not a real credential
+
+	// 1. It must be excluded from the generated read entries entirely.
+	state := &ProjectConfigResourceModel{
+		SMTPConnectionURI: types.StringValue(configured),
+	}
+	for _, e := range identityStringReadEntries(state) {
+		assert.NotSame(t, &state.SMTPConnectionURI, e.Field,
+			"smtp_connection_uri must not appear in read entries — it is write-only")
+	}
+
+	// 2. readSimpleFields must preserve the configured value regardless of what the
+	//    API returns for courier.smtp.connection_uri (absent, empty, or masked).
+	for _, apiValue := range []string{"", "****", "smtps://user:masked@smtp.example.com:465"} {
+		st := &ProjectConfigResourceModel{
+			SMTPConnectionURI: types.StringValue(configured),
+		}
+		project := projectWithIdentityConfig(map[string]interface{}{
+			"courier": map[string]interface{}{
+				"smtp": map[string]interface{}{
+					"connection_uri": apiValue,
+				},
+			},
+		})
+		readSimpleFields(context.Background(), project, st)
+		assert.Equal(t, configured, st.SMTPConnectionURI.ValueString(),
+			"configured smtp_connection_uri must be preserved when the API returns %q", apiValue)
+	}
+}
+
 // TestGeneratedSchemaAttributes_Count verifies generation produced a non-trivial
 // number of attributes. The AllOptional and ValidAndUnique tests verify correctness;
 // this test catches catastrophic generation failures (e.g., empty output).

--- a/internal/resources/projectconfig/read_gen.go
+++ b/internal/resources/projectconfig/read_gen.go
@@ -457,7 +457,6 @@ func identityStringReadEntries(state *ProjectConfigResourceModel) []StringReadEn
 		{&state.SelfserviceMethodsCaptchaConfigCFTurnstileSitekey, nil, []string{"selfservice", "methods", "captcha", "config", "cf_turnstile", "sitekey"}, false},
 		{&state.CourierHTTPRequestConfigAuthType, nil, []string{"courier", "http", "request_config", "auth", "type"}, false},
 		{&state.CourierHTTPRequestConfigMethod, nil, []string{"courier", "http", "request_config", "method"}, false},
-		{&state.SMTPConnectionURI, nil, []string{"courier", "smtp", "connection_uri"}, true},
 	}
 }
 

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -44,6 +44,39 @@ func TestAccProjectConfigResource_basic(t *testing.T) {
 	})
 }
 
+// TestAccProjectConfigResource_smtpConnectionURIWriteOnly verifies that
+// smtp_connection_uri can be created and updated, and that it never produces a
+// perpetual diff even though the Ory API does not return it in project-config
+// responses (it is a write-only secret). The terraform-plugin-testing framework
+// runs a plan after each apply and fails the step on a non-empty plan, so each
+// step also asserts idempotency — the read path must not clobber the configured
+// value with an empty or masked value returned by the API.
+func TestAccProjectConfigResource_smtpConnectionURIWriteOnly(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create with the connection URI set (STARTTLS on 587).
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/smtp_write_only.tf.tmpl", map[string]string{
+					"SMTPURI": "smtp://tf-acc-test:not-a-real-secret@smtp.example.com:587",
+				}),
+				Check: resource.TestCheckResourceAttr("ory_project_config.test", "smtp_connection_uri",
+					"smtp://tf-acc-test:not-a-real-secret@smtp.example.com:587"),
+			},
+			// Update the secret (implicit TLS on 465). A successful no-diff plan after
+			// this apply confirms the update was applied and not re-read as a diff.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/smtp_write_only.tf.tmpl", map[string]string{
+					"SMTPURI": "smtps://tf-acc-test:also-not-real@smtp.example.com:465",
+				}),
+				Check: resource.TestCheckResourceAttr("ory_project_config.test", "smtp_connection_uri",
+					"smtps://tf-acc-test:also-not-real@smtp.example.com:465"),
+			},
+		},
+	})
+}
+
 func TestAccProjectConfigResource_hydraConfig(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccPreCheck(t) },

--- a/internal/resources/projectconfig/testdata/smtp_write_only.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/smtp_write_only.tf.tmpl
@@ -1,0 +1,3 @@
+resource "ory_project_config" "test" {
+  smtp_connection_uri = "[[ .SMTPURI ]]"
+}

--- a/templates/resources/project_config.md.tmpl
+++ b/templates/resources/project_config.md.tmpl
@@ -91,6 +91,8 @@ The `smtp_connection_uri` attribute selects the SMTP security mode through the U
 
 -> **Credential encoding:** Usernames and passwords must be URI-encoded if they contain special characters (e.g., `@`, `:`, `/`, `?`, `#`). Use [`urlencode`](https://developer.hashicorp.com/terraform/language/functions/urlencode) in Terraform to encode them safely.
 
+-> **Write-only:** The Ory API does not return the SMTP connection URI in project-config responses (it contains credentials). The provider therefore treats `smtp_connection_uri` as write-only — it is sent on create and update but never read back, so the value in your configuration is authoritative. As a result, out-of-band changes to the SMTP URI are not detected, and the attribute will not show a diff if the API omits or masks the value.
+
 For more detail, see the [Ory Kratos SMTP documentation](https://www.ory.com/docs/kratos/emails-sms/sending-emails-smtp).
 
 ## Verification After Registration / Settings


### PR DESCRIPTION
## Description

The Ory API does not return secret values such as the SMTP connection URI in `ory_project_config` responses, and may begin returning a masked sentinel (e.g. `****`) instead of the real value. The `smtp_connection_uri` attribute was read back from the API via the generated `skip_empty_read` logic, which only skips empty strings. If the API returns a non-empty masked value, the provider would write that sentinel into state and every subsequent `terraform plan` would show a perpetual diff between the real URI in configuration and the masked value in state.

This PR adds a `write_only` flag to the `ory_project_config` code generator and applies it to `smtp_connection_uri`. A write-only attribute is still sent to the API on create and update, but is never read back into state, so the configured value is authoritative and the provider tolerates the API omitting, emptying, or masking the value without producing a diff. This mirrors how `ory_social_provider` already handles `client_secret` and `apple_private_key`, which are never read back.

Verified against the staging API: the SMTP connection URI is already absent from project-config responses today, while the social provider's `client_secret` is still returned in full. This change therefore makes the SMTP handling robust ahead of any server-side masking, and the two OIDC secrets need no change because the provider never reads them back.

### Changes

- Add a `write_only` option to the project_config codegen (`internal/codegen/mappings.yaml` schema plus the generator templates). When set, the attribute is excluded from every generated `*ReadEntries` table, so `readSimpleFields` never overwrites it from the API response.
- Mark `smtp_connection_uri` as `write_only` and regenerate `read_gen.go`. The only generated change is the removal of the SMTP read entry; the schema and patch tables are unchanged, so the value is still written on create and update.
- Document the `write_only` flag and the write-only secrets in `CONTRIBUTING.md`, `SECURITY.md`, and the `project_config` resource docs.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

`TestSMTPConnectionURI_WriteOnly` (unit): asserts `smtp_connection_uri` is excluded from the generated read entries, and that an empty, `****`, or partially-masked value returned by the API never overwrites the configured value.

`TestAccProjectConfigResource_smtpConnectionURIWriteOnly` (acceptance): create then update against a real Ory project; the testing framework's post-apply plan check confirms there is no perpetual diff. Passed against a staging project in ~17s.

Manual API verification confirmed the SMTP connection URI is not returned by the Console API even after being set, and that an OIDC `client_secret` is currently returned in full.

Also ran `make build`, `make format`, `make test-short`, and `make sec` (govulncheck, gosec, gitleaks) -- all pass.

## Screenshots/Output

```
=== RUN   TestSMTPConnectionURI_WriteOnly
--- PASS: TestSMTPConnectionURI_WriteOnly (0.00s)

=== RUN   TestAccProjectConfigResource_smtpConnectionURIWriteOnly
--- PASS: TestAccProjectConfigResource_smtpConnectionURIWriteOnly (17.26s)

gosec  Issues : 0
gitleaks  no leaks found
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed perpetual diffs for `smtp_connection_uri` in project configuration by preventing the provider from reading back write-only secrets from the API.

* **Documentation**
  * Added clarification that `smtp_connection_uri` is write-only; the API does not return it due to security.
  * Added security policy section documenting write-only secrets handling for affected fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->