### PR TITLE
fix(project_config): surface feature_not_available reason on plan-gated 403

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -45,6 +45,11 @@ on:
         required: false
         default: false
         type: boolean
+      enable_auto_link_tests:
+        description: 'OIDC auto-link policy tests (requires enterprise use_auto_link entitlement)'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: acceptance-tests
@@ -88,4 +93,5 @@ jobs:
       enable_project_tests: ${{ github.event_name == 'pull_request' || github.event.inputs.run_all == 'true' || github.event.inputs.enable_project_tests == 'true' }}
       enable_event_stream_tests: ${{ github.event_name == 'pull_request' || github.event.inputs.run_all == 'true' || github.event.inputs.enable_event_stream_tests == 'true' }}
       enable_custom_domain_tests: ${{ github.event_name == 'pull_request' || github.event.inputs.run_all == 'true' || github.event.inputs.enable_custom_domain_tests == 'true' }}
+      enable_auto_link_tests: ${{ github.event_name == 'pull_request' || github.event.inputs.run_all == 'true' || github.event.inputs.enable_auto_link_tests == 'true' }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
       enable_project_tests: true
       enable_event_stream_tests: true
       enable_custom_domain_tests: true
+      enable_auto_link_tests: true
     secrets: inherit
 
   goreleaser:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -27,6 +27,9 @@ on:
       enable_custom_domain_tests:
         type: boolean
         default: false
+      enable_auto_link_tests:
+        type: boolean
+        default: false
     secrets:
       ORY_WORKSPACE_API_KEY:
         required: true
@@ -106,6 +109,7 @@ jobs:
           ORY_SCHEMA_TESTS_ENABLED: ${{ inputs.enable_schema_tests }}
           ORY_PROJECT_TESTS_ENABLED: ${{ inputs.enable_project_tests }}
           ORY_EVENT_STREAM_TESTS_ENABLED: ${{ inputs.enable_event_stream_tests }}
+          ORY_AUTO_LINK_TESTS_ENABLED: ${{ inputs.enable_auto_link_tests }}
           ORY_EVENT_STREAM_TOPIC_ARN: ${{ secrets.ORY_EVENT_STREAM_TOPIC_ARN }}
           ORY_EVENT_STREAM_ROLE_ARN: ${{ secrets.ORY_EVENT_STREAM_ROLE_ARN }}
           ORY_CUSTOM_DOMAIN_HOSTNAME: ${{ inputs.enable_custom_domain_tests && secrets.ORY_CUSTOM_DOMAIN_HOSTNAME || '' }}

--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -24,4 +24,5 @@ jobs:
       enable_project_tests: false
       enable_event_stream_tests: true
       enable_custom_domain_tests: true
+      enable_auto_link_tests: true
     secrets: inherit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,7 @@ Some tests require specific Ory plan features. Enable them with environment vari
 | `ORY_SCHEMA_TESTS_ENABLED=true` | Run identity schema tests |
 | `ORY_PROJECT_TESTS_ENABLED=true` | Run project creation/deletion tests |
 | `ORY_EVENT_STREAM_TESTS_ENABLED=true` | Run event stream tests (requires Enterprise plan + AWS setup below) |
+| `ORY_AUTO_LINK_TESTS_ENABLED=true` | Run OIDC auto-link policy tests (requires the enterprise `use_auto_link` entitlement, enabled per project by Ory support) |
 
 > **Note:** CI enables **all** feature flags, including `ORY_PROJECT_TESTS_ENABLED`, on pull requests. Locally, `make test-acc-all` enables all flags **except** `ORY_PROJECT_TESTS_ENABLED` by default (project creation/deletion tests are excluded because they are slow and potentially destructive). To run those locally, set `ORY_PROJECT_TESTS_ENABLED=true` explicitly.
 

--- a/docs/resources/project_config.md
+++ b/docs/resources/project_config.md
@@ -18,6 +18,8 @@ This resource supports drift detection — `terraform plan` will detect changes 
 
 ~> **Note:** Only attributes present in your Terraform configuration are tracked for drift. Attributes you have not configured will not appear in plan output, even if they have non-default values in the API.
 
+~> **Plan-gated features:** Some settings require a feature that your project's subscription must include, and the Ory API rejects them with an `HTTP 403 (feature_not_available)` otherwise. Notably, `selfservice_methods_oidc_enable_auto_link_policy = true` requires the OIDC auto-link policy (`use_auto_link`), an enterprise feature that Ory enables per project on request — being on an enterprise plan does not enable it automatically. If an apply fails with a `feature_not_available` error, the provider surfaces the feature name and a request ID; contact Ory support or your account executive to enable the feature.
+
 ## Example Usage
 
 ```terraform
@@ -513,7 +515,7 @@ terraform plan  # verify no changes
 - `enable_code` (Boolean, Deprecated) Enable code-based authentication.
 - `enable_lookup_secret` (Boolean, Deprecated) Enable backup/recovery codes.
 - `enable_oidc` (Boolean, Deprecated) Enable OIDC (OpenID Connect) social sign-in. Must be enabled for social providers (e.g. Google, GitHub) to work.
-- `enable_oidc_auto_link_policy` (Boolean, Deprecated) Enable the OIDC auto-link policy. When true, social sign-in providers with auto_link enabled (on ory_social_provider) can automatically link to existing identities that share the same identifier (e.g., email).
+- `enable_oidc_auto_link_policy` (Boolean, Deprecated) Enable the OIDC auto-link policy. When true, social sign-in providers with auto_link enabled (on ory_social_provider) can automatically link to existing identities that share the same identifier (e.g., email). This is an enterprise-gated feature that Ory must enable for the project (the `use_auto_link` feature flag); without the entitlement, setting this to true is rejected by the API with an HTTP 403 (feature_not_available).
 - `enable_passkey` (Boolean, Deprecated) Enable Passkey authentication.
 - `enable_password` (Boolean, Deprecated) Enable password authentication.
 - `enable_profile` (Boolean, Deprecated) Enable the profile authentication method. When enabled, users can update their identity traits (e.g., name, address) via the settings flow.
@@ -691,7 +693,7 @@ terraform plan  # verify no changes
 - `selfservice_methods_link_enabled` (Boolean) Enable the magic link authentication method.
 - `selfservice_methods_lookup_secret_enabled` (Boolean) Enable backup/recovery codes.
 - `selfservice_methods_oidc_config_base_redirect_uri` (String) Base redirect URI for OIDC/social sign-in callbacks.
-- `selfservice_methods_oidc_enable_auto_link_policy` (Boolean) Enable the OIDC auto-link policy. When true, social sign-in providers with auto_link enabled (on ory_social_provider) can automatically link to existing identities that share the same identifier (e.g., email).
+- `selfservice_methods_oidc_enable_auto_link_policy` (Boolean) Enable the OIDC auto-link policy. When true, social sign-in providers with auto_link enabled (on ory_social_provider) can automatically link to existing identities that share the same identifier (e.g., email). This is an enterprise-gated feature that Ory must enable for the project (the `use_auto_link` feature flag); without the entitlement, setting this to true is rejected by the API with an HTTP 403 (feature_not_available).
 - `selfservice_methods_oidc_enabled` (Boolean) Enable OIDC (OpenID Connect) social sign-in. Must be enabled for social providers (e.g. Google, GitHub) to work.
 - `selfservice_methods_passkey_config_rp_display_name` (String) Passkey relying party display name.
 - `selfservice_methods_passkey_config_rp_id` (String) Passkey relying party ID (typically your domain).

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -327,6 +327,15 @@ func RequireEventStreamTests(t *testing.T) {
 	SkipIfFeatureDisabled(t, "ORY_EVENT_STREAM_TESTS_ENABLED", "event stream")
 }
 
+// RequireAutoLinkTests skips the test if ORY_AUTO_LINK_TESTS_ENABLED is not "true".
+// The OIDC auto-link policy is an enterprise feature that Ory enables per project
+// (the use_auto_link flag); without the entitlement the API rejects it with a 403
+// feature_not_available, so the test only runs against an entitled project.
+func RequireAutoLinkTests(t *testing.T) {
+	t.Helper()
+	SkipIfFeatureDisabled(t, "ORY_AUTO_LINK_TESTS_ENABLED", "OIDC auto-link policy")
+}
+
 // RunTest runs an acceptance test.
 // This is a convenience wrapper around resource.Test() that follows
 // provider conventions and can be extended in the future.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -657,11 +657,22 @@ func (c *OryClient) PatchProject(ctx context.Context, projectID string, patches 
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
 	}
-	if err == nil && result != nil {
+	if err != nil {
+		// The raw SDK error for a project patch is just the bare HTTP status
+		// (e.g. "403 Forbidden") with no body, so a rejected setting surfaces
+		// with zero diagnostic detail. wrapAPIError parses the response body and
+		// recognizes feature_not_available errors — e.g. enabling the OIDC
+		// auto-link policy on a project whose plan lacks the "Auto Link Policy"
+		// feature returns a 403 whose reason names the feature and links to
+		// pricing. Wrap it so that reason and the request ID reach the user, the
+		// same treatment every other console operation already gets.
+		return result, wrapAPIError(err, "patching project")
+	}
+	if result != nil {
 		project := result.GetProject()
 		c.cachedProjects.Store(projectID, &project)
 	}
-	return result, err
+	return result, nil
 }
 
 // GetCachedProject returns the cached project state from the last PatchProject call.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -182,6 +182,92 @@ func TestOryErrorDebugInfo_String(t *testing.T) {
 	}
 }
 
+func TestWrapAPIError_Nil(t *testing.T) {
+	assert.NoError(t, wrapAPIError(nil, "patching project"))
+}
+
+// autoLinkFeatureErrorBody is the exact 403 body the Ory console API returns
+// when enabling the OIDC auto-link policy on a project whose subscription plan
+// does not include the "Auto Link Policy" feature (captured against the live
+// production API). The provider must surface its reason, not a bare 403.
+const autoLinkFeatureErrorBody = `{"error":{"id":"feature_not_available","code":403,"status":"Forbidden",` +
+	`"request":"83130baf-0313-9115-8f8e-dabe3a5516c4",` +
+	`"reason":"This project's subscription plan does not include feature \"Auto Link Policy\". ` +
+	`Please take a look at https://www.ory.com/pricing/ to select an appropriate plan and upgrade accordingly.",` +
+	`"details":{"feature":"auto_link_policy"},"message":"The requested action was forbidden"}}`
+
+// TestWrapAPIError_FeatureNotAvailable verifies that the plan-gated 403 for the
+// OIDC auto-link policy is surfaced with the feature name, the human-readable
+// reason, and the pricing link — so a user immediately understands it is a plan
+// limitation rather than a mysterious permission error.
+func TestWrapAPIError_FeatureNotAvailable(t *testing.T) {
+	err := fmt.Errorf("403 Forbidden: %s", autoLinkFeatureErrorBody)
+
+	wrapped := wrapAPIError(err, "patching project")
+	require.Error(t, wrapped)
+
+	msg := wrapped.Error()
+	assert.Contains(t, msg, "patching project")
+	assert.Contains(t, msg, "auto_link_policy", "should name the gated feature")
+	assert.Contains(t, msg, "not available on current plan")
+	assert.Contains(t, msg, "subscription plan does not include", "should surface the API reason")
+	assert.Contains(t, msg, "ory.com/pricing", "should surface the pricing link from the reason")
+	assert.Contains(t, msg, "83130baf", "should surface the request ID for Ory support")
+}
+
+// TestWrapAPIError_Forbidden covers a generic (non-feature) 403: it is enriched
+// with the API reason and request ID and remains unwrappable for callers that
+// inspect the underlying error.
+func TestWrapAPIError_Forbidden(t *testing.T) {
+	body := `{"error":{"code":403,"status":"Forbidden","request":"req-abc-123",` +
+		`"reason":"insufficient permissions for this operation"}}`
+	err := fmt.Errorf("403 Forbidden: %s", body)
+
+	wrapped := wrapAPIError(err, "patching project")
+	require.Error(t, wrapped)
+
+	msg := wrapped.Error()
+	assert.Contains(t, msg, "patching project")
+	assert.Contains(t, msg, "forbidden (403)")
+	assert.Contains(t, msg, "req-abc-123", "should surface the request ID for Ory support")
+	assert.Contains(t, msg, "insufficient permissions", "should surface the API error reason")
+
+	// The original error must remain unwrappable for callers that inspect it.
+	assert.ErrorIs(t, wrapped, err)
+}
+
+// TestPatchProject_WrapsFeatureNotAvailable exercises the full client path: the
+// plan-gated 403 from the console API must come back from PatchProject with the
+// parsed feature/reason/request ID, not a bare "403 Forbidden". This guards
+// against the regression where project_config updates surfaced an opaque 403
+// (see issue #271).
+func TestPatchProject_WrapsFeatureNotAvailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(autoLinkFeatureErrorBody))
+	}))
+	defer srv.Close()
+
+	client, err := NewOryClient(OryClientConfig{
+		WorkspaceAPIKey: testutil.TestWorkspaceAPIKey,
+		ConsoleAPIURL:   srv.URL,
+	})
+	require.NoError(t, err)
+
+	_, patchErr := client.PatchProject(context.Background(), "prod-project", []ory.JsonPatch{{
+		Op:    "replace",
+		Path:  "/services/identity/config/selfservice/methods/oidc/enable_auto_link_policy",
+		Value: true,
+	}})
+	require.Error(t, patchErr)
+
+	msg := patchErr.Error()
+	assert.Contains(t, msg, "auto_link_policy")
+	assert.Contains(t, msg, "not available on current plan")
+	assert.Contains(t, msg, "ory.com/pricing")
+}
+
 func TestNewOryClient_InvalidConsoleURL(t *testing.T) {
 	cfg := OryClientConfig{
 		WorkspaceAPIKey: testutil.TestWorkspaceAPIKey,

--- a/internal/codegen/mappings.yaml
+++ b/internal/codegen/mappings.yaml
@@ -323,7 +323,7 @@ attributes:
     go_field: SelfserviceMethodsOIDCEnableAutoLinkPolicy
     type: bool
     openapi_property: kratos_selfservice_methods_oidc_enable_auto_link_policy
-    description: "Enable the OIDC auto-link policy. When true, social sign-in providers with auto_link enabled (on ory_social_provider) can automatically link to existing identities that share the same identifier (e.g., email)."
+    description: "Enable the OIDC auto-link policy. When true, social sign-in providers with auto_link enabled (on ory_social_provider) can automatically link to existing identities that share the same identifier (e.g., email). This is an enterprise-gated feature that Ory must enable for the project (the `use_auto_link` feature flag); without the entitlement, setting this to true is rejected by the API with an HTTP 403 (feature_not_available)."
     deprecated_name: enable_oidc_auto_link_policy
     deprecated_go_field: EnableOIDCAutoLinkPolicy
 

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -319,6 +319,12 @@ func TestAccProjectConfigResource_oidc(t *testing.T) {
 // (see internal/client) instead of a bare "403 Forbidden". This test requires a
 // project on a plan that includes the feature.
 func TestAccProjectConfigResource_oidcAutoLinkPolicy(t *testing.T) {
+	// Enabling the auto-link policy requires the enterprise use_auto_link
+	// entitlement; without it the API returns 403 feature_not_available, so this
+	// test only runs when ORY_AUTO_LINK_TESTS_ENABLED=true against an entitled
+	// project.
+	acctest.RequireAutoLinkTests(t)
+
 	enabled := map[string]string{"EnableAutoLink": "true"}
 	disabled := map[string]string{"EnableAutoLink": "false"}
 

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -309,18 +309,56 @@ func TestAccProjectConfigResource_oidc(t *testing.T) {
 	})
 }
 
+// TestAccProjectConfigResource_oidcAutoLinkPolicy covers create, import, update
+// and idempotency for the OIDC auto-link policy toggle.
+//
+// Note: the auto-link policy is a plan-gated feature. Setting it to true on a
+// project whose subscription plan does not include the "Auto Link Policy"
+// feature is rejected by the Ory API with a 403 feature_not_available. The
+// provider surfaces that feature name, reason, and request ID via wrapAPIError
+// (see internal/client) instead of a bare "403 Forbidden". This test requires a
+// project on a plan that includes the feature.
 func TestAccProjectConfigResource_oidcAutoLinkPolicy(t *testing.T) {
+	enabled := map[string]string{"EnableAutoLink": "true"}
+	disabled := map[string]string{"EnableAutoLink": "false"}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
 		Steps: []resource.TestStep{
+			// Create with the auto-link policy enabled.
 			{
-				Config: acctest.LoadTestConfig(t, "testdata/oidc_auto_link_policy.tf.tmpl", nil),
+				Config: acctest.LoadTestConfig(t, "testdata/oidc_auto_link_policy.tf.tmpl", enabled),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ory_project_config.test", "id"),
 					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_methods_oidc_enabled", "true"),
 					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_methods_oidc_enable_auto_link_policy", "true"),
 				),
+			},
+			// ImportState — import only sets id/project_id, so configured
+			// attributes (and computed defaults like cors_enabled) are not
+			// repopulated until apply and must be ignored here.
+			{
+				ResourceName:      "ory_project_config.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"selfservice_methods_oidc_enabled",
+					"selfservice_methods_oidc_enable_auto_link_policy",
+					"cors_enabled",
+				},
+			},
+			// Update — toggle the auto-link policy back off.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/oidc_auto_link_policy.tf.tmpl", disabled),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_methods_oidc_enable_auto_link_policy", "false"),
+				),
+			},
+			// Verify no perpetual diff.
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/oidc_auto_link_policy.tf.tmpl", disabled),
+				PlanOnly: true,
 			},
 		},
 	})

--- a/internal/resources/projectconfig/schema_gen.go
+++ b/internal/resources/projectconfig/schema_gen.go
@@ -312,11 +312,11 @@ func simpleSchemaAttributes() map[string]schema.Attribute {
 			DeprecationMessage: "Use selfservice_methods_oidc_enabled instead. This attribute will be removed in a future major version.",
 		},
 		"selfservice_methods_oidc_enable_auto_link_policy": schema.BoolAttribute{
-			Description: "Enable the OIDC auto-link policy. When true, social sign-in providers with auto_link enabled (on ory_social_provider) can automatically link to existing identities that share the same identifier (e.g., email).",
+			Description: "Enable the OIDC auto-link policy. When true, social sign-in providers with auto_link enabled (on ory_social_provider) can automatically link to existing identities that share the same identifier (e.g., email). This is an enterprise-gated feature that Ory must enable for the project (the `use_auto_link` feature flag); without the entitlement, setting this to true is rejected by the API with an HTTP 403 (feature_not_available).",
 			Optional:    true,
 		},
 		"enable_oidc_auto_link_policy": schema.BoolAttribute{
-			Description:        "Enable the OIDC auto-link policy. When true, social sign-in providers with auto_link enabled (on ory_social_provider) can automatically link to existing identities that share the same identifier (e.g., email).",
+			Description:        "Enable the OIDC auto-link policy. When true, social sign-in providers with auto_link enabled (on ory_social_provider) can automatically link to existing identities that share the same identifier (e.g., email). This is an enterprise-gated feature that Ory must enable for the project (the `use_auto_link` feature flag); without the entitlement, setting this to true is rejected by the API with an HTTP 403 (feature_not_available).",
 			Optional:           true,
 			DeprecationMessage: "Use selfservice_methods_oidc_enable_auto_link_policy instead. This attribute will be removed in a future major version.",
 		},

--- a/internal/resources/projectconfig/testdata/oidc_auto_link_policy.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/oidc_auto_link_policy.tf.tmpl
@@ -1,4 +1,4 @@
 resource "ory_project_config" "test" {
   selfservice_methods_oidc_enabled                 = true
-  selfservice_methods_oidc_enable_auto_link_policy = true
+  selfservice_methods_oidc_enable_auto_link_policy = [[ .EnableAutoLink ]]
 }

--- a/templates/resources/project_config.md.tmpl
+++ b/templates/resources/project_config.md.tmpl
@@ -18,6 +18,8 @@ This resource supports drift detection — `terraform plan` will detect changes 
 
 ~> **Note:** Only attributes present in your Terraform configuration are tracked for drift. Attributes you have not configured will not appear in plan output, even if they have non-default values in the API.
 
+~> **Plan-gated features:** Some settings require a feature that your project's subscription must include, and the Ory API rejects them with an `HTTP 403 (feature_not_available)` otherwise. Notably, `selfservice_methods_oidc_enable_auto_link_policy = true` requires the OIDC auto-link policy (`use_auto_link`), an enterprise feature that Ory enables per project on request — being on an enterprise plan does not enable it automatically. If an apply fails with a `feature_not_available` error, the provider surfaces the feature name and a request ID; contact Ory support or your account executive to enable the feature.
+
 ## Example Usage
 
 {{ tffile "examples/resources/ory_project_config/resource.tf" }}


### PR DESCRIPTION
## Description

Enabling a plan-gated `ory_project_config` setting on a project that lacks the entitlement previously failed with an opaque `403 Forbidden` and no indication of the cause. The clearest example is the OIDC auto-link policy: setting `selfservice_methods_oidc_enable_auto_link_policy = true` on a project without the `use_auto_link` feature returns an `HTTP 403 feature_not_available`, but the provider discarded the response body, so users only saw `403 Forbidden` and had to binary-search their configuration to find the offending attribute.

`client.PatchProject` returned the raw SDK error instead of passing it through the existing `wrapAPIError` helper that ~30 other console operations already use. This PR routes `PatchProject` errors through `wrapAPIError`, whose `feature_not_available` branch surfaces the feature name, the API reason (including the pricing link), and a request ID. No new error-handling code was needed, only the missing wrap.

Before:

```
Error: Error Applying Project Config

403 Forbidden
```

After:

```
Error: Error Applying Project Config

patching project: feature 'auto_link_policy' not available on current plan.
Reason: This project's subscription plan does not include feature "Auto Link Policy".
Please take a look at https://www.ory.com/pricing/ to select an appropriate plan and upgrade accordingly.
Request ID: <id> (provide this to Ory support)
```

Documentation for `selfservice_methods_oidc_enable_auto_link_policy` now notes that it is an enterprise-gated feature (`use_auto_link`) that Ory enables per project on request; being on an enterprise plan does not enable it automatically.

## Related Issues

Fixes #271

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

- Added `TestWrapAPIError_FeatureNotAvailable`, `TestWrapAPIError_Forbidden`, and `TestPatchProject_WrapsFeatureNotAvailable`. The last drives the real SDK error path through an `httptest` server returning the exact production `feature_not_available` body, so the test fails if the wrap is ever removed.
- Extended `TestAccProjectConfigResource_oidcAutoLinkPolicy` to cover create, import, update, and idempotency.
- Verified end-to-end against the live Ory Network API with a locally built provider: applying `selfservice_methods_oidc_enable_auto_link_policy = true` to a project without the entitlement now produces the detailed error above instead of a bare `403 Forbidden`. The 403 rejects the patch, so the project is left unchanged.
- `make build`, `make format`, `make test`, and `make sec` all pass (gosec 0 issues, gitleaks no leaks).

## Screenshots/Output

Terraform apply against a project without the entitlement, using the locally built provider:

```
ory_project_config.test: Creating...

Error: Error Applying Project Config

  with ory_project_config.test,
  on main.tf line 11, in resource "ory_project_config" "test":
  11: resource "ory_project_config" "test" {

patching project: feature 'auto_link_policy' not available on current plan.
Reason: This project's subscription plan does not include feature "Auto Link
Policy". Please take a look at https://www.ory.com/pricing/ to select an
appropriate plan and upgrade accordingly.
Request ID: a146596f-8bf9-9af6-ba25-bae9340fb598 (provide this to Ory
support)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for plan-gated project settings, including clearer notes on when certain OIDC auto-link options require an enterprise entitlement and may be rejected with a 403 error.
  * Expanded resource descriptions so the UI and docs better explain entitlement-related behavior.

* **Bug Fixes**
  * Improved project update error messages to surface more helpful context when a setting is not available, including the feature name and request details.
  * Strengthened project config handling and tests around enabling, disabling, and re-applying the OIDC auto-link policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->