### PR TITLE
feat: add write-only (ephemeral) arguments for secrets

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,17 +29,41 @@ When using this provider:
 
 Use Terraform's sensitive variable handling and state encryption to protect these values.
 
-### Write-only secrets
+### Not-read-back secrets (still stored in state)
 
-Some secrets are **write-only**: the provider sends them to the Ory API on create
-and update, but the API does not return them in its responses, so the provider never
-reads them back from the API. The value configured in Terraform is the source of
-truth (and is still stored in state, masked as sensitive). Because the provider does
-not refresh these from the API, it tolerates the API omitting the value or returning
-a masked sentinel (such as `****`) without producing a spurious diff:
+Some secrets are sent to the Ory API on create and update, but the API does not
+return them in its responses, so the provider never reads them back. The value
+configured in Terraform is the source of truth and is **still stored in state**,
+masked as sensitive. Because the provider does not refresh these from the API, it
+tolerates the API omitting the value or returning a masked sentinel (such as
+`****`) without producing a spurious diff:
 
 - `smtp_connection_uri` in `ory_project_config`
 - `client_secret` and `apple_private_key` in `ory_social_provider`
 
 These values still originate from your configuration, so keep them in sensitive
 variables and protect your state as described above.
+
+### Write-only arguments (never stored in state)
+
+For stronger protection, several secrets also offer **write-only** arguments
+(Terraform 1.11+ [write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only)).
+A write-only value is sent to the Ory API but is **never written to Terraform state
+or plan** — making it ideal for credentials sourced from an ephemeral resource such
+as a Vault secret. Each write-only argument is mutually exclusive with its stateful
+counterpart and has a companion `*_wo_version` attribute; because write-only values
+are not stored, Terraform cannot diff them, so you change the version whenever the
+secret rotates to have the provider re-send it.
+
+| Resource | Write-only argument | Stateful counterpart |
+|----------|---------------------|----------------------|
+| `ory_social_provider` | `client_id_wo`, `client_secret_wo`, `apple_private_key_wo` | `client_id`, `client_secret`, `apple_private_key` |
+| `ory_identity` | `password_wo` | `password` |
+| `ory_action` | `webhook_auth_basic_auth_password_wo`, `webhook_auth_api_key_value_wo` | `webhook_auth_basic_auth_password`, `webhook_auth_api_key_value` |
+| `ory_oauth2_client` | `jwks_wo` | `jwks` |
+| `ory_project_config` | `smtp_connection_uri_wo` | `smtp_connection_uri` |
+
+> **Note:** Write-only values are only available to the provider during create and
+> update (Terraform does not expose them during refresh or import). Importing a
+> resource therefore cannot recover a write-only value — re-supply it in your
+> configuration after import.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,8 +40,10 @@ tolerates the API omitting the value or returning a masked sentinel (such as
 
 - `smtp_connection_uri` in `ory_project_config`
 - `client_secret` and `apple_private_key` in `ory_social_provider`
+- `password` in `ory_identity`
+- `client_secret` in `ory_oauth2_client` (server-generated; returned only on create, never on subsequent reads)
 
-These values still originate from your configuration, so keep them in sensitive
+These values still originate from your configuration (or, for `ory_oauth2_client.client_secret`, from the create response), so keep them in sensitive
 variables and protect your state as described above.
 
 ### Write-only arguments (never stored in state)

--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -41,6 +41,27 @@ resource "ory_action" "validate_login" {
   can_interrupt = true # Allow webhook to block login
 }
 
+# Webhook with write-only (ephemeral) authentication secrets sourced from Vault.
+# The *_wo secrets are never stored in Terraform state or plan (Terraform 1.11+).
+# Bump the matching *_wo_version whenever a secret rotates so Terraform re-sends it.
+ephemeral "vault_kv_secret_v2" "webhook_auth" {
+  mount = "secret"
+  name  = "ory/webhook-auth"
+}
+
+resource "ory_action" "secured_webhook" {
+  flow        = "registration"
+  timing      = "after"
+  auth_method = "password"
+  url         = "https://api.example.com/webhooks/secured"
+  method      = "POST"
+
+  webhook_auth_type                           = "basic_auth"
+  webhook_auth_basic_auth_user                = "webhook-user"
+  webhook_auth_basic_auth_password_wo         = ephemeral.vault_kv_secret_v2.webhook_auth.data["password"]
+  webhook_auth_basic_auth_password_wo_version = "1"
+}
+
 # Async audit log (fire and forget)
 resource "ory_action" "audit_log" {
   flow            = "settings"
@@ -239,6 +260,8 @@ Common issues:
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `auth_method` (String) Authentication method that triggers the webhook. In the Ory Console UI, this is the "Method" selector. Valid values: `password` (default), `oidc` (social login), `code` (magic link/OTP), `webauthn`, `passkey`, `totp`, `lookup_secret`. Only applies to `timing = "after"` webhooks on the `login`, `registration`, and `settings` flows; it is ignored for the `recovery` and `verification` flows.
 - `body` (String) Jsonnet template for the request body.
 - `can_interrupt` (Boolean) Allow webhook to interrupt/block the flow (default: false).
@@ -248,8 +271,12 @@ Common issues:
 - `response_parse` (Boolean) Parse response to modify identity (default: false).
 - `webhook_auth_api_key_in` (String) Where to send the API key: 'header' or 'cookie'.
 - `webhook_auth_api_key_name` (String) Header or cookie name for API key webhook authentication.
-- `webhook_auth_api_key_value` (String, Sensitive) API key value for API key webhook authentication.
-- `webhook_auth_basic_auth_password` (String, Sensitive) Password for basic auth webhook authentication.
+- `webhook_auth_api_key_value` (String, Sensitive) API key value for API key webhook authentication. Stored in Terraform state; for an ephemeral alternative that is never persisted, use webhook_auth_api_key_value_wo.
+- `webhook_auth_api_key_value_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only equivalent of webhook_auth_api_key_value (Terraform 1.11+ write-only argument): the value is sent to Ory but never stored in Terraform state or plan. Use this to source the API key from an ephemeral resource such as a Vault secret. Because write-only values are not persisted, Terraform cannot detect when the value changes on its own — change webhook_auth_api_key_value_wo_version to rotate it. Mutually exclusive with webhook_auth_api_key_value.
+- `webhook_auth_api_key_value_wo_version` (String) Version trigger for webhook_auth_api_key_value_wo. Change this value whenever the write-only API key changes so Terraform sends the new value to Ory (write-only values are not stored in state and cannot be diffed). Has no effect unless webhook_auth_api_key_value_wo is set.
+- `webhook_auth_basic_auth_password` (String, Sensitive) Password for basic auth webhook authentication. Stored in Terraform state; for an ephemeral alternative that is never persisted, use webhook_auth_basic_auth_password_wo.
+- `webhook_auth_basic_auth_password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only equivalent of webhook_auth_basic_auth_password (Terraform 1.11+ write-only argument): the value is sent to Ory but never stored in Terraform state or plan. Use this to source the password from an ephemeral resource such as a Vault secret. Because write-only values are not persisted, Terraform cannot detect when the value changes on its own — change webhook_auth_basic_auth_password_wo_version to rotate it. Mutually exclusive with webhook_auth_basic_auth_password.
+- `webhook_auth_basic_auth_password_wo_version` (String) Version trigger for webhook_auth_basic_auth_password_wo. Change this value whenever the write-only password changes so Terraform sends the new value to Ory (write-only values are not stored in state and cannot be diffed). Has no effect unless webhook_auth_basic_auth_password_wo is set.
 - `webhook_auth_basic_auth_user` (String) Username for basic auth webhook authentication.
 - `webhook_auth_type` (String) Webhook authentication type: 'basic_auth' or 'api_key'.
 

--- a/docs/resources/identity.md
+++ b/docs/resources/identity.md
@@ -70,6 +70,24 @@ resource "ory_identity" "user_with_password" {
   state    = "active"
 }
 
+# Identity with a write-only (ephemeral) password sourced from Vault.
+# password_wo is never stored in Terraform state or plan (Terraform 1.11+).
+# Bump password_wo_version whenever the password rotates so Terraform re-sends it.
+ephemeral "vault_kv_secret_v2" "user_password" {
+  mount = "secret"
+  name  = "ory/user-password"
+}
+
+resource "ory_identity" "user_with_write_only_password" {
+  schema_id = "preset://email"
+  traits = jsonencode({
+    email = "ephemeral-user@example.com"
+  })
+  password_wo         = ephemeral.vault_kv_secret_v2.user_password.data["password"]
+  password_wo_version = "1"
+  state               = "active"
+}
+
 # Identity with custom schema and metadata
 resource "ory_identity" "customer" {
   schema_id = ory_identity_schema.customer.schema_id
@@ -138,9 +156,13 @@ terraform import ory_identity.user <identity-id>
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `metadata_admin` (String, Sensitive) Admin metadata as JSON string. Only visible to admins.
 - `metadata_public` (String) Public metadata as JSON string. Visible to the identity.
-- `password` (String, Sensitive) Password for the identity. Write-only, not returned on read.
+- `password` (String, Sensitive) Password for the identity. Not returned on read. Stored in Terraform state; for an ephemeral alternative that is never persisted, use password_wo. Exactly one of password or password_wo may be set.
+- `password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only equivalent of password (Terraform 1.11+ write-only argument): the value is sent to Ory but never stored in Terraform state or plan. Use this to source the password from an ephemeral resource such as a Vault secret. Because write-only values are not persisted, Terraform cannot detect when the value changes on its own — change password_wo_version to rotate it. Mutually exclusive with password.
+- `password_wo_version` (String) Version trigger for password_wo. Change this value whenever the write-only password_wo changes so Terraform sends the new password to Ory (write-only values are not stored in state and cannot be diffed). Has no effect unless password_wo is set.
 - `project_api_key` (String, Sensitive) Project API key for API access. Use this to pass credentials at the resource level when the provider is configured before the project exists (e.g., creating a project and identity in the same apply). Overrides the provider-level project_api_key.
 - `project_slug` (String) Project slug for API access. Use this to pass credentials at the resource level when the provider is configured before the project exists (e.g., creating a project and identity in the same apply). Overrides the provider-level project_slug.
 - `state` (String) Identity state: active or inactive.

--- a/docs/resources/oauth2_client.md
+++ b/docs/resources/oauth2_client.md
@@ -47,6 +47,23 @@ resource "ory_oauth2_client" "api_service" {
   client_credentials_grant_access_token_lifespan = "30m"
 }
 
+# Client using private_key_jwt with a write-only (ephemeral) JWKS from Vault.
+# jwks_wo is never stored in Terraform state or plan (Terraform 1.11+). Bump
+# jwks_wo_version whenever the key set rotates so Terraform re-sends it.
+ephemeral "vault_kv_secret_v2" "client_jwks" {
+  mount = "secret"
+  name  = "ory/client-jwks"
+}
+
+resource "ory_oauth2_client" "private_key_jwt_client" {
+  client_name                = "Private Key JWT Client"
+  grant_types                = ["client_credentials"]
+  token_endpoint_auth_method = "private_key_jwt"
+
+  jwks_wo         = ephemeral.vault_kv_secret_v2.client_jwks.data["jwks"]
+  jwks_wo_version = "1"
+}
+
 # Web application (Authorization Code flow) with OIDC logout and metadata
 resource "ory_oauth2_client" "web_app" {
   client_name    = "Web Application"
@@ -343,6 +360,8 @@ terraform import ory_oauth2_client.api <client-id>
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `access_token_strategy` (String) Access token strategy: jwt or opaque.
 - `allowed_cors_origins` (List of String) List of allowed CORS origins for this client.
 - `audience` (List of String) List of allowed audiences for tokens.
@@ -363,8 +382,10 @@ terraform import ory_oauth2_client.api <client-id>
 - `grant_types` (List of String) OAuth2 grant types: authorization_code, implicit, client_credentials, refresh_token.
 - `implicit_grant_access_token_lifespan` (String) Access token lifespan for implicit grant (e.g., '1h', '30m').
 - `implicit_grant_id_token_lifespan` (String) ID token lifespan for implicit grant (e.g., '1h', '30m').
-- `jwks` (String, Sensitive) Inline JSON Web Key Set (JWKS) as a JSON string. Use this to provide keys directly instead of via jwks_uri. Mutually exclusive with jwks_uri. Marked sensitive because JWKS may contain private key material.
+- `jwks` (String, Sensitive) Inline JSON Web Key Set (JWKS) as a JSON string. Use this to provide keys directly instead of via jwks_uri. Mutually exclusive with jwks_uri. Marked sensitive because JWKS may contain private key material. Stored in Terraform state; for an ephemeral alternative that is never persisted, use jwks_wo.
 - `jwks_uri` (String) URL of the client's JSON Web Key Set for private_key_jwt authentication. Mutually exclusive with jwks.
+- `jwks_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only equivalent of jwks (Terraform 1.11+ write-only argument): the inline JSON Web Key Set is sent to Ory but never stored in Terraform state or plan. Use this to source private key material from an ephemeral resource such as a Vault secret. Because write-only values are not persisted, Terraform cannot detect when the value changes on its own — change jwks_wo_version to rotate it. Mutually exclusive with jwks and jwks_uri.
+- `jwks_wo_version` (String) Version trigger for jwks_wo. Change this value whenever the write-only jwks_wo changes so Terraform sends the new key set to Ory (write-only values are not stored in state and cannot be diffed). Has no effect unless jwks_wo is set.
 - `jwt_bearer_grant_access_token_lifespan` (String) Access token lifespan for JWT bearer grant (e.g., '1h', '30m').
 - `logo_uri` (String) URL of the client's logo.
 - `metadata` (String) Custom metadata as JSON string.

--- a/docs/resources/project_config.md
+++ b/docs/resources/project_config.md
@@ -29,6 +29,19 @@ resource "ory_project_config" "basic" {
   session_lifespan                                        = "720h0m0s" # 30 days
 }
 
+# Project configuration with a write-only (ephemeral) SMTP connection URI from Vault.
+# smtp_connection_uri_wo is never stored in Terraform state or plan (Terraform 1.11+).
+# Bump smtp_connection_uri_wo_version whenever the secret rotates so Terraform re-sends it.
+ephemeral "vault_kv_secret_v2" "smtp" {
+  mount = "secret"
+  name  = "ory/smtp"
+}
+
+resource "ory_project_config" "with_write_only_smtp" {
+  smtp_connection_uri_wo         = ephemeral.vault_kv_secret_v2.smtp.data["connection_uri"]
+  smtp_connection_uri_wo_version = "1"
+}
+
 # Full security configuration
 resource "ory_project_config" "secure" {
   # Public CORS
@@ -472,6 +485,8 @@ terraform plan  # verify no changes
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `account_experience_default_locale` (String) Default locale for the hosted login UI (e.g., 'en', 'de').
 - `account_experience_enabled_locales` (List of String) Enabled locales for the hosted login UI.
 - `account_experience_favicon_dark` (String) Favicon for the hosted Account Experience UI (dark theme). Must be an inline data URI (e.g. data:image/png;base64,...) or a storage URL previously returned by the API. The API uploads the image and serves it from a content-addressed storage URL; the provider matches that URL against the data URI by content hash to detect drift. Set to an empty string to remove.
@@ -722,6 +737,8 @@ terraform plan  # verify no changes
 - `settings_privileged_session_max_age` (String, Deprecated) Maximum age of a privileged session for the settings flow (e.g., '15m0s'). After this duration, the user must re-authenticate to make privileged changes like password updates.
 - `settings_ui_url` (String, Deprecated) URL for the account settings UI.
 - `smtp_connection_uri` (String, Sensitive) SMTP connection URI for sending emails. The URI scheme selects the security mode: `smtp://` uses STARTTLS (recommended for port 587), `smtps://` uses implicit TLS (recommended for port 465). Append `?disable_starttls=true` for cleartext or `?skip_ssl_verify=true` to skip certificate verification (development only). See the SMTP Security Modes section in the resource documentation for the full list.
+- `smtp_connection_uri_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only equivalent of smtp_connection_uri (Terraform 1.11+ write-only argument): the SMTP connection URI is sent to Ory but never stored in Terraform state or plan. Use this to source the value from an ephemeral resource such as a Vault secret. Because write-only values are not persisted, Terraform cannot detect when the value changes on its own — change smtp_connection_uri_wo_version to rotate it. Mutually exclusive with smtp_connection_uri.
+- `smtp_connection_uri_wo_version` (String) Version trigger for smtp_connection_uri_wo. Change this value whenever the write-only smtp_connection_uri_wo changes so Terraform sends the new value to Ory (write-only values are not stored in state and cannot be diffed). Has no effect unless smtp_connection_uri_wo is set.
 - `smtp_from_address` (String, Deprecated) Email address to send from.
 - `smtp_from_name` (String, Deprecated) Name to display as sender.
 - `smtp_headers` (Map of String) Custom SMTP headers for outbound emails.

--- a/docs/resources/social_provider.md
+++ b/docs/resources/social_provider.md
@@ -45,6 +45,43 @@ Ory uses these to automatically generate the JWT `client_secret` required by App
 
 Alternatively, you may provide a pre-generated `client_secret` directly if you prefer to manage the JWT yourself.
 
+## Ephemeral (Write-Only) Credentials
+
+In addition to `client_id`, `client_secret`, and `apple_private_key`, this resource
+exposes **write-only** equivalents that are never written to Terraform state or
+plan (Terraform 1.11+ [write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only)):
+
+| Write-only attribute | Replaces | Version trigger |
+|----------------------|----------|-----------------|
+| `client_id_wo` | `client_id` | `client_id_wo_version` |
+| `client_secret_wo` | `client_secret` | `client_secret_wo_version` |
+| `apple_private_key_wo` | `apple_private_key` | `apple_private_key_wo_version` |
+
+Each write-only attribute is mutually exclusive with its stateful counterpart. Use
+them to feed credentials from an ephemeral source such as a Vault secret without
+persisting them in state. Because write-only values are never stored, Terraform
+cannot detect when the value changes on its own — change the matching
+`*_wo_version` whenever the secret rotates so Terraform sends the new value to Ory.
+
+```hcl
+ephemeral "vault_kv_secret_v2" "google_oauth" {
+  mount = "secret"
+  name  = "ory/google-oauth"
+}
+
+resource "ory_social_provider" "google" {
+  provider_id   = "google"
+  provider_type = "google"
+
+  client_id_wo             = ephemeral.vault_kv_secret_v2.google_oauth.data["client_id"]
+  client_id_wo_version     = "1"
+  client_secret_wo         = ephemeral.vault_kv_secret_v2.google_oauth.data["client_secret"]
+  client_secret_wo_version = "1"
+
+  scope = ["email", "profile"]
+}
+```
+
 ## Example Usage
 
 ```terraform
@@ -55,6 +92,28 @@ resource "ory_social_provider" "google" {
   client_id     = var.google_client_id
   client_secret = var.google_client_secret
   scope         = ["email", "profile"]
+}
+
+# Google Sign-In with write-only (ephemeral) credentials sourced from Vault.
+# Write-only arguments (Terraform 1.11+) send the value to Ory without ever
+# storing it in state or plan — ideal for secrets read from an ephemeral
+# resource such as Vault. Bump the matching *_wo_version whenever a secret
+# changes so Terraform re-sends it (write-only values cannot be diffed).
+ephemeral "vault_kv_secret_v2" "google_oauth" {
+  mount = "secret"
+  name  = "ory/google-oauth"
+}
+
+resource "ory_social_provider" "google_write_only" {
+  provider_id   = "google-wo"
+  provider_type = "google"
+
+  client_id_wo             = ephemeral.vault_kv_secret_v2.google_oauth.data["client_id"]
+  client_id_wo_version     = "1"
+  client_secret_wo         = ephemeral.vault_kv_secret_v2.google_oauth.data["client_secret"]
+  client_secret_wo_version = "1"
+
+  scope = ["email", "profile"]
 }
 
 # Google Sign-In with automatic account linking
@@ -390,9 +449,9 @@ resource "ory_social_provider" "google" {
 ## Important Behaviors
 
 - **`provider_id` and `provider_type` cannot be changed** after creation. Changing either forces a new resource.
-- **`client_secret` is write-only.** The API does not return secrets on read, so Terraform cannot detect external changes to the secret.
+- **`client_secret` is not returned on read.** The API does not return secrets, so Terraform cannot detect external changes to the secret. (For a value that is never stored in state at all, use the write-only `client_secret_wo` — see [Ephemeral (Write-Only) Credentials](#ephemeral-write-only-credentials).)
 - **`tenant` maps to `microsoft_tenant`** in the Ory API. This is only used with `provider_type = "microsoft"`.
-- **Apple-specific fields** (`apple_team_id`, `apple_private_key_id`, `apple_private_key`) are only valid with `provider_type = "apple"`. The `apple_private_key` is write-only (not returned by API).
+- **Apple-specific fields** (`apple_team_id`, `apple_private_key_id`, `apple_private_key`) are only valid with `provider_type = "apple"`. The `apple_private_key` is not returned by the API on read.
 - **Deleting the last provider** resets the entire OIDC configuration to a disabled state with an empty providers array.
 
 ## Import
@@ -403,33 +462,41 @@ Import using the provider ID:
 terraform import ory_social_provider.google google
 ```
 
-The `provider_id` is the unique identifier you chose when creating the provider. After import, you must provide write-only credentials in your configuration since they cannot be read from the API:
+The `provider_id` is the unique identifier you chose when creating the provider. After import, you must provide the secret credentials in your configuration since they cannot be read from the API (either the stateful attributes below or their `_wo` write-only equivalents):
 
-- **Non-Apple providers:** Set `client_secret`.
-- **Apple providers:** Set either `client_secret` (pre-generated JWT) or all three Apple-specific fields (`apple_team_id`, `apple_private_key_id`, and `apple_private_key`).
+- **Non-Apple providers:** Set `client_secret` (or `client_secret_wo`).
+- **Apple providers:** Set either `client_secret` (pre-generated JWT) or all three Apple-specific fields (`apple_team_id`, `apple_private_key_id`, and `apple_private_key` / `apple_private_key_wo`).
 
 <!-- schema generated by tfplugindocs -->
 ## Schema
 
 ### Required
 
-- `client_id` (String) OAuth2 client ID from the provider.
 - `provider_id` (String) Unique identifier for the provider (used in callback URLs).
 - `provider_type` (String) Provider type (google, github, microsoft, apple, generic, etc.).
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `aal2_acr_values` (List of String) Upstream OpenID Connect `acr` claim values that elevate the resulting Ory session to AAL2. If the ID token returned by the upstream provider contains an `acr` claim matching any of these values, the user is not prompted for a second factor. Leave unset to always issue AAL1 sessions through this provider. Works with providers that return the `acr` claim (Auth0, Okta, Keycloak, PingFederate, Entra ID v1, generic enterprise IdPs).
 - `aal2_amr_values` (List of String) Upstream OpenID Connect `amr` values (per RFC 8176, for example `mfa`, `otp`, `hwk`) that mark the session AAL2 when they appear in the upstream `amr` array. Leave unset to ignore the `amr` claim.
 - `account_linking_mode` (String) Controls how accounts are linked when a user signs in with this provider and a matching identity already exists. "automatic" links without user interaction; "confirm_with_existing_credential" requires the user to verify ownership of the existing account first.
 - `additional_id_token_audiences` (List of String) Additional audiences allowed in the ID Token. Only relevant in OIDC flows that submit an ID Token directly instead of using the callback from the OIDC provider (e.g., native mobile apps signing in with Google or Apple where the app and the OIDC client are registered with different audiences).
-- `apple_private_key` (String, Sensitive) Apple private key in PEM format (contents of the .p8 file). Required when provider_type is "apple" and client_secret is not set. Ory uses this to generate the JWT client secret automatically.
+- `apple_private_key` (String, Sensitive) Apple private key in PEM format (contents of the .p8 file). Required when provider_type is "apple" and client_secret is not set. Ory uses this to generate the JWT client secret automatically. Exactly one of apple_private_key or apple_private_key_wo may be set.
 - `apple_private_key_id` (String) Apple private key ID from the Apple Developer portal (e.g., "UX56C66723"). Required when provider_type is "apple" and client_secret is not set.
+- `apple_private_key_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only equivalent of apple_private_key (Terraform 1.11+ write-only argument): the value is sent to Ory but never stored in Terraform state or plan. Use this to source the Apple private key from an ephemeral resource such as a Vault secret. Because write-only values are not persisted, Terraform cannot detect when the value changes on its own — change apple_private_key_wo_version to rotate it. Mutually exclusive with apple_private_key.
+- `apple_private_key_wo_version` (String) Version trigger for apple_private_key_wo. Change this value whenever the write-only apple_private_key_wo changes so Terraform sends the new key to Ory (write-only values are not stored in state and cannot be diffed). Has no effect unless apple_private_key_wo is set.
 - `apple_team_id` (String) Apple Developer Team ID (e.g., "KP76DQS54M"). Required when provider_type is "apple" and client_secret is not set.
 - `auth_url` (String) Custom authorization URL (for non-standard providers).
 - `auto_link` (Boolean) Enable automatic account linking for this provider. When true, if an identity with the same identifier (e.g., email) already exists, the social sign-in will automatically link to that identity instead of failing. Requires enable_oidc_auto_link_policy to be true in the project config (ory_project_config). This attribute is write-only — the API accepts it on create/update but does not return it on read, so Terraform preserves the value from state. On import, the value will not be populated. Removing this attribute from your configuration will automatically disable auto-linking server-side.
 - `base_redirect_uri` (String, Deprecated) Override the base redirect URI for OIDC callbacks (e.g., "https://iam.example.com"). When set, Ory constructs callback URLs using this base instead of the default project domain. This is a global OIDC config setting — if multiple social providers set different values, the last applied value wins.
-- `client_secret` (String, Sensitive) OAuth2 client secret from the provider. Required for all providers except Apple (where Ory generates the secret from apple_team_id, apple_private_key_id, and apple_private_key).
+- `client_id` (String) OAuth2 client ID from the provider. Exactly one of client_id or client_id_wo must be set.
+- `client_id_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only equivalent of client_id (Terraform 1.11+ write-only argument): the value is sent to Ory but never stored in Terraform state or plan. Use this to source the client ID from an ephemeral resource such as a Vault secret. Because write-only values are not persisted, Terraform cannot detect when the value changes on its own — change client_id_wo_version to force the new value to be sent. Mutually exclusive with client_id.
+- `client_id_wo_version` (String) Version trigger for client_id_wo. Change this value whenever the write-only client_id_wo changes so Terraform sends the new value to Ory (write-only values are not stored in state and cannot be diffed). Has no effect unless client_id_wo is set.
+- `client_secret` (String, Sensitive) OAuth2 client secret from the provider. Required for all providers except Apple (where Ory generates the secret from apple_team_id, apple_private_key_id, and apple_private_key). Exactly one of client_secret or client_secret_wo may be set.
+- `client_secret_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only equivalent of client_secret (Terraform 1.11+ write-only argument): the value is sent to Ory but never stored in Terraform state or plan. Use this to source the client secret from an ephemeral resource such as a Vault secret. Because write-only values are not persisted, Terraform cannot detect when the value changes on its own — change client_secret_wo_version to rotate it. Mutually exclusive with client_secret.
+- `client_secret_wo_version` (String) Version trigger for client_secret_wo. Change this value whenever the write-only client_secret_wo changes so Terraform sends the new secret to Ory (write-only values are not stored in state and cannot be diffed). Has no effect unless client_secret_wo is set.
 - `fedcm_config_url` (String) URL of the provider's FedCM (Federated Credential Management) configuration file. When set, Ory can use the browser's FedCM API for sign-in with this provider instead of a full-page redirect. For example, Google's FedCM configuration is served at "https://accounts.google.com/gsi/fedcm.json". Leave unset to disable FedCM for this provider.
 - `issuer_url` (String) OIDC issuer URL (required for generic providers).
 - `label` (String) Human-readable label for the provider, displayed on the login button (e.g., "Sign in with Corporate SSO").

--- a/examples/resources/ory_action/resource.tf
+++ b/examples/resources/ory_action/resource.tf
@@ -23,6 +23,27 @@ resource "ory_action" "validate_login" {
   can_interrupt = true # Allow webhook to block login
 }
 
+# Webhook with write-only (ephemeral) authentication secrets sourced from Vault.
+# The *_wo secrets are never stored in Terraform state or plan (Terraform 1.11+).
+# Bump the matching *_wo_version whenever a secret rotates so Terraform re-sends it.
+ephemeral "vault_kv_secret_v2" "webhook_auth" {
+  mount = "secret"
+  name  = "ory/webhook-auth"
+}
+
+resource "ory_action" "secured_webhook" {
+  flow        = "registration"
+  timing      = "after"
+  auth_method = "password"
+  url         = "https://api.example.com/webhooks/secured"
+  method      = "POST"
+
+  webhook_auth_type                           = "basic_auth"
+  webhook_auth_basic_auth_user                = "webhook-user"
+  webhook_auth_basic_auth_password_wo         = ephemeral.vault_kv_secret_v2.webhook_auth.data["password"]
+  webhook_auth_basic_auth_password_wo_version = "1"
+}
+
 # Async audit log (fire and forget)
 resource "ory_action" "audit_log" {
   flow            = "settings"

--- a/examples/resources/ory_identity/resource.tf
+++ b/examples/resources/ory_identity/resource.tf
@@ -16,6 +16,24 @@ resource "ory_identity" "user_with_password" {
   state    = "active"
 }
 
+# Identity with a write-only (ephemeral) password sourced from Vault.
+# password_wo is never stored in Terraform state or plan (Terraform 1.11+).
+# Bump password_wo_version whenever the password rotates so Terraform re-sends it.
+ephemeral "vault_kv_secret_v2" "user_password" {
+  mount = "secret"
+  name  = "ory/user-password"
+}
+
+resource "ory_identity" "user_with_write_only_password" {
+  schema_id = "preset://email"
+  traits = jsonencode({
+    email = "ephemeral-user@example.com"
+  })
+  password_wo         = ephemeral.vault_kv_secret_v2.user_password.data["password"]
+  password_wo_version = "1"
+  state               = "active"
+}
+
 # Identity with custom schema and metadata
 resource "ory_identity" "customer" {
   schema_id = ory_identity_schema.customer.schema_id

--- a/examples/resources/ory_oauth2_client/resource.tf
+++ b/examples/resources/ory_oauth2_client/resource.tf
@@ -12,6 +12,23 @@ resource "ory_oauth2_client" "api_service" {
   client_credentials_grant_access_token_lifespan = "30m"
 }
 
+# Client using private_key_jwt with a write-only (ephemeral) JWKS from Vault.
+# jwks_wo is never stored in Terraform state or plan (Terraform 1.11+). Bump
+# jwks_wo_version whenever the key set rotates so Terraform re-sends it.
+ephemeral "vault_kv_secret_v2" "client_jwks" {
+  mount = "secret"
+  name  = "ory/client-jwks"
+}
+
+resource "ory_oauth2_client" "private_key_jwt_client" {
+  client_name                = "Private Key JWT Client"
+  grant_types                = ["client_credentials"]
+  token_endpoint_auth_method = "private_key_jwt"
+
+  jwks_wo         = ephemeral.vault_kv_secret_v2.client_jwks.data["jwks"]
+  jwks_wo_version = "1"
+}
+
 # Web application (Authorization Code flow) with OIDC logout and metadata
 resource "ory_oauth2_client" "web_app" {
   client_name    = "Web Application"

--- a/examples/resources/ory_project_config/resource.tf
+++ b/examples/resources/ory_project_config/resource.tf
@@ -6,6 +6,19 @@ resource "ory_project_config" "basic" {
   session_lifespan                                        = "720h0m0s" # 30 days
 }
 
+# Project configuration with a write-only (ephemeral) SMTP connection URI from Vault.
+# smtp_connection_uri_wo is never stored in Terraform state or plan (Terraform 1.11+).
+# Bump smtp_connection_uri_wo_version whenever the secret rotates so Terraform re-sends it.
+ephemeral "vault_kv_secret_v2" "smtp" {
+  mount = "secret"
+  name  = "ory/smtp"
+}
+
+resource "ory_project_config" "with_write_only_smtp" {
+  smtp_connection_uri_wo         = ephemeral.vault_kv_secret_v2.smtp.data["connection_uri"]
+  smtp_connection_uri_wo_version = "1"
+}
+
 # Full security configuration
 resource "ory_project_config" "secure" {
   # Public CORS

--- a/examples/resources/ory_social_provider/resource.tf
+++ b/examples/resources/ory_social_provider/resource.tf
@@ -7,6 +7,28 @@ resource "ory_social_provider" "google" {
   scope         = ["email", "profile"]
 }
 
+# Google Sign-In with write-only (ephemeral) credentials sourced from Vault.
+# Write-only arguments (Terraform 1.11+) send the value to Ory without ever
+# storing it in state or plan — ideal for secrets read from an ephemeral
+# resource such as Vault. Bump the matching *_wo_version whenever a secret
+# changes so Terraform re-sends it (write-only values cannot be diffed).
+ephemeral "vault_kv_secret_v2" "google_oauth" {
+  mount = "secret"
+  name  = "ory/google-oauth"
+}
+
+resource "ory_social_provider" "google_write_only" {
+  provider_id   = "google-wo"
+  provider_type = "google"
+
+  client_id_wo             = ephemeral.vault_kv_secret_v2.google_oauth.data["client_id"]
+  client_id_wo_version     = "1"
+  client_secret_wo         = ephemeral.vault_kv_secret_v2.google_oauth.data["client_secret"]
+  client_secret_wo_version = "1"
+
+  scope = ["email", "profile"]
+}
+
 # Google Sign-In with automatic account linking
 resource "ory_social_provider" "google_auto_link" {
   provider_id   = "google-auto-link"

--- a/internal/resources/action/resource.go
+++ b/internal/resources/action/resource.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -18,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	ory "github.com/ory/client-go"
 
@@ -77,12 +79,16 @@ type ActionResourceModel struct {
 	CanInterrupt   types.Bool   `tfsdk:"can_interrupt"`
 
 	// Webhook authentication configuration
-	WebhookAuthType              types.String `tfsdk:"webhook_auth_type"`
-	WebhookAuthBasicAuthUser     types.String `tfsdk:"webhook_auth_basic_auth_user"`
-	WebhookAuthBasicAuthPassword types.String `tfsdk:"webhook_auth_basic_auth_password"`
-	WebhookAuthAPIKeyName        types.String `tfsdk:"webhook_auth_api_key_name"`
-	WebhookAuthAPIKeyValue       types.String `tfsdk:"webhook_auth_api_key_value"`
-	WebhookAuthAPIKeyIn          types.String `tfsdk:"webhook_auth_api_key_in"`
+	WebhookAuthType                       types.String `tfsdk:"webhook_auth_type"`
+	WebhookAuthBasicAuthUser              types.String `tfsdk:"webhook_auth_basic_auth_user"`
+	WebhookAuthBasicAuthPassword          types.String `tfsdk:"webhook_auth_basic_auth_password"`
+	WebhookAuthBasicAuthPasswordWO        types.String `tfsdk:"webhook_auth_basic_auth_password_wo"`
+	WebhookAuthBasicAuthPasswordWOVersion types.String `tfsdk:"webhook_auth_basic_auth_password_wo_version"`
+	WebhookAuthAPIKeyName                 types.String `tfsdk:"webhook_auth_api_key_name"`
+	WebhookAuthAPIKeyValue                types.String `tfsdk:"webhook_auth_api_key_value"`
+	WebhookAuthAPIKeyValueWO              types.String `tfsdk:"webhook_auth_api_key_value_wo"`
+	WebhookAuthAPIKeyValueWOVersion       types.String `tfsdk:"webhook_auth_api_key_value_wo_version"`
+	WebhookAuthAPIKeyIn                   types.String `tfsdk:"webhook_auth_api_key_in"`
 }
 
 const actionMarkdownDescription = `
@@ -309,7 +315,7 @@ func (r *ActionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"webhook_auth_basic_auth_password": schema.StringAttribute{
-				Description: "Password for basic auth webhook authentication.",
+				Description: "Password for basic auth webhook authentication. Stored in Terraform state; for an ephemeral alternative that is never persisted, use webhook_auth_basic_auth_password_wo.",
 				Optional:    true,
 				Sensitive:   true,
 				Validators: []validator.String{
@@ -319,6 +325,28 @@ func (r *ActionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						path.MatchRoot("webhook_auth_api_key_value"),
 						path.MatchRoot("webhook_auth_api_key_in"),
 					),
+				},
+			},
+			"webhook_auth_basic_auth_password_wo": schema.StringAttribute{
+				Description: "Write-only equivalent of webhook_auth_basic_auth_password (Terraform 1.11+ write-only argument): the value is sent to Ory but never stored in Terraform state or plan. Use this to source the password from an ephemeral resource such as a Vault secret. Because write-only values are not persisted, Terraform cannot detect when the value changes on its own — change webhook_auth_basic_auth_password_wo_version to rotate it. Mutually exclusive with webhook_auth_basic_auth_password.",
+				Optional:    true,
+				WriteOnly:   true,
+				Sensitive:   true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.MatchRoot("webhook_auth_type")),
+					stringvalidator.ConflictsWith(
+						path.MatchRoot("webhook_auth_basic_auth_password"),
+						path.MatchRoot("webhook_auth_api_key_name"),
+						path.MatchRoot("webhook_auth_api_key_value"),
+						path.MatchRoot("webhook_auth_api_key_in"),
+					),
+				},
+			},
+			"webhook_auth_basic_auth_password_wo_version": schema.StringAttribute{
+				Description: "Version trigger for webhook_auth_basic_auth_password_wo. Change this value whenever the write-only password changes so Terraform sends the new value to Ory (write-only values are not stored in state and cannot be diffed). Has no effect unless webhook_auth_basic_auth_password_wo is set.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.MatchRoot("webhook_auth_basic_auth_password_wo")),
 				},
 			},
 			"webhook_auth_api_key_name": schema.StringAttribute{
@@ -333,7 +361,7 @@ func (r *ActionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"webhook_auth_api_key_value": schema.StringAttribute{
-				Description: "API key value for API key webhook authentication.",
+				Description: "API key value for API key webhook authentication. Stored in Terraform state; for an ephemeral alternative that is never persisted, use webhook_auth_api_key_value_wo.",
 				Optional:    true,
 				Sensitive:   true,
 				Validators: []validator.String{
@@ -342,6 +370,28 @@ func (r *ActionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						path.MatchRoot("webhook_auth_basic_auth_user"),
 						path.MatchRoot("webhook_auth_basic_auth_password"),
 					),
+				},
+			},
+			"webhook_auth_api_key_value_wo": schema.StringAttribute{
+				Description: "Write-only equivalent of webhook_auth_api_key_value (Terraform 1.11+ write-only argument): the value is sent to Ory but never stored in Terraform state or plan. Use this to source the API key from an ephemeral resource such as a Vault secret. Because write-only values are not persisted, Terraform cannot detect when the value changes on its own — change webhook_auth_api_key_value_wo_version to rotate it. Mutually exclusive with webhook_auth_api_key_value.",
+				Optional:    true,
+				WriteOnly:   true,
+				Sensitive:   true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.MatchRoot("webhook_auth_type")),
+					stringvalidator.ConflictsWith(
+						path.MatchRoot("webhook_auth_api_key_value"),
+						path.MatchRoot("webhook_auth_basic_auth_user"),
+						path.MatchRoot("webhook_auth_basic_auth_password"),
+						path.MatchRoot("webhook_auth_basic_auth_password_wo"),
+					),
+				},
+			},
+			"webhook_auth_api_key_value_wo_version": schema.StringAttribute{
+				Description: "Version trigger for webhook_auth_api_key_value_wo. Change this value whenever the write-only API key changes so Terraform sends the new value to Ory (write-only values are not stored in state and cannot be diffed). Has no effect unless webhook_auth_api_key_value_wo is set.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.MatchRoot("webhook_auth_api_key_value_wo")),
 				},
 			},
 			"webhook_auth_api_key_in": schema.StringAttribute{
@@ -426,11 +476,14 @@ func (r *ActionResource) ValidateConfig(ctx context.Context, req resource.Valida
 				"webhook_auth_basic_auth_user is required when webhook_auth_type is \"basic_auth\".",
 			)
 		}
-		if !config.WebhookAuthBasicAuthPassword.IsUnknown() && config.WebhookAuthBasicAuthPassword.IsNull() {
+		// The password may be supplied via webhook_auth_basic_auth_password or its
+		// write-only counterpart. Only error when both are known and null.
+		if !config.WebhookAuthBasicAuthPassword.IsUnknown() && config.WebhookAuthBasicAuthPassword.IsNull() &&
+			!config.WebhookAuthBasicAuthPasswordWO.IsUnknown() && config.WebhookAuthBasicAuthPasswordWO.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("webhook_auth_basic_auth_password"),
 				"Missing Required Attribute",
-				"webhook_auth_basic_auth_password is required when webhook_auth_type is \"basic_auth\".",
+				"webhook_auth_basic_auth_password (or webhook_auth_basic_auth_password_wo) is required when webhook_auth_type is \"basic_auth\".",
 			)
 		}
 	case webhookAuthAPIKey:
@@ -441,11 +494,14 @@ func (r *ActionResource) ValidateConfig(ctx context.Context, req resource.Valida
 				"webhook_auth_api_key_name is required when webhook_auth_type is \"api_key\".",
 			)
 		}
-		if !config.WebhookAuthAPIKeyValue.IsUnknown() && config.WebhookAuthAPIKeyValue.IsNull() {
+		// The API key value may be supplied via webhook_auth_api_key_value or its
+		// write-only counterpart. Only error when both are known and null.
+		if !config.WebhookAuthAPIKeyValue.IsUnknown() && config.WebhookAuthAPIKeyValue.IsNull() &&
+			!config.WebhookAuthAPIKeyValueWO.IsUnknown() && config.WebhookAuthAPIKeyValueWO.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("webhook_auth_api_key_value"),
 				"Missing Required Attribute",
-				"webhook_auth_api_key_value is required when webhook_auth_type is \"api_key\".",
+				"webhook_auth_api_key_value (or webhook_auth_api_key_value_wo) is required when webhook_auth_type is \"api_key\".",
 			)
 		}
 		if !config.WebhookAuthAPIKeyIn.IsUnknown() && config.WebhookAuthAPIKeyIn.IsNull() {
@@ -458,7 +514,12 @@ func (r *ActionResource) ValidateConfig(ctx context.Context, req resource.Valida
 	}
 }
 
-func (r *ActionResource) buildHookValue(plan *ActionResourceModel) map[string]interface{} {
+// buildHookValue builds the Ory web_hook config map. basicAuthPassword and
+// apiKeyValue carry the resolved secret values (the write-only _wo value when
+// set, otherwise the stateful attribute), read from req.Config by
+// resolveAuthSecrets. They are used only to build the API payload and are never
+// written back into the model, so they never reach Terraform state.
+func (r *ActionResource) buildHookValue(plan *ActionResourceModel, basicAuthPassword, apiKeyValue types.String) map[string]interface{} {
 	hookConfig := map[string]interface{}{
 		"url":    plan.URL.ValueString(),
 		"method": plan.HTTPMethod.ValueString(),
@@ -497,17 +558,17 @@ func (r *ActionResource) buildHookValue(plan *ActionResourceModel) map[string]in
 		switch authType {
 		case webhookAuthBasicAuth:
 			if !plan.WebhookAuthBasicAuthUser.IsNull() && !plan.WebhookAuthBasicAuthUser.IsUnknown() &&
-				!plan.WebhookAuthBasicAuthPassword.IsNull() && !plan.WebhookAuthBasicAuthPassword.IsUnknown() {
+				!basicAuthPassword.IsNull() && !basicAuthPassword.IsUnknown() {
 				authCfg["user"] = plan.WebhookAuthBasicAuthUser.ValueString()
-				authCfg["password"] = plan.WebhookAuthBasicAuthPassword.ValueString()
+				authCfg["password"] = basicAuthPassword.ValueString()
 				hasValidAuthConfig = true
 			}
 		case webhookAuthAPIKey:
 			if !plan.WebhookAuthAPIKeyName.IsNull() && !plan.WebhookAuthAPIKeyName.IsUnknown() &&
-				!plan.WebhookAuthAPIKeyValue.IsNull() && !plan.WebhookAuthAPIKeyValue.IsUnknown() &&
+				!apiKeyValue.IsNull() && !apiKeyValue.IsUnknown() &&
 				!plan.WebhookAuthAPIKeyIn.IsNull() && !plan.WebhookAuthAPIKeyIn.IsUnknown() {
 				authCfg["name"] = plan.WebhookAuthAPIKeyName.ValueString()
-				authCfg["value"] = plan.WebhookAuthAPIKeyValue.ValueString()
+				authCfg["value"] = apiKeyValue.ValueString()
 				authCfg["in"] = plan.WebhookAuthAPIKeyIn.ValueString()
 				hasValidAuthConfig = true
 			}
@@ -525,6 +586,27 @@ func (r *ActionResource) buildHookValue(plan *ActionResourceModel) map[string]in
 		"hook":   "web_hook",
 		"config": hookConfig,
 	}
+}
+
+// resolveAuthSecrets returns the effective basic-auth password and api-key value
+// for an apply, preferring the write-only (_wo) value when the user supplied one.
+// Write-only attribute values are nullified in the plan and state, so they must
+// be read from the configuration (req.Config) at Create and Update time.
+func (r *ActionResource) resolveAuthSecrets(ctx context.Context, config tfsdk.Config, plan *ActionResourceModel, diags *diag.Diagnostics) (basicAuthPassword, apiKeyValue types.String) {
+	basicAuthPassword = plan.WebhookAuthBasicAuthPassword
+	apiKeyValue = plan.WebhookAuthAPIKeyValue
+
+	var passwordWO, valueWO types.String
+	diags.Append(config.GetAttribute(ctx, path.Root("webhook_auth_basic_auth_password_wo"), &passwordWO)...)
+	diags.Append(config.GetAttribute(ctx, path.Root("webhook_auth_api_key_value_wo"), &valueWO)...)
+
+	if !passwordWO.IsNull() && !passwordWO.IsUnknown() {
+		basicAuthPassword = passwordWO
+	}
+	if !valueWO.IsNull() && !valueWO.IsUnknown() {
+		apiKeyValue = valueWO
+	}
+	return basicAuthPassword, apiKeyValue
 }
 
 // copyHooks returns a deep copy of the hooks slice via a JSON round-trip so
@@ -685,7 +767,11 @@ func (r *ActionResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	hookValue := r.buildHookValue(&plan)
+	basicAuthPassword, apiKeyValue := r.resolveAuthSecrets(ctx, req.Config, &plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	hookValue := r.buildHookValue(&plan, basicAuthPassword, apiKeyValue)
 	hookPath := r.hookPath(flow, timing, authMethod)
 
 	// Append the new hook to existing hooks and replace the entire array
@@ -873,8 +959,13 @@ func (r *ActionResource) Read(ctx context.Context, req resource.ReadRequest, res
 				}
 				// Password is sensitive - the API may not return it.
 				// Preserve the existing state value to avoid drift when omitted.
-				if password, ok := authCfg["password"].(string); ok && password != "" {
-					state.WebhookAuthBasicAuthPassword = types.StringValue(password)
+				// Only refresh when already tracked in state: when supplied via the
+				// write-only webhook_auth_basic_auth_password_wo it is null in state
+				// and must stay null so the secret never lands in state.
+				if !state.WebhookAuthBasicAuthPassword.IsNull() {
+					if password, ok := authCfg["password"].(string); ok && password != "" {
+						state.WebhookAuthBasicAuthPassword = types.StringValue(password)
+					}
 				}
 				// Clear unrelated auth-type fields
 				state.WebhookAuthAPIKeyName = types.StringNull()
@@ -888,8 +979,13 @@ func (r *ActionResource) Read(ctx context.Context, req resource.ReadRequest, res
 				}
 				// Value is sensitive - the API may not return it.
 				// Preserve the existing state value to avoid drift when omitted.
-				if value, ok := authCfg["value"].(string); ok && value != "" {
-					state.WebhookAuthAPIKeyValue = types.StringValue(value)
+				// Only refresh when already tracked in state: when supplied via the
+				// write-only webhook_auth_api_key_value_wo it is null in state and
+				// must stay null so the secret never lands in state.
+				if !state.WebhookAuthAPIKeyValue.IsNull() {
+					if value, ok := authCfg["value"].(string); ok && value != "" {
+						state.WebhookAuthAPIKeyValue = types.StringValue(value)
+					}
 				}
 				if in, ok := authCfg["in"].(string); ok && in != "" {
 					state.WebhookAuthAPIKeyIn = types.StringValue(in)
@@ -966,7 +1062,11 @@ func (r *ActionResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	hookValue := r.buildHookValue(&plan)
+	basicAuthPassword, apiKeyValue := r.resolveAuthSecrets(ctx, req.Config, &plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	hookValue := r.buildHookValue(&plan, basicAuthPassword, apiKeyValue)
 	hookPath := r.hookPath(flow, timing, authMethod)
 
 	patches := []ory.JsonPatch{{

--- a/internal/resources/action/resource_test.go
+++ b/internal/resources/action/resource_test.go
@@ -25,8 +25,12 @@ import (
 // written to Terraform state, and that bumping the version trigger rotates it.
 // Write-only arguments require Terraform 1.11+.
 func TestAccActionResource_writeOnlyBasicAuth(t *testing.T) {
+	hookPath := "/services/identity/config/selfservice/flows/registration/after/password/hooks"
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() { acctest.AccPreCheck(t) },
+		PreCheck: func() {
+			acctest.AccPreCheck(t)
+			cleanupDanglingWebhook(t, hookPath, testutil.ExampleWebhookURL+"/wo-basic-auth-webhook")
+		},
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_11_0),
 		},
@@ -75,8 +79,12 @@ func TestAccActionResource_writeOnlyBasicAuth(t *testing.T) {
 // TestAccActionResource_writeOnlyAPIKey verifies the same for the api-key value
 // supplied via webhook_auth_api_key_value_wo.
 func TestAccActionResource_writeOnlyAPIKey(t *testing.T) {
+	hookPath := "/services/identity/config/selfservice/flows/registration/after/password/hooks"
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() { acctest.AccPreCheck(t) },
+		PreCheck: func() {
+			acctest.AccPreCheck(t)
+			cleanupDanglingWebhook(t, hookPath, testutil.ExampleWebhookURL+"/wo-api-key-webhook")
+		},
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_11_0),
 		},

--- a/internal/resources/action/resource_test.go
+++ b/internal/resources/action/resource_test.go
@@ -9,12 +9,118 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	ory "github.com/ory/client-go"
 
 	"github.com/ory/terraform-provider-ory/internal/acctest"
 	"github.com/ory/terraform-provider-ory/internal/testutil"
 )
+
+// TestAccActionResource_writeOnlyBasicAuth verifies that the basic-auth password
+// supplied via webhook_auth_basic_auth_password_wo is sent to the API but never
+// written to Terraform state, and that bumping the version trigger rotates it.
+// Write-only arguments require Terraform 1.11+.
+func TestAccActionResource_writeOnlyBasicAuth(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.AccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/write_only_basic_auth.tf.tmpl", map[string]string{
+					"WebhookURL": testutil.ExampleWebhookURL,
+					"Version":    "1",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_action.wo", "webhook_auth_type", "basic_auth"),
+					resource.TestCheckResourceAttr("ory_action.wo", "webhook_auth_basic_auth_user", "webhook-user"),
+					resource.TestCheckResourceAttr("ory_action.wo", "webhook_auth_basic_auth_password_wo_version", "1"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("ory_action.wo", tfjsonpath.New("webhook_auth_basic_auth_password_wo"), knownvalue.Null()),
+					statecheck.ExpectKnownValue("ory_action.wo", tfjsonpath.New("webhook_auth_basic_auth_password"), knownvalue.Null()),
+				},
+			},
+			// Rotate via version bump.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/write_only_basic_auth.tf.tmpl", map[string]string{
+					"WebhookURL": testutil.ExampleWebhookURL,
+					"Version":    "2",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_action.wo", "webhook_auth_basic_auth_password_wo_version", "2"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("ory_action.wo", tfjsonpath.New("webhook_auth_basic_auth_password_wo"), knownvalue.Null()),
+				},
+			},
+			// Idempotency.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/write_only_basic_auth.tf.tmpl", map[string]string{
+					"WebhookURL": testutil.ExampleWebhookURL,
+					"Version":    "2",
+				}),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccActionResource_writeOnlyAPIKey verifies the same for the api-key value
+// supplied via webhook_auth_api_key_value_wo.
+func TestAccActionResource_writeOnlyAPIKey(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.AccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/write_only_api_key.tf.tmpl", map[string]string{
+					"WebhookURL": testutil.ExampleWebhookURL,
+					"Version":    "1",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_action.wo", "webhook_auth_type", "api_key"),
+					resource.TestCheckResourceAttr("ory_action.wo", "webhook_auth_api_key_name", "X-API-KEY"),
+					resource.TestCheckResourceAttr("ory_action.wo", "webhook_auth_api_key_value_wo_version", "1"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("ory_action.wo", tfjsonpath.New("webhook_auth_api_key_value_wo"), knownvalue.Null()),
+					statecheck.ExpectKnownValue("ory_action.wo", tfjsonpath.New("webhook_auth_api_key_value"), knownvalue.Null()),
+				},
+			},
+			// Rotate via version bump.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/write_only_api_key.tf.tmpl", map[string]string{
+					"WebhookURL": testutil.ExampleWebhookURL,
+					"Version":    "2",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_action.wo", "webhook_auth_api_key_value_wo_version", "2"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("ory_action.wo", tfjsonpath.New("webhook_auth_api_key_value_wo"), knownvalue.Null()),
+				},
+			},
+			// Idempotency.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/write_only_api_key.tf.tmpl", map[string]string{
+					"WebhookURL": testutil.ExampleWebhookURL,
+					"Version":    "2",
+				}),
+				PlanOnly: true,
+			},
+		},
+	})
+}
 
 // cleanupDanglingWebhook removes a specific webhook left behind by a previous
 // failed test run. Only the matching webhook is removed; other hooks at the

--- a/internal/resources/action/testdata/write_only_api_key.tf.tmpl
+++ b/internal/resources/action/testdata/write_only_api_key.tf.tmpl
@@ -1,0 +1,13 @@
+resource "ory_action" "wo" {
+  flow        = "registration"
+  timing      = "after"
+  auth_method = "password"
+  url         = "[[ .WebhookURL ]]/wo-api-key-webhook"
+  method      = "POST"
+
+  webhook_auth_type                     = "api_key"
+  webhook_auth_api_key_name             = "X-API-KEY"
+  webhook_auth_api_key_value_wo         = "wo-api-key-[[ .Version ]]"
+  webhook_auth_api_key_value_wo_version = "[[ .Version ]]"
+  webhook_auth_api_key_in               = "header"
+}

--- a/internal/resources/action/testdata/write_only_basic_auth.tf.tmpl
+++ b/internal/resources/action/testdata/write_only_basic_auth.tf.tmpl
@@ -1,0 +1,12 @@
+resource "ory_action" "wo" {
+  flow        = "registration"
+  timing      = "after"
+  auth_method = "password"
+  url         = "[[ .WebhookURL ]]/wo-basic-auth-webhook"
+  method      = "POST"
+
+  webhook_auth_type                           = "basic_auth"
+  webhook_auth_basic_auth_user                = "webhook-user"
+  webhook_auth_basic_auth_password_wo         = "wo-basic-password-[[ .Version ]]"
+  webhook_auth_basic_auth_password_wo_version = "[[ .Version ]]"
+}

--- a/internal/resources/action/validate_config_test.go
+++ b/internal/resources/action/validate_config_test.go
@@ -22,44 +22,52 @@ func buildActionTestConfig(t *testing.T, model ActionResourceModel) resource.Val
 	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
 
 	vals := map[string]tftypes.Value{
-		"id":                               tftypes.NewValue(tftypes.String, nil),
-		"project_id":                       tftypes.NewValue(tftypes.String, nil),
-		"flow":                             tfActionStringValue(model.Flow),
-		"timing":                           tfActionStringValue(model.Timing),
-		"auth_method":                      tfActionStringValue(model.AuthMethod),
-		"url":                              tfActionStringValue(model.URL),
-		"method":                           tfActionStringValue(model.HTTPMethod),
-		"body":                             tftypes.NewValue(tftypes.String, nil),
-		"response_ignore":                  tftypes.NewValue(tftypes.Bool, nil),
-		"response_parse":                   tftypes.NewValue(tftypes.Bool, nil),
-		"can_interrupt":                    tftypes.NewValue(tftypes.Bool, nil),
-		"webhook_auth_type":                tfActionStringValue(model.WebhookAuthType),
-		"webhook_auth_basic_auth_user":     tfActionStringValue(model.WebhookAuthBasicAuthUser),
-		"webhook_auth_basic_auth_password": tfActionStringValue(model.WebhookAuthBasicAuthPassword),
-		"webhook_auth_api_key_name":        tfActionStringValue(model.WebhookAuthAPIKeyName),
-		"webhook_auth_api_key_value":       tfActionStringValue(model.WebhookAuthAPIKeyValue),
-		"webhook_auth_api_key_in":          tfActionStringValue(model.WebhookAuthAPIKeyIn),
+		"id":                                  tftypes.NewValue(tftypes.String, nil),
+		"project_id":                          tftypes.NewValue(tftypes.String, nil),
+		"flow":                                tfActionStringValue(model.Flow),
+		"timing":                              tfActionStringValue(model.Timing),
+		"auth_method":                         tfActionStringValue(model.AuthMethod),
+		"url":                                 tfActionStringValue(model.URL),
+		"method":                              tfActionStringValue(model.HTTPMethod),
+		"body":                                tftypes.NewValue(tftypes.String, nil),
+		"response_ignore":                     tftypes.NewValue(tftypes.Bool, nil),
+		"response_parse":                      tftypes.NewValue(tftypes.Bool, nil),
+		"can_interrupt":                       tftypes.NewValue(tftypes.Bool, nil),
+		"webhook_auth_type":                   tfActionStringValue(model.WebhookAuthType),
+		"webhook_auth_basic_auth_user":        tfActionStringValue(model.WebhookAuthBasicAuthUser),
+		"webhook_auth_basic_auth_password":    tfActionStringValue(model.WebhookAuthBasicAuthPassword),
+		"webhook_auth_basic_auth_password_wo": tfActionStringValue(model.WebhookAuthBasicAuthPasswordWO),
+		"webhook_auth_basic_auth_password_wo_version": tfActionStringValue(model.WebhookAuthBasicAuthPasswordWOVersion),
+		"webhook_auth_api_key_name":                   tfActionStringValue(model.WebhookAuthAPIKeyName),
+		"webhook_auth_api_key_value":                  tfActionStringValue(model.WebhookAuthAPIKeyValue),
+		"webhook_auth_api_key_value_wo":               tfActionStringValue(model.WebhookAuthAPIKeyValueWO),
+		"webhook_auth_api_key_value_wo_version":       tfActionStringValue(model.WebhookAuthAPIKeyValueWOVersion),
+		"webhook_auth_api_key_in":                     tfActionStringValue(model.WebhookAuthAPIKeyIn),
 	}
 
 	objType := tftypes.Object{
 		AttributeTypes: map[string]tftypes.Type{
-			"id":                               tftypes.String,
-			"project_id":                       tftypes.String,
-			"flow":                             tftypes.String,
-			"timing":                           tftypes.String,
-			"auth_method":                      tftypes.String,
-			"url":                              tftypes.String,
-			"method":                           tftypes.String,
-			"body":                             tftypes.String,
-			"response_ignore":                  tftypes.Bool,
-			"response_parse":                   tftypes.Bool,
-			"can_interrupt":                    tftypes.Bool,
-			"webhook_auth_type":                tftypes.String,
-			"webhook_auth_basic_auth_user":     tftypes.String,
-			"webhook_auth_basic_auth_password": tftypes.String,
-			"webhook_auth_api_key_name":        tftypes.String,
-			"webhook_auth_api_key_value":       tftypes.String,
-			"webhook_auth_api_key_in":          tftypes.String,
+			"id":                                  tftypes.String,
+			"project_id":                          tftypes.String,
+			"flow":                                tftypes.String,
+			"timing":                              tftypes.String,
+			"auth_method":                         tftypes.String,
+			"url":                                 tftypes.String,
+			"method":                              tftypes.String,
+			"body":                                tftypes.String,
+			"response_ignore":                     tftypes.Bool,
+			"response_parse":                      tftypes.Bool,
+			"can_interrupt":                       tftypes.Bool,
+			"webhook_auth_type":                   tftypes.String,
+			"webhook_auth_basic_auth_user":        tftypes.String,
+			"webhook_auth_basic_auth_password":    tftypes.String,
+			"webhook_auth_basic_auth_password_wo": tftypes.String,
+			"webhook_auth_basic_auth_password_wo_version": tftypes.String,
+			"webhook_auth_api_key_name":                   tftypes.String,
+			"webhook_auth_api_key_value":                  tftypes.String,
+			"webhook_auth_api_key_value_wo":               tftypes.String,
+			"webhook_auth_api_key_value_wo_version":       tftypes.String,
+			"webhook_auth_api_key_in":                     tftypes.String,
 		},
 	}
 
@@ -364,6 +372,49 @@ func TestValidateConfig_BasicAuth_UnknownUser_SkipsValidation(t *testing.T) {
 	r.ValidateConfig(ctx, req, &resp)
 
 	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for unknown webhook_auth_basic_auth_user: %v", resp.Diagnostics.Errors())
+}
+
+// TestValidateConfig_BasicAuth_WriteOnlyPassword_Passes verifies that supplying
+// only the write-only webhook_auth_basic_auth_password_wo satisfies the password
+// requirement for basic_auth.
+func TestValidateConfig_BasicAuth_WriteOnlyPassword_Passes(t *testing.T) {
+	r := &ActionResource{}
+	ctx := context.Background()
+
+	req := buildActionTestConfig(t, ActionResourceModel{
+		Flow:                           types.StringValue("registration"),
+		Timing:                         types.StringValue("after"),
+		URL:                            types.StringValue("https://example.com/webhook"),
+		WebhookAuthType:                types.StringValue("basic_auth"),
+		WebhookAuthBasicAuthUser:       types.StringValue("user"),
+		WebhookAuthBasicAuthPasswordWO: types.StringValue("wo-pass"),
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for write-only basic auth password: %v", resp.Diagnostics.Errors())
+}
+
+// TestValidateConfig_APIKey_WriteOnlyValue_Passes verifies that supplying only the
+// write-only webhook_auth_api_key_value_wo satisfies the value requirement for
+// api_key.
+func TestValidateConfig_APIKey_WriteOnlyValue_Passes(t *testing.T) {
+	r := &ActionResource{}
+	ctx := context.Background()
+
+	req := buildActionTestConfig(t, ActionResourceModel{
+		Flow:                     types.StringValue("login"),
+		Timing:                   types.StringValue("after"),
+		URL:                      types.StringValue("https://example.com/webhook"),
+		WebhookAuthType:          types.StringValue("api_key"),
+		WebhookAuthAPIKeyName:    types.StringValue("X-API-Key"),
+		WebhookAuthAPIKeyValueWO: types.StringValue("wo-secret"),
+		WebhookAuthAPIKeyIn:      types.StringValue("header"),
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for write-only api key value: %v", resp.Diagnostics.Errors())
 }
 
 // TestValidateConfig_APIKey_UnknownValue_NullName_StillFails verifies that when

--- a/internal/resources/identity/resource.go
+++ b/internal/resources/identity/resource.go
@@ -470,21 +470,33 @@ func (r *IdentityResource) Update(ctx context.Context, req resource.UpdateReques
 		body.MetadataAdmin = metadataAdmin
 	}
 
-	// Rotate the password when it is supplied write-only (password_wo) and its
-	// version trigger changed. Write-only values are read from req.Config; the
-	// version comparison ensures the secret is only re-sent on an intentional
-	// rotation, not on every unrelated update.
+	// Build password credentials for the update. Two independent paths set a new
+	// password (they are mutually exclusive via the password/password_wo
+	// ConflictsWith validator, so at most one fires):
+	//   - the write-only password_wo, re-sent only when its version trigger
+	//     changes so the secret is not re-sent on every unrelated update; and
+	//   - the stateful password, sent when it actually changed (plan != state).
+	// Write-only values live only in the configuration, so password_wo is read
+	// from req.Config.
 	var passwordWO types.String
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("password_wo"), &passwordWO)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if !passwordWO.IsNull() && !passwordWO.IsUnknown() && passwordWO.ValueString() != "" &&
-		!plan.PasswordWOVersion.Equal(state.PasswordWOVersion) {
+	var newPassword *string
+	switch {
+	case !passwordWO.IsNull() && !passwordWO.IsUnknown() && passwordWO.ValueString() != "" &&
+		!plan.PasswordWOVersion.Equal(state.PasswordWOVersion):
+		newPassword = ory.PtrString(passwordWO.ValueString())
+	case !plan.Password.IsNull() && !plan.Password.IsUnknown() && plan.Password.ValueString() != "" &&
+		!plan.Password.Equal(state.Password):
+		newPassword = ory.PtrString(plan.Password.ValueString())
+	}
+	if newPassword != nil {
 		body.Credentials = &ory.IdentityWithCredentials{
 			Password: &ory.IdentityWithCredentialsPassword{
 				Config: &ory.IdentityWithCredentialsPasswordConfig{
-					Password: ory.PtrString(passwordWO.ValueString()),
+					Password: newPassword,
 				},
 			},
 		}

--- a/internal/resources/identity/resource.go
+++ b/internal/resources/identity/resource.go
@@ -41,15 +41,17 @@ type IdentityResource struct {
 
 // IdentityResourceModel describes the resource data model.
 type IdentityResourceModel struct {
-	ID             types.String `tfsdk:"id"`
-	ProjectSlug    types.String `tfsdk:"project_slug"`
-	ProjectAPIKey  types.String `tfsdk:"project_api_key"`
-	SchemaID       types.String `tfsdk:"schema_id"`
-	Traits         types.String `tfsdk:"traits"`
-	State          types.String `tfsdk:"state"`
-	Password       types.String `tfsdk:"password"`
-	MetadataPublic types.String `tfsdk:"metadata_public"`
-	MetadataAdmin  types.String `tfsdk:"metadata_admin"`
+	ID                types.String `tfsdk:"id"`
+	ProjectSlug       types.String `tfsdk:"project_slug"`
+	ProjectAPIKey     types.String `tfsdk:"project_api_key"`
+	SchemaID          types.String `tfsdk:"schema_id"`
+	Traits            types.String `tfsdk:"traits"`
+	State             types.String `tfsdk:"state"`
+	Password          types.String `tfsdk:"password"`
+	PasswordWO        types.String `tfsdk:"password_wo"`
+	PasswordWOVersion types.String `tfsdk:"password_wo_version"`
+	MetadataPublic    types.String `tfsdk:"metadata_public"`
+	MetadataAdmin     types.String `tfsdk:"metadata_admin"`
 }
 
 func (r *IdentityResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -183,11 +185,30 @@ func (r *IdentityResource) Schema(ctx context.Context, req resource.SchemaReques
 				Default:     stringdefault.StaticString("active"),
 			},
 			"password": schema.StringAttribute{
-				Description: "Password for the identity. Write-only, not returned on read.",
+				Description: "Password for the identity. Not returned on read. Stored in Terraform state; for an ephemeral alternative that is never persisted, use password_wo. Exactly one of password or password_wo may be set.",
 				Optional:    true,
 				Sensitive:   true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("password_wo")),
+				},
+			},
+			"password_wo": schema.StringAttribute{
+				Description: "Write-only equivalent of password (Terraform 1.11+ write-only argument): the value is sent to Ory but never stored in Terraform state or plan. Use this to source the password from an ephemeral resource such as a Vault secret. Because write-only values are not persisted, Terraform cannot detect when the value changes on its own — change password_wo_version to rotate it. Mutually exclusive with password.",
+				Optional:    true,
+				WriteOnly:   true,
+				Sensitive:   true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("password")),
+				},
+			},
+			"password_wo_version": schema.StringAttribute{
+				Description: "Version trigger for password_wo. Change this value whenever the write-only password_wo changes so Terraform sends the new password to Ory (write-only values are not stored in state and cannot be diffed). Has no effect unless password_wo is set.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.MatchRoot("password_wo")),
 				},
 			},
 			"metadata_public": schema.StringAttribute{
@@ -227,6 +248,14 @@ func (r *IdentityResource) ValidateConfig(ctx context.Context, req resource.Vali
 		return
 	}
 	resp.Diagnostics.Append(helpers.ValidateProjectCredentialPair(config.ProjectSlug, config.ProjectAPIKey)...)
+
+	if !config.PasswordWO.IsNull() && !config.PasswordWO.IsUnknown() && config.PasswordWO.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("password_wo"),
+			"Invalid Attribute Value",
+			"password_wo must not be an empty string.",
+		)
+	}
 }
 
 func (r *IdentityResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -260,11 +289,25 @@ func (r *IdentityResource) Create(ctx context.Context, req resource.CreateReques
 		State:    ory.PtrString(plan.State.ValueString()),
 	}
 
-	if !plan.Password.IsNull() && !plan.Password.IsUnknown() {
+	// Resolve the effective password, preferring the write-only password_wo. Its
+	// value lives only in the configuration (write-only values are nullified in
+	// the plan and state), so it must be read from req.Config and is never
+	// written back into the model.
+	password := plan.Password
+	var passwordWO types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("password_wo"), &passwordWO)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !passwordWO.IsNull() && !passwordWO.IsUnknown() {
+		password = passwordWO
+	}
+
+	if !password.IsNull() && !password.IsUnknown() && password.ValueString() != "" {
 		body.Credentials = &ory.IdentityWithCredentials{
 			Password: &ory.IdentityWithCredentialsPassword{
 				Config: &ory.IdentityWithCredentialsPasswordConfig{
-					Password: ory.PtrString(plan.Password.ValueString()),
+					Password: ory.PtrString(password.ValueString()),
 				},
 			},
 		}
@@ -425,6 +468,26 @@ func (r *IdentityResource) Update(ctx context.Context, req resource.UpdateReques
 			return
 		}
 		body.MetadataAdmin = metadataAdmin
+	}
+
+	// Rotate the password when it is supplied write-only (password_wo) and its
+	// version trigger changed. Write-only values are read from req.Config; the
+	// version comparison ensures the secret is only re-sent on an intentional
+	// rotation, not on every unrelated update.
+	var passwordWO types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("password_wo"), &passwordWO)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !passwordWO.IsNull() && !passwordWO.IsUnknown() && passwordWO.ValueString() != "" &&
+		!plan.PasswordWOVersion.Equal(state.PasswordWOVersion) {
+		body.Credentials = &ory.IdentityWithCredentials{
+			Password: &ory.IdentityWithCredentialsPassword{
+				Config: &ory.IdentityWithCredentialsPasswordConfig{
+					Password: ory.PtrString(passwordWO.ValueString()),
+				},
+			},
+		}
 	}
 
 	identity, err := client.UpdateIdentity(ctx, state.ID.ValueString(), body)

--- a/internal/resources/identity/resource_test.go
+++ b/internal/resources/identity/resource_test.go
@@ -6,9 +6,72 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 
 	"github.com/ory/terraform-provider-ory/internal/acctest"
 )
+
+// TestAccIdentityResource_writeOnlyPassword verifies that password_wo is accepted
+// by the API but never written to Terraform state, and that bumping
+// password_wo_version rotates the password. Write-only arguments require
+// Terraform 1.11+.
+func TestAccIdentityResource_writeOnlyPassword(t *testing.T) {
+	acctest.RunTest(t, resource.TestCase{
+		PreCheck: func() { acctest.AccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create with a write-only password (version 1).
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/write_only_password.tf.tmpl", map[string]string{
+					"Username": "test-wo-pw-user",
+					"Version":  "1",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_identity.wo", "id"),
+					resource.TestCheckResourceAttr("ory_identity.wo", "password_wo_version", "1"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("ory_identity.wo", tfjsonpath.New("password_wo"), knownvalue.Null()),
+					statecheck.ExpectKnownValue("ory_identity.wo", tfjsonpath.New("password"), knownvalue.Null()),
+				},
+			},
+			// Rotate the password by bumping the version trigger (version 2).
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/write_only_password.tf.tmpl", map[string]string{
+					"Username": "test-wo-pw-user",
+					"Version":  "2",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_identity.wo", "password_wo_version", "2"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("ory_identity.wo", tfjsonpath.New("password_wo"), knownvalue.Null()),
+				},
+			},
+			// Re-applying the same config must produce no diff (idempotency).
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/write_only_password.tf.tmpl", map[string]string{
+					"Username": "test-wo-pw-user",
+					"Version":  "2",
+				}),
+				PlanOnly: true,
+			},
+			// Import: write-only attributes and their version do not round-trip.
+			{
+				ResourceName:            "ory_identity.wo",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password", "password_wo", "password_wo_version"},
+			},
+		},
+	})
+}
 
 func TestAccIdentityResource_basic(t *testing.T) {
 	acctest.RunTest(t, resource.TestCase{

--- a/internal/resources/identity/testdata/write_only_password.tf.tmpl
+++ b/internal/resources/identity/testdata/write_only_password.tf.tmpl
@@ -1,0 +1,12 @@
+resource "ory_identity" "wo" {
+  schema_id = "preset://username"
+
+  traits = jsonencode({
+    username = "[[ .Username ]]"
+  })
+
+  state = "active"
+
+  password_wo         = "Tf-Wo-Pass-[[ .Version ]]-xK9qLm2!"
+  password_wo_version = "[[ .Version ]]"
+}

--- a/internal/resources/oauth2client/resource.go
+++ b/internal/resources/oauth2client/resource.go
@@ -83,6 +83,8 @@ type OAuth2ClientResourceModel struct {
 
 	// OIDC fields
 	Jwks                      types.String `tfsdk:"jwks"`
+	JwksWO                    types.String `tfsdk:"jwks_wo"`
+	JwksWOVersion             types.String `tfsdk:"jwks_wo_version"`
 	JwksURI                   types.String `tfsdk:"jwks_uri"`
 	UserinfoSignedResponseAlg types.String `tfsdk:"userinfo_signed_response_alg"`
 	RequestObjectSigningAlg   types.String `tfsdk:"request_object_signing_alg"`
@@ -339,11 +341,27 @@ func (r *OAuth2ClientResource) Schema(ctx context.Context, req resource.SchemaRe
 
 			// OIDC fields
 			"jwks": schema.StringAttribute{
-				Description: "Inline JSON Web Key Set (JWKS) as a JSON string. Use this to provide keys directly instead of via jwks_uri. Mutually exclusive with jwks_uri. Marked sensitive because JWKS may contain private key material.",
+				Description: "Inline JSON Web Key Set (JWKS) as a JSON string. Use this to provide keys directly instead of via jwks_uri. Mutually exclusive with jwks_uri. Marked sensitive because JWKS may contain private key material. Stored in Terraform state; for an ephemeral alternative that is never persisted, use jwks_wo.",
 				Optional:    true,
 				Sensitive:   true,
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.MatchRoot("jwks_uri")),
+				},
+			},
+			"jwks_wo": schema.StringAttribute{
+				Description: "Write-only equivalent of jwks (Terraform 1.11+ write-only argument): the inline JSON Web Key Set is sent to Ory but never stored in Terraform state or plan. Use this to source private key material from an ephemeral resource such as a Vault secret. Because write-only values are not persisted, Terraform cannot detect when the value changes on its own — change jwks_wo_version to rotate it. Mutually exclusive with jwks and jwks_uri.",
+				Optional:    true,
+				WriteOnly:   true,
+				Sensitive:   true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("jwks"), path.MatchRoot("jwks_uri")),
+				},
+			},
+			"jwks_wo_version": schema.StringAttribute{
+				Description: "Version trigger for jwks_wo. Change this value whenever the write-only jwks_wo changes so Terraform sends the new key set to Ory (write-only values are not stored in state and cannot be diffed). Has no effect unless jwks_wo is set.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.MatchRoot("jwks_wo")),
 				},
 			},
 			"jwks_uri": schema.StringAttribute{
@@ -544,9 +562,22 @@ func (r *OAuth2ClientResource) Create(ctx context.Context, req resource.CreateRe
 	setNullableStringFromPlan(&oauthClient.RefreshTokenGrantIdTokenLifespan, plan.RefreshTokenGrantIdTokenLifespan)
 	setNullableStringFromPlan(&oauthClient.RefreshTokenGrantRefreshTokenLifespan, plan.RefreshTokenGrantRefreshTokenLifespan)
 
-	if !plan.Jwks.IsNull() && !plan.Jwks.IsUnknown() {
+	// Resolve the effective JWKS, preferring the write-only jwks_wo. Its value
+	// lives only in the configuration (write-only values are nullified in the
+	// plan and state), so it must be read from req.Config and is never written
+	// back into the model.
+	jwksValue := plan.Jwks
+	var jwksWO types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("jwks_wo"), &jwksWO)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !jwksWO.IsNull() && !jwksWO.IsUnknown() {
+		jwksValue = jwksWO
+	}
+	if !jwksValue.IsNull() && !jwksValue.IsUnknown() {
 		var jwks ory.JsonWebKeySet
-		if err := json.Unmarshal([]byte(plan.Jwks.ValueString()), &jwks); err != nil {
+		if err := json.Unmarshal([]byte(jwksValue.ValueString()), &jwks); err != nil {
 			resp.Diagnostics.AddError(
 				"Invalid JWKS JSON",
 				"Could not parse jwks as JSON: "+err.Error(),
@@ -631,26 +662,32 @@ func (r *OAuth2ClientResource) Create(ctx context.Context, req resource.CreateRe
 		plan.BackchannelLogoutSessionRequired = types.BoolValue(false)
 	}
 
-	plan.Jwks = types.StringNull()
-	if created.Jwks != nil && len(created.Jwks.Keys) > 0 {
-		if jwksJSON, err := json.Marshal(created.Jwks); err == nil {
-			var normalized interface{}
-			if err := json.Unmarshal(jwksJSON, &normalized); err != nil {
-				resp.Diagnostics.AddWarning(
-					"Failed to normalize OAuth2 Client JWKS",
-					fmt.Sprintf("Unable to unmarshal JWKS for OAuth2 client %q during normalization. The JWKS will be kept in its original format. Error: %s", plan.ID.ValueString(), err),
-				)
-			} else {
-				if canonicalJSON, err := json.Marshal(normalized); err != nil {
+	// Only reflect jwks back into state when it was supplied via the stateful
+	// jwks attribute. When supplied write-only via jwks_wo, jwks is null in the
+	// plan and must stay null in state (otherwise Terraform reports an
+	// inconsistent result, and the key material would land in state).
+	if !plan.Jwks.IsNull() {
+		plan.Jwks = types.StringNull()
+		if created.Jwks != nil && len(created.Jwks.Keys) > 0 {
+			if jwksJSON, err := json.Marshal(created.Jwks); err == nil {
+				var normalized interface{}
+				if err := json.Unmarshal(jwksJSON, &normalized); err != nil {
 					resp.Diagnostics.AddWarning(
 						"Failed to normalize OAuth2 Client JWKS",
-						fmt.Sprintf("Unable to remarshal JWKS for OAuth2 client %q during normalization. The JWKS will be kept in its original format. Error: %s", plan.ID.ValueString(), err),
+						fmt.Sprintf("Unable to unmarshal JWKS for OAuth2 client %q during normalization. The JWKS will be kept in its original format. Error: %s", plan.ID.ValueString(), err),
 					)
 				} else {
-					jwksJSON = canonicalJSON
+					if canonicalJSON, err := json.Marshal(normalized); err != nil {
+						resp.Diagnostics.AddWarning(
+							"Failed to normalize OAuth2 Client JWKS",
+							fmt.Sprintf("Unable to remarshal JWKS for OAuth2 client %q during normalization. The JWKS will be kept in its original format. Error: %s", plan.ID.ValueString(), err),
+						)
+					} else {
+						jwksJSON = canonicalJSON
+					}
 				}
+				plan.Jwks = types.StringValue(string(jwksJSON))
 			}
-			plan.Jwks = types.StringValue(string(jwksJSON))
 		}
 	}
 
@@ -785,36 +822,42 @@ func (r *OAuth2ClientResource) Read(ctx context.Context, req resource.ReadReques
 	readNullableStringToState(oauthClient.RefreshTokenGrantIdTokenLifespan, &state.RefreshTokenGrantIdTokenLifespan)
 	readNullableStringToState(oauthClient.RefreshTokenGrantRefreshTokenLifespan, &state.RefreshTokenGrantRefreshTokenLifespan)
 
-	// Reset JWKS in state by default to avoid keeping stale values when the remote JWKS is cleared.
-	state.Jwks = types.StringNull()
-	if oauthClient.Jwks != nil && len(oauthClient.Jwks.Keys) > 0 {
-		// Normalize JWKS JSON to match Terraform's jsonencode() key ordering.
-		// Marshal the SDK struct, then round-trip through interface{} to get
-		// Go's map key ordering (alphabetical), which matches jsonencode.
-		jwksJSON, err := json.Marshal(oauthClient.Jwks)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error marshaling OAuth2 Client JWKS",
-				fmt.Sprintf("Unable to marshal JWKS for OAuth2 client %q: %s", state.ID.ValueString(), err),
-			)
-		} else {
-			var normalized interface{}
-			if err := json.Unmarshal(jwksJSON, &normalized); err != nil {
-				resp.Diagnostics.AddWarning(
-					"Failed to normalize OAuth2 Client JWKS",
-					fmt.Sprintf("Unable to unmarshal JWKS for OAuth2 client %q during normalization. The JWKS will be kept in its original format. Error: %s", state.ID.ValueString(), err),
+	// Refresh JWKS only when it is already tracked in state. When the client is
+	// managed via the write-only jwks_wo, jwks is null in state and must stay
+	// null so the key material never lands in state. ImportState seeds jwks so a
+	// normal import still round-trips it.
+	if !state.Jwks.IsNull() {
+		// Reset JWKS in state by default to avoid keeping stale values when the remote JWKS is cleared.
+		state.Jwks = types.StringNull()
+		if oauthClient.Jwks != nil && len(oauthClient.Jwks.Keys) > 0 {
+			// Normalize JWKS JSON to match Terraform's jsonencode() key ordering.
+			// Marshal the SDK struct, then round-trip through interface{} to get
+			// Go's map key ordering (alphabetical), which matches jsonencode.
+			jwksJSON, err := json.Marshal(oauthClient.Jwks)
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error marshaling OAuth2 Client JWKS",
+					fmt.Sprintf("Unable to marshal JWKS for OAuth2 client %q: %s", state.ID.ValueString(), err),
 				)
 			} else {
-				if canonicalJSON, err := json.Marshal(normalized); err != nil {
+				var normalized interface{}
+				if err := json.Unmarshal(jwksJSON, &normalized); err != nil {
 					resp.Diagnostics.AddWarning(
 						"Failed to normalize OAuth2 Client JWKS",
-						fmt.Sprintf("Unable to remarshal JWKS for OAuth2 client %q during normalization. The JWKS will be kept in its original format. Error: %s", state.ID.ValueString(), err),
+						fmt.Sprintf("Unable to unmarshal JWKS for OAuth2 client %q during normalization. The JWKS will be kept in its original format. Error: %s", state.ID.ValueString(), err),
 					)
 				} else {
-					jwksJSON = canonicalJSON
+					if canonicalJSON, err := json.Marshal(normalized); err != nil {
+						resp.Diagnostics.AddWarning(
+							"Failed to normalize OAuth2 Client JWKS",
+							fmt.Sprintf("Unable to remarshal JWKS for OAuth2 client %q during normalization. The JWKS will be kept in its original format. Error: %s", state.ID.ValueString(), err),
+						)
+					} else {
+						jwksJSON = canonicalJSON
+					}
 				}
+				state.Jwks = types.StringValue(string(jwksJSON))
 			}
-			state.Jwks = types.StringValue(string(jwksJSON))
 		}
 	}
 
@@ -982,13 +1025,25 @@ func (r *OAuth2ClientResource) Update(ctx context.Context, req resource.UpdateRe
 	setNullableStringFromPlan(&oauthClient.RefreshTokenGrantIdTokenLifespan, plan.RefreshTokenGrantIdTokenLifespan)
 	setNullableStringFromPlan(&oauthClient.RefreshTokenGrantRefreshTokenLifespan, plan.RefreshTokenGrantRefreshTokenLifespan)
 
-	if !plan.Jwks.IsUnknown() {
-		if plan.Jwks.IsNull() {
-			// Explicitly clear JWKS when removed from configuration.
+	// Resolve the effective JWKS, preferring the write-only jwks_wo (read from
+	// req.Config). The write-only value is re-sent on every update; bump
+	// jwks_wo_version to trigger an update when only the secret changed.
+	jwksValue := plan.Jwks
+	var jwksWO types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("jwks_wo"), &jwksWO)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !jwksWO.IsNull() && !jwksWO.IsUnknown() {
+		jwksValue = jwksWO
+	}
+	if !jwksValue.IsUnknown() {
+		if jwksValue.IsNull() {
+			// Explicitly clear JWKS when both jwks and jwks_wo are removed.
 			oauthClient.Jwks = nil
 		} else {
 			var jwks ory.JsonWebKeySet
-			if err := json.Unmarshal([]byte(plan.Jwks.ValueString()), &jwks); err != nil {
+			if err := json.Unmarshal([]byte(jwksValue.ValueString()), &jwks); err != nil {
 				resp.Diagnostics.AddError(
 					"Invalid JWKS JSON",
 					"Could not parse jwks as JSON: "+err.Error(),
@@ -1073,26 +1128,30 @@ func (r *OAuth2ClientResource) Update(ctx context.Context, req resource.UpdateRe
 		plan.BackchannelLogoutSessionRequired = types.BoolValue(false)
 	}
 
-	plan.Jwks = types.StringNull()
-	if updated.Jwks != nil && len(updated.Jwks.Keys) > 0 {
-		if jwksJSON, err := json.Marshal(updated.Jwks); err == nil {
-			var normalized interface{}
-			if err := json.Unmarshal(jwksJSON, &normalized); err != nil {
-				resp.Diagnostics.AddWarning(
-					"Failed to normalize OAuth2 Client JWKS",
-					fmt.Sprintf("Unable to unmarshal JWKS for OAuth2 client %q during normalization. The JWKS will be kept in its original format. Error: %s", plan.ID.ValueString(), err),
-				)
-			} else {
-				if canonicalJSON, err := json.Marshal(normalized); err != nil {
+	// See the matching note in Create: keep jwks out of state when it is managed
+	// write-only via jwks_wo (null in the plan).
+	if !plan.Jwks.IsNull() {
+		plan.Jwks = types.StringNull()
+		if updated.Jwks != nil && len(updated.Jwks.Keys) > 0 {
+			if jwksJSON, err := json.Marshal(updated.Jwks); err == nil {
+				var normalized interface{}
+				if err := json.Unmarshal(jwksJSON, &normalized); err != nil {
 					resp.Diagnostics.AddWarning(
 						"Failed to normalize OAuth2 Client JWKS",
-						fmt.Sprintf("Unable to remarshal JWKS for OAuth2 client %q during normalization. The JWKS will be kept in its original format. Error: %s", plan.ID.ValueString(), err),
+						fmt.Sprintf("Unable to unmarshal JWKS for OAuth2 client %q during normalization. The JWKS will be kept in its original format. Error: %s", plan.ID.ValueString(), err),
 					)
 				} else {
-					jwksJSON = canonicalJSON
+					if canonicalJSON, err := json.Marshal(normalized); err != nil {
+						resp.Diagnostics.AddWarning(
+							"Failed to normalize OAuth2 Client JWKS",
+							fmt.Sprintf("Unable to remarshal JWKS for OAuth2 client %q during normalization. The JWKS will be kept in its original format. Error: %s", plan.ID.ValueString(), err),
+						)
+					} else {
+						jwksJSON = canonicalJSON
+					}
 				}
+				plan.Jwks = types.StringValue(string(jwksJSON))
 			}
-			plan.Jwks = types.StringValue(string(jwksJSON))
 		}
 	}
 
@@ -1123,6 +1182,21 @@ func (r *OAuth2ClientResource) Delete(ctx context.Context, req resource.DeleteRe
 func (r *OAuth2ClientResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("client_id"), req.ID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+
+	// Seed jwks from the API so the post-import refresh keeps it in sync. Read
+	// only refreshes jwks when it is already present in state (so clients managed
+	// via the write-only jwks_wo keep it out of state); without seeding it here a
+	// normal import would lose jwks. Best-effort: Read re-normalizes the value, so
+	// the exact format set here does not matter.
+	oauthClient, err := r.client.GetOAuth2Client(ctx, req.ID)
+	if err != nil {
+		return
+	}
+	if oauthClient.Jwks != nil && len(oauthClient.Jwks.Keys) > 0 {
+		if jwksJSON, err := json.Marshal(oauthClient.Jwks); err == nil {
+			resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("jwks"), string(jwksJSON))...)
+		}
+	}
 }
 
 func setNullableStringFromPlan(field *ory.NullableString, tfValue types.String) {

--- a/internal/resources/oauth2client/resource_test.go
+++ b/internal/resources/oauth2client/resource_test.go
@@ -3,6 +3,7 @@
 package oauth2client_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -10,12 +11,48 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 
 	"github.com/ory/terraform-provider-ory/internal/acctest"
 	"github.com/ory/terraform-provider-ory/internal/testutil"
 )
+
+// checkOAuth2ClientServerJWKSKid reads the OAuth2 client back from the Ory API
+// and asserts its JWKS contains a key with the expected kid. Because jwks is
+// supplied write-only (and therefore absent from state), this is the only way to
+// confirm the write-only JWKS — and its rotation via jwks_wo_version — actually
+// reached the server, so a no-op Update path cannot pass silently.
+func checkOAuth2ClientServerJWKSKid(resourceName, expectedKid string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found in state: %s", resourceName)
+		}
+		clientID := rs.Primary.Attributes["client_id"]
+		if clientID == "" {
+			return fmt.Errorf("client_id is empty in state for %s", resourceName)
+		}
+		c, err := acctest.GetOryClient()
+		if err != nil {
+			return err
+		}
+		oauthClient, err := c.GetOAuth2Client(context.Background(), clientID)
+		if err != nil {
+			return fmt.Errorf("failed to read OAuth2 client %s: %w", clientID, err)
+		}
+		if oauthClient.Jwks == nil || len(oauthClient.Jwks.Keys) == 0 {
+			return fmt.Errorf("expected JWKS with keys on the server for %s, got none", clientID)
+		}
+		for _, k := range oauthClient.Jwks.Keys {
+			if k.Kid == expectedKid {
+				return nil
+			}
+		}
+		return fmt.Errorf("expected server JWKS for %s to contain kid %q", clientID, expectedKid)
+	}
+}
 
 // TestAccOAuth2ClientResource_writeOnlyJWKS verifies that an inline JWKS supplied
 // via jwks_wo is sent to the API but never written to Terraform state, and that
@@ -38,6 +75,8 @@ func TestAccOAuth2ClientResource_writeOnlyJWKS(t *testing.T) {
 					resource.TestCheckResourceAttrSet("ory_oauth2_client.wo", "id"),
 					resource.TestCheckResourceAttr("ory_oauth2_client.wo", "token_endpoint_auth_method", "private_key_jwt"),
 					resource.TestCheckResourceAttr("ory_oauth2_client.wo", "jwks_wo_version", "1"),
+					// Confirm the write-only JWKS reached the server.
+					checkOAuth2ClientServerJWKSKid("ory_oauth2_client.wo", "test-key-1"),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue("ory_oauth2_client.wo", tfjsonpath.New("jwks_wo"), knownvalue.Null()),
@@ -52,6 +91,8 @@ func TestAccOAuth2ClientResource_writeOnlyJWKS(t *testing.T) {
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ory_oauth2_client.wo", "jwks_wo_version", "2"),
+					// The rotated key set (new kid) must have reached the server.
+					checkOAuth2ClientServerJWKSKid("ory_oauth2_client.wo", "test-key-2"),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue("ory_oauth2_client.wo", tfjsonpath.New("jwks_wo"), knownvalue.Null()),

--- a/internal/resources/oauth2client/resource_test.go
+++ b/internal/resources/oauth2client/resource_test.go
@@ -8,10 +8,67 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 
 	"github.com/ory/terraform-provider-ory/internal/acctest"
 	"github.com/ory/terraform-provider-ory/internal/testutil"
 )
+
+// TestAccOAuth2ClientResource_writeOnlyJWKS verifies that an inline JWKS supplied
+// via jwks_wo is sent to the API but never written to Terraform state, and that
+// bumping jwks_wo_version triggers an update. Write-only arguments require
+// Terraform 1.11+.
+func TestAccOAuth2ClientResource_writeOnlyJWKS(t *testing.T) {
+	acctest.RunTest(t, resource.TestCase{
+		PreCheck: func() { acctest.AccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/write_only_jwks.tf.tmpl", map[string]string{
+					"Name":    "Test Client with write-only JWKS",
+					"Version": "1",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_oauth2_client.wo", "id"),
+					resource.TestCheckResourceAttr("ory_oauth2_client.wo", "token_endpoint_auth_method", "private_key_jwt"),
+					resource.TestCheckResourceAttr("ory_oauth2_client.wo", "jwks_wo_version", "1"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("ory_oauth2_client.wo", tfjsonpath.New("jwks_wo"), knownvalue.Null()),
+					statecheck.ExpectKnownValue("ory_oauth2_client.wo", tfjsonpath.New("jwks"), knownvalue.Null()),
+				},
+			},
+			// Rotate via version bump.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/write_only_jwks.tf.tmpl", map[string]string{
+					"Name":    "Test Client with write-only JWKS",
+					"Version": "2",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_oauth2_client.wo", "jwks_wo_version", "2"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("ory_oauth2_client.wo", tfjsonpath.New("jwks_wo"), knownvalue.Null()),
+					statecheck.ExpectKnownValue("ory_oauth2_client.wo", tfjsonpath.New("jwks"), knownvalue.Null()),
+				},
+			},
+			// Idempotency.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/write_only_jwks.tf.tmpl", map[string]string{
+					"Name":    "Test Client with write-only JWKS",
+					"Version": "2",
+				}),
+				PlanOnly: true,
+			},
+		},
+	})
+}
 
 func TestAccOAuth2ClientResource_basic(t *testing.T) {
 	acctest.RunTest(t, resource.TestCase{

--- a/internal/resources/oauth2client/testdata/write_only_jwks.tf.tmpl
+++ b/internal/resources/oauth2client/testdata/write_only_jwks.tf.tmpl
@@ -9,7 +9,7 @@ resource "ory_oauth2_client" "wo" {
   jwks_wo = jsonencode({
     keys = [
       {
-        kid = "test-key-1"
+        kid = "test-key-[[ .Version ]]"
         kty = "RSA"
         alg = "RS256"
         use = "sig"

--- a/internal/resources/oauth2client/testdata/write_only_jwks.tf.tmpl
+++ b/internal/resources/oauth2client/testdata/write_only_jwks.tf.tmpl
@@ -1,0 +1,22 @@
+resource "ory_oauth2_client" "wo" {
+  client_name = "[[ .Name ]]"
+
+  grant_types                = ["client_credentials"]
+  response_types             = ["token"]
+  scope                      = "api:read"
+  token_endpoint_auth_method = "private_key_jwt"
+
+  jwks_wo = jsonencode({
+    keys = [
+      {
+        kid = "test-key-1"
+        kty = "RSA"
+        alg = "RS256"
+        use = "sig"
+        e   = "AQAB"
+        n   = "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
+      }
+    ]
+  })
+  jwks_wo_version = "[[ .Version ]]"
+}

--- a/internal/resources/projectconfig/resource.go
+++ b/internal/resources/projectconfig/resource.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -16,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -131,10 +133,12 @@ type ProjectConfigResourceModel struct {
 	VerificationNotifyUnknownRecipients types.Bool   `tfsdk:"verification_notify_unknown_recipients"`
 
 	// SMTP Configuration
-	SMTPConnectionURI types.String `tfsdk:"smtp_connection_uri"`
-	SMTPFromAddress   types.String `tfsdk:"smtp_from_address"`
-	SMTPFromName      types.String `tfsdk:"smtp_from_name"`
-	SMTPHeaders       types.Map    `tfsdk:"smtp_headers"`
+	SMTPConnectionURI          types.String `tfsdk:"smtp_connection_uri"`
+	SMTPConnectionURIWO        types.String `tfsdk:"smtp_connection_uri_wo"`
+	SMTPConnectionURIWOVersion types.String `tfsdk:"smtp_connection_uri_wo_version"`
+	SMTPFromAddress            types.String `tfsdk:"smtp_from_address"`
+	SMTPFromName               types.String `tfsdk:"smtp_from_name"`
+	SMTPHeaders                types.Map    `tfsdk:"smtp_headers"`
 
 	// MFA Policy
 	MFAEnforcement           types.String `tfsdk:"mfa_enforcement"`
@@ -587,6 +591,27 @@ func (r *ProjectConfigResource) Schema(ctx context.Context, req resource.SchemaR
 			stringplanmodifier.RequiresReplace(),
 		},
 	}
+	// Write-only companions for smtp_connection_uri (Terraform 1.11+ write-only
+	// arguments). These are hand-written rather than codegen'd because write-only
+	// values must be read from the configuration (req.Config) at apply time, not
+	// from the plan model the codegen patch tables iterate over.
+	attrs["smtp_connection_uri_wo"] = schema.StringAttribute{
+		Description: "Write-only equivalent of smtp_connection_uri (Terraform 1.11+ write-only argument): the SMTP connection URI is sent to Ory but never stored in Terraform state or plan. Use this to source the value from an ephemeral resource such as a Vault secret. Because write-only values are not persisted, Terraform cannot detect when the value changes on its own — change smtp_connection_uri_wo_version to rotate it. Mutually exclusive with smtp_connection_uri.",
+		Optional:    true,
+		WriteOnly:   true,
+		Sensitive:   true,
+		Validators: []validator.String{
+			stringvalidator.ConflictsWith(path.MatchRoot("smtp_connection_uri")),
+		},
+	}
+	attrs["smtp_connection_uri_wo_version"] = schema.StringAttribute{
+		Description: "Version trigger for smtp_connection_uri_wo. Change this value whenever the write-only smtp_connection_uri_wo changes so Terraform sends the new value to Ory (write-only values are not stored in state and cannot be diffed). Has no effect unless smtp_connection_uri_wo is set.",
+		Optional:    true,
+		Validators: []validator.String{
+			stringvalidator.AlsoRequires(path.MatchRoot("smtp_connection_uri_wo")),
+		},
+	}
+
 	// --- Hand-written attributes (not in mappings.yaml) ---
 	// These require custom logic that the codegen can't express:
 	//   CORS (4):                   project-level /cors_* paths (not /services/*/config/)
@@ -866,6 +891,26 @@ func (r *ProjectConfigResource) Configure(ctx context.Context, req resource.Conf
 		return
 	}
 	r.client = oryClient
+}
+
+// appendWriteOnlySMTPPatch appends a patch for the SMTP connection URI when it is
+// supplied via the write-only smtp_connection_uri_wo attribute. Write-only values
+// live only in the configuration (nullified in the plan and state), so they are
+// read from req.Config rather than the plan model that buildPatches iterates over,
+// and are never written back into state. smtp_connection_uri and
+// smtp_connection_uri_wo are mutually exclusive, so at most one patch targets the
+// connection_uri path.
+func (r *ProjectConfigResource) appendWriteOnlySMTPPatch(ctx context.Context, config tfsdk.Config, patches []ory.JsonPatch, diags *diag.Diagnostics) []ory.JsonPatch {
+	var uriWO types.String
+	diags.Append(config.GetAttribute(ctx, path.Root("smtp_connection_uri_wo"), &uriWO)...)
+	if diags.HasError() || uriWO.IsNull() || uriWO.IsUnknown() {
+		return patches
+	}
+	return append(patches, ory.JsonPatch{
+		Op:    "replace",
+		Path:  "/services/identity/config/courier/smtp/connection_uri",
+		Value: uriWO.ValueString(),
+	})
 }
 
 // =============================================================================
@@ -1392,6 +1437,10 @@ func (r *ProjectConfigResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	patches := r.buildPatches(ctx, &plan)
+	patches = r.appendWriteOnlySMTPPatch(ctx, req.Config, patches, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	if needsHookPrefetch(&plan) {
 		currentProject, err := r.client.GetProject(ctx, projectID)
@@ -1942,6 +1991,10 @@ func (r *ProjectConfigResource) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	patches := r.buildPatches(ctx, &plan)
+	patches = r.appendWriteOnlySMTPPatch(ctx, req.Config, patches, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// Clear `oauth2.token_hook.auth` when the user transitions from set in
 	// state to null in the plan. The API requires `token_hook` to be either a

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -7,12 +7,63 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	ory "github.com/ory/client-go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ory/terraform-provider-ory/internal/acctest"
 	"github.com/ory/terraform-provider-ory/internal/testutil"
 )
+
+// TestAccProjectConfigResource_smtpConnectionURIWriteOnlyArgument verifies the
+// native write-only argument smtp_connection_uri_wo: the value is sent to the API
+// but never written to Terraform state, and bumping smtp_connection_uri_wo_version
+// rotates it. This is distinct from smtp_connection_uri, which is not read back
+// but is still stored in state. Write-only arguments require Terraform 1.11+.
+func TestAccProjectConfigResource_smtpConnectionURIWriteOnlyArgument(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.AccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/smtp_connection_uri_wo.tf.tmpl", map[string]string{
+					"SMTPURI": "smtp://tf-acc-wo:not-a-real-secret@smtp.example.com:587",
+					"Version": "1",
+				}),
+				Check: resource.TestCheckResourceAttr("ory_project_config.test", "smtp_connection_uri_wo_version", "1"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("ory_project_config.test", tfjsonpath.New("smtp_connection_uri_wo"), knownvalue.Null()),
+					statecheck.ExpectKnownValue("ory_project_config.test", tfjsonpath.New("smtp_connection_uri"), knownvalue.Null()),
+				},
+			},
+			// Rotate the secret via the version trigger.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/smtp_connection_uri_wo.tf.tmpl", map[string]string{
+					"SMTPURI": "smtps://tf-acc-wo:also-not-real@smtp.example.com:465",
+					"Version": "2",
+				}),
+				Check: resource.TestCheckResourceAttr("ory_project_config.test", "smtp_connection_uri_wo_version", "2"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("ory_project_config.test", tfjsonpath.New("smtp_connection_uri_wo"), knownvalue.Null()),
+				},
+			},
+			// Idempotency.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/smtp_connection_uri_wo.tf.tmpl", map[string]string{
+					"SMTPURI": "smtps://tf-acc-wo:also-not-real@smtp.example.com:465",
+					"Version": "2",
+				}),
+				PlanOnly: true,
+			},
+		},
+	})
+}
 
 func TestAccProjectConfigResource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{

--- a/internal/resources/projectconfig/testdata/smtp_connection_uri_wo.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/smtp_connection_uri_wo.tf.tmpl
@@ -1,0 +1,4 @@
+resource "ory_project_config" "test" {
+  smtp_connection_uri_wo         = "[[ .SMTPURI ]]"
+  smtp_connection_uri_wo_version = "[[ .Version ]]"
+}

--- a/internal/resources/socialprovider/resource.go
+++ b/internal/resources/socialprovider/resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	ory "github.com/ory/client-go"
 
@@ -62,7 +63,11 @@ type SocialProviderResourceModel struct {
 	ProviderID                 types.String `tfsdk:"provider_id"`
 	ProviderType               types.String `tfsdk:"provider_type"`
 	ClientID                   types.String `tfsdk:"client_id"`
+	ClientIDWO                 types.String `tfsdk:"client_id_wo"`
+	ClientIDWOVersion          types.String `tfsdk:"client_id_wo_version"`
 	ClientSecret               types.String `tfsdk:"client_secret"`
+	ClientSecretWO             types.String `tfsdk:"client_secret_wo"`
+	ClientSecretWOVersion      types.String `tfsdk:"client_secret_wo_version"`
 	IssuerURL                  types.String `tfsdk:"issuer_url"`
 	Scope                      types.List   `tfsdk:"scope"`
 	MapperURL                  types.String `tfsdk:"mapper_url"`
@@ -72,6 +77,8 @@ type SocialProviderResourceModel struct {
 	AppleTeamID                types.String `tfsdk:"apple_team_id"`
 	ApplePrivateKeyID          types.String `tfsdk:"apple_private_key_id"`
 	ApplePrivateKey            types.String `tfsdk:"apple_private_key"`
+	ApplePrivateKeyWO          types.String `tfsdk:"apple_private_key_wo"`
+	ApplePrivateKeyWOVersion   types.String `tfsdk:"apple_private_key_wo_version"`
 	AutoLink                   types.Bool   `tfsdk:"auto_link"`
 	Label                      types.String `tfsdk:"label"`
 	AccountLinkingMode         types.String `tfsdk:"account_linking_mode"`
@@ -122,13 +129,50 @@ func (r *SocialProviderResource) Schema(ctx context.Context, req resource.Schema
 				},
 			},
 			"client_id": schema.StringAttribute{
-				Description: "OAuth2 client ID from the provider.",
-				Required:    true,
+				Description: "OAuth2 client ID from the provider. Exactly one of client_id or client_id_wo must be set.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("client_id_wo")),
+				},
+			},
+			"client_id_wo": schema.StringAttribute{
+				Description: "Write-only equivalent of client_id (Terraform 1.11+ write-only argument): the value is sent to Ory but never stored in Terraform state or plan. Use this to source the client ID from an ephemeral resource such as a Vault secret. Because write-only values are not persisted, Terraform cannot detect when the value changes on its own — change client_id_wo_version to force the new value to be sent. Mutually exclusive with client_id.",
+				Optional:    true,
+				WriteOnly:   true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("client_id")),
+				},
+			},
+			"client_id_wo_version": schema.StringAttribute{
+				Description: "Version trigger for client_id_wo. Change this value whenever the write-only client_id_wo changes so Terraform sends the new value to Ory (write-only values are not stored in state and cannot be diffed). Has no effect unless client_id_wo is set.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.MatchRoot("client_id_wo")),
+				},
 			},
 			"client_secret": schema.StringAttribute{
-				Description: "OAuth2 client secret from the provider. Required for all providers except Apple (where Ory generates the secret from apple_team_id, apple_private_key_id, and apple_private_key).",
+				Description: "OAuth2 client secret from the provider. Required for all providers except Apple (where Ory generates the secret from apple_team_id, apple_private_key_id, and apple_private_key). Exactly one of client_secret or client_secret_wo may be set.",
 				Optional:    true,
 				Sensitive:   true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("client_secret_wo")),
+				},
+			},
+			"client_secret_wo": schema.StringAttribute{
+				Description: "Write-only equivalent of client_secret (Terraform 1.11+ write-only argument): the value is sent to Ory but never stored in Terraform state or plan. Use this to source the client secret from an ephemeral resource such as a Vault secret. Because write-only values are not persisted, Terraform cannot detect when the value changes on its own — change client_secret_wo_version to rotate it. Mutually exclusive with client_secret.",
+				Optional:    true,
+				WriteOnly:   true,
+				Sensitive:   true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("client_secret")),
+				},
+			},
+			"client_secret_wo_version": schema.StringAttribute{
+				Description: "Version trigger for client_secret_wo. Change this value whenever the write-only client_secret_wo changes so Terraform sends the new secret to Ory (write-only values are not stored in state and cannot be diffed). Has no effect unless client_secret_wo is set.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.MatchRoot("client_secret_wo")),
+				},
 			},
 			"issuer_url": schema.StringAttribute{
 				Description: "OIDC issuer URL (required for generic providers).",
@@ -164,9 +208,28 @@ func (r *SocialProviderResource) Schema(ctx context.Context, req resource.Schema
 				Optional:    true,
 			},
 			"apple_private_key": schema.StringAttribute{
-				Description: "Apple private key in PEM format (contents of the .p8 file). Required when provider_type is \"apple\" and client_secret is not set. Ory uses this to generate the JWT client secret automatically.",
+				Description: "Apple private key in PEM format (contents of the .p8 file). Required when provider_type is \"apple\" and client_secret is not set. Ory uses this to generate the JWT client secret automatically. Exactly one of apple_private_key or apple_private_key_wo may be set.",
 				Optional:    true,
 				Sensitive:   true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("apple_private_key_wo")),
+				},
+			},
+			"apple_private_key_wo": schema.StringAttribute{
+				Description: "Write-only equivalent of apple_private_key (Terraform 1.11+ write-only argument): the value is sent to Ory but never stored in Terraform state or plan. Use this to source the Apple private key from an ephemeral resource such as a Vault secret. Because write-only values are not persisted, Terraform cannot detect when the value changes on its own — change apple_private_key_wo_version to rotate it. Mutually exclusive with apple_private_key.",
+				Optional:    true,
+				WriteOnly:   true,
+				Sensitive:   true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("apple_private_key")),
+				},
+			},
+			"apple_private_key_wo_version": schema.StringAttribute{
+				Description: "Version trigger for apple_private_key_wo. Change this value whenever the write-only apple_private_key_wo changes so Terraform sends the new key to Ory (write-only values are not stored in state and cannot be diffed). Has no effect unless apple_private_key_wo is set.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.MatchRoot("apple_private_key_wo")),
+				},
 			},
 			"auto_link": schema.BoolAttribute{
 				Description: "Enable automatic account linking for this provider. When true, if an identity with the same identifier (e.g., email) already exists, the social sign-in will automatically link to that identity instead of failing. Requires enable_oidc_auto_link_policy to be true in the project config (ory_project_config). This attribute is write-only — the API accepts it on create/update but does not return it on read, so Terraform preserves the value from state. On import, the value will not be populated. Removing this attribute from your configuration will automatically disable auto-linking server-side.",
@@ -259,27 +322,57 @@ func (r *SocialProviderResource) ValidateConfig(ctx context.Context, req resourc
 
 	providerType := config.ProviderType.ValueString()
 
+	// client_id is required for every provider type. It may be supplied either
+	// via client_id (stored in state) or client_id_wo (write-only). The mutual
+	// exclusion is enforced by ConflictsWith validators on the schema; here we
+	// only require that at least one is set. IsNull is false for unknown values,
+	// so an unknown value defers this check to apply time automatically.
+	if config.ClientID.IsNull() && config.ClientIDWO.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("client_id"),
+			"Missing Required Attribute",
+			"Either client_id or client_id_wo must be set.",
+		)
+	}
+
 	// When any attribute value is unknown (e.g. sourced from a data source like
-	// AWS Secrets Manager), we cannot validate cross-field requirements yet.
-	// Unknown values will become known at apply time, so we defer validation.
+	// AWS Secrets Manager, or an ephemeral resource feeding a write-only field),
+	// we cannot validate cross-field requirements yet. Unknown values will become
+	// known at apply time, so we defer validation.
 	// See: https://developer.hashicorp.com/terraform/plugin/framework/validation
 	if config.ClientSecret.IsUnknown() ||
+		config.ClientSecretWO.IsUnknown() ||
 		config.AppleTeamID.IsUnknown() ||
 		config.ApplePrivateKeyID.IsUnknown() ||
-		config.ApplePrivateKey.IsUnknown() {
+		config.ApplePrivateKey.IsUnknown() ||
+		config.ApplePrivateKeyWO.IsUnknown() {
 		return
 	}
 
-	hasClientSecret := !config.ClientSecret.IsNull()
+	// A secret may be provided either via the normal attribute or its write-only
+	// (_wo) counterpart; treat either as "present" for the requirement checks.
+	hasClientSecret := !config.ClientSecret.IsNull() || !config.ClientSecretWO.IsNull()
 	hasAppleTeamID := !config.AppleTeamID.IsNull()
 	hasApplePrivateKeyID := !config.ApplePrivateKeyID.IsNull()
-	hasApplePrivateKey := !config.ApplePrivateKey.IsNull()
+	hasApplePrivateKey := !config.ApplePrivateKey.IsNull() || !config.ApplePrivateKeyWO.IsNull()
 	hasAnyAppleField := hasAppleTeamID || hasApplePrivateKeyID || hasApplePrivateKey
 	hasAllAppleFields := hasAppleTeamID && hasApplePrivateKeyID && hasApplePrivateKey
 
 	// Validate that known values are not empty strings
-	if hasClientSecret && config.ClientSecret.ValueString() == "" {
+	if !config.ClientID.IsNull() && config.ClientID.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(path.Root("client_id"), "Invalid Attribute Value", "client_id must not be an empty string.")
+	}
+	if !config.ClientIDWO.IsNull() && config.ClientIDWO.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(path.Root("client_id_wo"), "Invalid Attribute Value", "client_id_wo must not be an empty string.")
+	}
+	if !config.ClientSecret.IsNull() && config.ClientSecret.ValueString() == "" {
 		resp.Diagnostics.AddAttributeError(path.Root("client_secret"), "Invalid Attribute Value", "client_secret must not be an empty string.")
+	}
+	if !config.ClientSecretWO.IsNull() && config.ClientSecretWO.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(path.Root("client_secret_wo"), "Invalid Attribute Value", "client_secret_wo must not be an empty string.")
+	}
+	if !config.ApplePrivateKeyWO.IsNull() && config.ApplePrivateKeyWO.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(path.Root("apple_private_key_wo"), "Invalid Attribute Value", "apple_private_key_wo must not be an empty string.")
 	}
 	if hasAppleTeamID && config.AppleTeamID.ValueString() == "" {
 		resp.Diagnostics.AddAttributeError(path.Root("apple_team_id"), "Invalid Attribute Value", "apple_team_id must not be an empty string.")
@@ -287,7 +380,7 @@ func (r *SocialProviderResource) ValidateConfig(ctx context.Context, req resourc
 	if hasApplePrivateKeyID && config.ApplePrivateKeyID.ValueString() == "" {
 		resp.Diagnostics.AddAttributeError(path.Root("apple_private_key_id"), "Invalid Attribute Value", "apple_private_key_id must not be an empty string.")
 	}
-	if hasApplePrivateKey && config.ApplePrivateKey.ValueString() == "" {
+	if !config.ApplePrivateKey.IsNull() && config.ApplePrivateKey.ValueString() == "" {
 		resp.Diagnostics.AddAttributeError(path.Root("apple_private_key"), "Invalid Attribute Value", "apple_private_key must not be an empty string.")
 	}
 	if !config.BaseRedirectURI.IsNull() && !config.BaseRedirectURI.IsUnknown() && config.BaseRedirectURI.ValueString() == "" {
@@ -338,15 +431,20 @@ func (r *SocialProviderResource) ValidateConfig(ctx context.Context, req resourc
 // The base64-encoded Jsonnet maps claims to identity traits.
 const defaultMapperURL = "base64://bG9jYWwgY2xhaW1zID0gc3RkLmV4dFZhcignY2xhaW1zJyk7CnsKICBpZGVudGl0eTogewogICAgdHJhaXRzOiB7CiAgICAgIGVtYWlsOiBjbGFpbXMuZW1haWwsCiAgICB9LAogIH0sCn0="
 
-func (r *SocialProviderResource) buildProviderConfig(ctx context.Context, plan *SocialProviderResourceModel) map[string]interface{} {
+// buildProviderConfig builds the Ory provider config map. The clientID,
+// clientSecret, and applePrivateKey arguments carry the resolved credential
+// values (the write-only _wo value when set, otherwise the stateful attribute),
+// since write-only values live only in the configuration and must be read from
+// req.Config rather than the plan. See resolveCredentials.
+func (r *SocialProviderResource) buildProviderConfig(ctx context.Context, plan *SocialProviderResourceModel, clientID, clientSecret, applePrivateKey types.String) map[string]interface{} {
 	config := map[string]interface{}{
 		"id":        plan.ProviderID.ValueString(),
 		"provider":  plan.ProviderType.ValueString(),
-		"client_id": plan.ClientID.ValueString(),
+		"client_id": clientID.ValueString(),
 	}
 
-	if !plan.ClientSecret.IsNull() && !plan.ClientSecret.IsUnknown() && plan.ClientSecret.ValueString() != "" {
-		config["client_secret"] = plan.ClientSecret.ValueString()
+	if !clientSecret.IsNull() && !clientSecret.IsUnknown() && clientSecret.ValueString() != "" {
+		config["client_secret"] = clientSecret.ValueString()
 	}
 	if !plan.IssuerURL.IsNull() && !plan.IssuerURL.IsUnknown() {
 		config["issuer_url"] = plan.IssuerURL.ValueString()
@@ -426,11 +524,39 @@ func (r *SocialProviderResource) buildProviderConfig(ctx context.Context, plan *
 	if !plan.ApplePrivateKeyID.IsNull() && !plan.ApplePrivateKeyID.IsUnknown() && plan.ApplePrivateKeyID.ValueString() != "" {
 		config["apple_private_key_id"] = plan.ApplePrivateKeyID.ValueString()
 	}
-	if !plan.ApplePrivateKey.IsNull() && !plan.ApplePrivateKey.IsUnknown() && plan.ApplePrivateKey.ValueString() != "" {
-		config["apple_private_key"] = plan.ApplePrivateKey.ValueString()
+	if !applePrivateKey.IsNull() && !applePrivateKey.IsUnknown() && applePrivateKey.ValueString() != "" {
+		config["apple_private_key"] = applePrivateKey.ValueString()
 	}
 
 	return config
+}
+
+// resolveCredentials returns the effective client_id, client_secret, and
+// apple_private_key for an apply, preferring the write-only (_wo) value when the
+// user supplied one. Write-only attribute values are nullified in the plan and
+// state, so they must be read from the configuration (req.Config) at Create and
+// Update time. Resolved values are used only to build the API payload; they are
+// never written back into the model, so they never reach Terraform state.
+func (r *SocialProviderResource) resolveCredentials(ctx context.Context, config tfsdk.Config, plan *SocialProviderResourceModel, diags *diag.Diagnostics) (clientID, clientSecret, applePrivateKey types.String) {
+	clientID = plan.ClientID
+	clientSecret = plan.ClientSecret
+	applePrivateKey = plan.ApplePrivateKey
+
+	var clientIDWO, clientSecretWO, applePrivateKeyWO types.String
+	diags.Append(config.GetAttribute(ctx, path.Root("client_id_wo"), &clientIDWO)...)
+	diags.Append(config.GetAttribute(ctx, path.Root("client_secret_wo"), &clientSecretWO)...)
+	diags.Append(config.GetAttribute(ctx, path.Root("apple_private_key_wo"), &applePrivateKeyWO)...)
+
+	if !clientIDWO.IsNull() && !clientIDWO.IsUnknown() {
+		clientID = clientIDWO
+	}
+	if !clientSecretWO.IsNull() && !clientSecretWO.IsUnknown() {
+		clientSecret = clientSecretWO
+	}
+	if !applePrivateKeyWO.IsNull() && !applePrivateKeyWO.IsUnknown() {
+		applePrivateKey = applePrivateKeyWO
+	}
+	return clientID, clientSecret, applePrivateKey
 }
 
 // readStringList converts a JSON-decoded string array from the API into a
@@ -555,7 +681,11 @@ func (r *SocialProviderResource) Create(ctx context.Context, req resource.Create
 		projectID = r.client.ProjectID()
 	}
 
-	providerConfig := r.buildProviderConfig(ctx, &plan)
+	clientID, clientSecret, applePrivateKey := r.resolveCredentials(ctx, req.Config, &plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	providerConfig := r.buildProviderConfig(ctx, &plan, clientID, clientSecret, applePrivateKey)
 
 	// Serialize mutations to prevent concurrent read-modify-write races.
 	mu := projectMutex(projectID)
@@ -716,8 +846,16 @@ func (r *SocialProviderResource) Read(ctx context.Context, req resource.ReadRequ
 
 	provider := providers[index]
 	state.ProviderType = types.StringValue(fmt.Sprintf("%v", provider["provider"]))
-	state.ClientID = types.StringValue(fmt.Sprintf("%v", provider["client_id"]))
-	// Don't read back client_secret for security - it's sensitive
+	// Refresh client_id from the API only when it is already tracked in state.
+	// When the provider is managed via the write-only client_id_wo, client_id is
+	// null in state and must stay null — otherwise the API value would be written
+	// to state and produce a perpetual diff against the (write-only) config.
+	// ImportState seeds client_id so normal imports still round-trip it.
+	if !state.ClientID.IsNull() {
+		state.ClientID = types.StringValue(fmt.Sprintf("%v", provider["client_id"]))
+	}
+	// Don't read back client_secret for security - it's sensitive (and may be
+	// supplied write-only via client_secret_wo, which is never stored).
 
 	if issuer, ok := provider["issuer_url"].(string); ok {
 		state.IssuerURL = types.StringValue(issuer)
@@ -849,7 +987,11 @@ func (r *SocialProviderResource) Update(ctx context.Context, req resource.Update
 		projectID = r.client.ProjectID()
 	}
 
-	providerConfig := r.buildProviderConfig(ctx, &plan)
+	clientID, clientSecret, applePrivateKey := r.resolveCredentials(ctx, req.Config, &plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	providerConfig := r.buildProviderConfig(ctx, &plan, clientID, clientSecret, applePrivateKey)
 
 	// If auto_link was previously set but is now removed from config,
 	// explicitly send false to disable it server-side (auto_link is write-only
@@ -983,4 +1125,26 @@ func (r *SocialProviderResource) Delete(ctx context.Context, req resource.Delete
 func (r *SocialProviderResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("provider_id"), req.ID)...)
+
+	// Seed client_id from the API. Read only refreshes client_id when it is
+	// already present in state (so providers managed via the write-only
+	// client_id_wo keep it out of state). Without seeding it here, the
+	// post-import refresh would leave client_id null for a normally-managed
+	// provider. Best-effort: if the lookup fails, Read still recovers everything
+	// except client_id, and the next apply reconciles it.
+	projectID := r.client.ProjectID()
+	if projectID == "" {
+		return
+	}
+	providers, err := r.getProviders(ctx, projectID)
+	if err != nil {
+		return
+	}
+	index := r.findProviderIndex(providers, req.ID)
+	if index < 0 {
+		return
+	}
+	if clientID, ok := providers[index]["client_id"].(string); ok && clientID != "" {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("client_id"), clientID)...)
+	}
 }

--- a/internal/resources/socialprovider/resource.go
+++ b/internal/resources/socialprovider/resource.go
@@ -358,11 +358,13 @@ func (r *SocialProviderResource) ValidateConfig(ctx context.Context, req resourc
 	hasAnyAppleField := hasAppleTeamID || hasApplePrivateKeyID || hasApplePrivateKey
 	hasAllAppleFields := hasAppleTeamID && hasApplePrivateKeyID && hasApplePrivateKey
 
-	// Validate that known values are not empty strings
-	if !config.ClientID.IsNull() && config.ClientID.ValueString() == "" {
+	// Validate that known values are not empty strings. client_id and
+	// client_id_wo are not covered by the unknown-deferral block above, so guard
+	// against unknown values here (an unknown value reports ValueString() == "").
+	if !config.ClientID.IsNull() && !config.ClientID.IsUnknown() && config.ClientID.ValueString() == "" {
 		resp.Diagnostics.AddAttributeError(path.Root("client_id"), "Invalid Attribute Value", "client_id must not be an empty string.")
 	}
-	if !config.ClientIDWO.IsNull() && config.ClientIDWO.ValueString() == "" {
+	if !config.ClientIDWO.IsNull() && !config.ClientIDWO.IsUnknown() && config.ClientIDWO.ValueString() == "" {
 		resp.Diagnostics.AddAttributeError(path.Root("client_id_wo"), "Invalid Attribute Value", "client_id_wo must not be an empty string.")
 	}
 	if !config.ClientSecret.IsNull() && config.ClientSecret.ValueString() == "" {

--- a/internal/resources/socialprovider/resource_test.go
+++ b/internal/resources/socialprovider/resource_test.go
@@ -11,6 +11,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ory/terraform-provider-ory/internal/acctest"
@@ -41,6 +45,106 @@ func TestAccSocialProviderResource_concurrentCreate(t *testing.T) {
 			// Verify no diff — all 4 providers should already exist
 			{
 				Config:   acctest.LoadTestConfig(t, "testdata/concurrent_create.tf.tmpl", nil),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccSocialProviderResource_writeOnlySecret verifies that client_secret_wo
+// is accepted by the API but never written to Terraform state, and that bumping
+// client_secret_wo_version triggers an update (rotation). Write-only arguments
+// require Terraform 1.11+.
+func TestAccSocialProviderResource_writeOnlySecret(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.AccPreCheck(t)
+			acctest.RequireSocialProviderTests(t)
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create with a write-only client secret (version 1).
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/write_only_secret.tf.tmpl", map[string]string{
+					"Version": "1",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_social_provider.wo", "provider_id", "test-wo-google"),
+					resource.TestCheckResourceAttr("ory_social_provider.wo", "provider_type", "google"),
+					resource.TestCheckResourceAttr("ory_social_provider.wo", "client_id", "test-wo-client-id.apps.googleusercontent.com"),
+					resource.TestCheckResourceAttr("ory_social_provider.wo", "client_secret_wo_version", "1"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// The write-only secret and the unused stateful client_secret
+					// must both be absent from state.
+					statecheck.ExpectKnownValue("ory_social_provider.wo", tfjsonpath.New("client_secret_wo"), knownvalue.Null()),
+					statecheck.ExpectKnownValue("ory_social_provider.wo", tfjsonpath.New("client_secret"), knownvalue.Null()),
+				},
+			},
+			// Rotate the secret by bumping the version trigger (version 2).
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/write_only_secret.tf.tmpl", map[string]string{
+					"Version": "2",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_social_provider.wo", "client_secret_wo_version", "2"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("ory_social_provider.wo", tfjsonpath.New("client_secret_wo"), knownvalue.Null()),
+				},
+			},
+			// Re-applying the same config must produce no diff (idempotency).
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/write_only_secret.tf.tmpl", map[string]string{
+					"Version": "2",
+				}),
+				PlanOnly: true,
+			},
+			// Import: client_id round-trips; write-only attributes do not.
+			{
+				ResourceName:            "ory_social_provider.wo",
+				ImportState:             true,
+				ImportStateId:           "test-wo-google",
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"client_secret", "client_secret_wo", "client_secret_wo_version"},
+			},
+		},
+	})
+}
+
+// TestAccSocialProviderResource_writeOnlyClientID verifies that when client_id is
+// supplied via the write-only client_id_wo, the client_id never appears in state
+// and the configuration remains free of perpetual diffs.
+func TestAccSocialProviderResource_writeOnlyClientID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.AccPreCheck(t)
+			acctest.RequireSocialProviderTests(t)
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/write_only_client_id.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_social_provider.woid", "provider_id", "test-wo-id-google"),
+					resource.TestCheckResourceAttr("ory_social_provider.woid", "client_id_wo_version", "1"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// Neither the stateful client_id nor any write-only value is stored.
+					statecheck.ExpectKnownValue("ory_social_provider.woid", tfjsonpath.New("client_id"), knownvalue.Null()),
+					statecheck.ExpectKnownValue("ory_social_provider.woid", tfjsonpath.New("client_id_wo"), knownvalue.Null()),
+					statecheck.ExpectKnownValue("ory_social_provider.woid", tfjsonpath.New("client_secret_wo"), knownvalue.Null()),
+				},
+			},
+			// No perpetual diff: client_id stays out of state across refreshes.
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/write_only_client_id.tf.tmpl", nil),
 				PlanOnly: true,
 			},
 		},

--- a/internal/resources/socialprovider/testdata/write_only_client_id.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/write_only_client_id.tf.tmpl
@@ -1,0 +1,9 @@
+resource "ory_social_provider" "woid" {
+  provider_id              = "test-wo-id-google"
+  provider_type            = "google"
+  client_id_wo             = "test-wo-id-client-id.apps.googleusercontent.com"
+  client_id_wo_version     = "1"
+  client_secret_wo         = "test-wo-id-client-secret"
+  client_secret_wo_version = "1"
+  scope                    = ["email", "profile"]
+}

--- a/internal/resources/socialprovider/testdata/write_only_secret.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/write_only_secret.tf.tmpl
@@ -1,0 +1,8 @@
+resource "ory_social_provider" "wo" {
+  provider_id              = "test-wo-google"
+  provider_type            = "google"
+  client_id                = "test-wo-client-id.apps.googleusercontent.com"
+  client_secret_wo         = "test-wo-client-secret-[[ .Version ]]"
+  client_secret_wo_version = "[[ .Version ]]"
+  scope                    = ["email", "profile"]
+}

--- a/internal/resources/socialprovider/validate_config_test.go
+++ b/internal/resources/socialprovider/validate_config_test.go
@@ -255,6 +255,24 @@ func TestValidateConfig_WriteOnlyClientID_Passes(t *testing.T) {
 	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for write-only client_id_wo: %v", resp.Diagnostics.Errors())
 }
 
+func TestValidateConfig_UnknownClientID_SkipsValidation(t *testing.T) {
+	r := &SocialProviderResource{}
+	ctx := context.Background()
+
+	// client_id sourced from an unknown value (e.g. an ephemeral resource) must
+	// not be rejected as an empty string at plan time.
+	req := buildTestConfig(t, SocialProviderResourceModel{
+		ProviderID:   types.StringValue("google"),
+		ProviderType: types.StringValue("generic"),
+		ClientID:     types.StringUnknown(),
+		ClientSecret: types.StringValue("my-secret"),
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for unknown client_id: %v", resp.Diagnostics.Errors())
+}
+
 func TestValidateConfig_MissingClientID_Fails(t *testing.T) {
 	r := &SocialProviderResource{}
 	ctx := context.Background()

--- a/internal/resources/socialprovider/validate_config_test.go
+++ b/internal/resources/socialprovider/validate_config_test.go
@@ -27,7 +27,11 @@ func buildTestConfig(t *testing.T, model SocialProviderResourceModel) resource.V
 		"provider_id":                   tftypes.NewValue(tftypes.String, model.ProviderID.ValueString()),
 		"provider_type":                 tfStringValue(model.ProviderType),
 		"client_id":                     tfStringValue(model.ClientID),
+		"client_id_wo":                  tfStringValue(model.ClientIDWO),
+		"client_id_wo_version":          tfStringValue(model.ClientIDWOVersion),
 		"client_secret":                 tfStringValue(model.ClientSecret),
+		"client_secret_wo":              tfStringValue(model.ClientSecretWO),
+		"client_secret_wo_version":      tfStringValue(model.ClientSecretWOVersion),
 		"issuer_url":                    tftypes.NewValue(tftypes.String, nil),
 		"scope":                         tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
 		"mapper_url":                    tftypes.NewValue(tftypes.String, nil),
@@ -37,6 +41,8 @@ func buildTestConfig(t *testing.T, model SocialProviderResourceModel) resource.V
 		"apple_team_id":                 tfStringValue(model.AppleTeamID),
 		"apple_private_key_id":          tfStringValue(model.ApplePrivateKeyID),
 		"apple_private_key":             tfStringValue(model.ApplePrivateKey),
+		"apple_private_key_wo":          tfStringValue(model.ApplePrivateKeyWO),
+		"apple_private_key_wo_version":  tfStringValue(model.ApplePrivateKeyWOVersion),
 		"auto_link":                     tfBoolValue(model.AutoLink),
 		"label":                         tfStringValue(model.Label),
 		"account_linking_mode":          tfStringValue(model.AccountLinkingMode),
@@ -55,7 +61,11 @@ func buildTestConfig(t *testing.T, model SocialProviderResourceModel) resource.V
 			"provider_id":                   tftypes.String,
 			"provider_type":                 tftypes.String,
 			"client_id":                     tftypes.String,
+			"client_id_wo":                  tftypes.String,
+			"client_id_wo_version":          tftypes.String,
 			"client_secret":                 tftypes.String,
+			"client_secret_wo":              tftypes.String,
+			"client_secret_wo_version":      tftypes.String,
 			"issuer_url":                    tftypes.String,
 			"scope":                         tftypes.List{ElementType: tftypes.String},
 			"mapper_url":                    tftypes.String,
@@ -65,6 +75,8 @@ func buildTestConfig(t *testing.T, model SocialProviderResourceModel) resource.V
 			"apple_team_id":                 tftypes.String,
 			"apple_private_key_id":          tftypes.String,
 			"apple_private_key":             tftypes.String,
+			"apple_private_key_wo":          tftypes.String,
+			"apple_private_key_wo_version":  tftypes.String,
 			"auto_link":                     tftypes.Bool,
 			"label":                         tftypes.String,
 			"account_linking_mode":          tftypes.String,
@@ -205,6 +217,111 @@ func TestValidateConfig_EmptyFedcmConfigURL_Fails(t *testing.T) {
 	r.ValidateConfig(ctx, req, &resp)
 
 	assert.True(t, resp.Diagnostics.HasError(), "expected error for empty fedcm_config_url")
+}
+
+func TestValidateConfig_WriteOnlyClientSecret_Passes(t *testing.T) {
+	r := &SocialProviderResource{}
+	ctx := context.Background()
+
+	// A non-Apple provider with only the write-only client_secret_wo set must
+	// satisfy the "client_secret is required" rule.
+	req := buildTestConfig(t, SocialProviderResourceModel{
+		ProviderID:     types.StringValue("google"),
+		ProviderType:   types.StringValue("generic"),
+		ClientID:       types.StringValue("my-client-id"),
+		ClientSecretWO: types.StringValue("my-wo-secret"),
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for write-only client_secret_wo: %v", resp.Diagnostics.Errors())
+}
+
+func TestValidateConfig_WriteOnlyClientID_Passes(t *testing.T) {
+	r := &SocialProviderResource{}
+	ctx := context.Background()
+
+	// client_id supplied only via the write-only client_id_wo satisfies the
+	// "client_id is required" rule.
+	req := buildTestConfig(t, SocialProviderResourceModel{
+		ProviderID:   types.StringValue("google"),
+		ProviderType: types.StringValue("generic"),
+		ClientIDWO:   types.StringValue("my-wo-client-id"),
+		ClientSecret: types.StringValue("my-secret"),
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for write-only client_id_wo: %v", resp.Diagnostics.Errors())
+}
+
+func TestValidateConfig_MissingClientID_Fails(t *testing.T) {
+	r := &SocialProviderResource{}
+	ctx := context.Background()
+
+	// Neither client_id nor client_id_wo set — should fail.
+	req := buildTestConfig(t, SocialProviderResourceModel{
+		ProviderID:   types.StringValue("google"),
+		ProviderType: types.StringValue("generic"),
+		ClientSecret: types.StringValue("my-secret"),
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.True(t, resp.Diagnostics.HasError(), "expected error when neither client_id nor client_id_wo is set")
+}
+
+func TestValidateConfig_EmptyWriteOnlyClientSecret_Fails(t *testing.T) {
+	r := &SocialProviderResource{}
+	ctx := context.Background()
+
+	req := buildTestConfig(t, SocialProviderResourceModel{
+		ProviderID:     types.StringValue("google"),
+		ProviderType:   types.StringValue("generic"),
+		ClientID:       types.StringValue("my-client-id"),
+		ClientSecretWO: types.StringValue(""), // empty string — should fail
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.True(t, resp.Diagnostics.HasError(), "expected error for empty client_secret_wo")
+}
+
+func TestValidateConfig_UnknownWriteOnlyClientSecret_SkipsValidation(t *testing.T) {
+	r := &SocialProviderResource{}
+	ctx := context.Background()
+
+	// An ephemeral resource may produce an unknown value at plan time.
+	req := buildTestConfig(t, SocialProviderResourceModel{
+		ProviderID:     types.StringValue("google"),
+		ProviderType:   types.StringValue("generic"),
+		ClientID:       types.StringValue("my-client-id"),
+		ClientSecretWO: types.StringUnknown(),
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for unknown client_secret_wo: %v", resp.Diagnostics.Errors())
+}
+
+func TestValidateConfig_AppleWithWriteOnlyPrivateKey_Passes(t *testing.T) {
+	r := &SocialProviderResource{}
+	ctx := context.Background()
+
+	// Apple provider using the write-only apple_private_key_wo plus the other two
+	// Apple fields must satisfy the "all three Apple fields" rule.
+	req := buildTestConfig(t, SocialProviderResourceModel{
+		ProviderID:        types.StringValue("apple"),
+		ProviderType:      types.StringValue("apple"),
+		ClientID:          types.StringValue("com.example.app"),
+		AppleTeamID:       types.StringValue("KP76DQS54M"),
+		ApplePrivateKeyID: types.StringValue("UX56C66723"),
+		ApplePrivateKeyWO: types.StringValue("-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----"),
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for Apple with apple_private_key_wo: %v", resp.Diagnostics.Errors())
 }
 
 func TestValidateConfig_UnknownProviderType_SkipsValidation(t *testing.T) {

--- a/templates/resources/social_provider.md.tmpl
+++ b/templates/resources/social_provider.md.tmpl
@@ -45,6 +45,43 @@ Ory uses these to automatically generate the JWT `client_secret` required by App
 
 Alternatively, you may provide a pre-generated `client_secret` directly if you prefer to manage the JWT yourself.
 
+## Ephemeral (Write-Only) Credentials
+
+In addition to `client_id`, `client_secret`, and `apple_private_key`, this resource
+exposes **write-only** equivalents that are never written to Terraform state or
+plan (Terraform 1.11+ [write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only)):
+
+| Write-only attribute | Replaces | Version trigger |
+|----------------------|----------|-----------------|
+| `client_id_wo` | `client_id` | `client_id_wo_version` |
+| `client_secret_wo` | `client_secret` | `client_secret_wo_version` |
+| `apple_private_key_wo` | `apple_private_key` | `apple_private_key_wo_version` |
+
+Each write-only attribute is mutually exclusive with its stateful counterpart. Use
+them to feed credentials from an ephemeral source such as a Vault secret without
+persisting them in state. Because write-only values are never stored, Terraform
+cannot detect when the value changes on its own — change the matching
+`*_wo_version` whenever the secret rotates so Terraform sends the new value to Ory.
+
+```hcl
+ephemeral "vault_kv_secret_v2" "google_oauth" {
+  mount = "secret"
+  name  = "ory/google-oauth"
+}
+
+resource "ory_social_provider" "google" {
+  provider_id   = "google"
+  provider_type = "google"
+
+  client_id_wo             = ephemeral.vault_kv_secret_v2.google_oauth.data["client_id"]
+  client_id_wo_version     = "1"
+  client_secret_wo         = ephemeral.vault_kv_secret_v2.google_oauth.data["client_secret"]
+  client_secret_wo_version = "1"
+
+  scope = ["email", "profile"]
+}
+```
+
 ## Example Usage
 
 {{ tffile "examples/resources/ory_social_provider/resource.tf" }}
@@ -193,9 +230,9 @@ resource "ory_social_provider" "google" {
 ## Important Behaviors
 
 - **`provider_id` and `provider_type` cannot be changed** after creation. Changing either forces a new resource.
-- **`client_secret` is write-only.** The API does not return secrets on read, so Terraform cannot detect external changes to the secret.
+- **`client_secret` is not returned on read.** The API does not return secrets, so Terraform cannot detect external changes to the secret. (For a value that is never stored in state at all, use the write-only `client_secret_wo` — see [Ephemeral (Write-Only) Credentials](#ephemeral-write-only-credentials).)
 - **`tenant` maps to `microsoft_tenant`** in the Ory API. This is only used with `provider_type = "microsoft"`.
-- **Apple-specific fields** (`apple_team_id`, `apple_private_key_id`, `apple_private_key`) are only valid with `provider_type = "apple"`. The `apple_private_key` is write-only (not returned by API).
+- **Apple-specific fields** (`apple_team_id`, `apple_private_key_id`, `apple_private_key`) are only valid with `provider_type = "apple"`. The `apple_private_key` is not returned by the API on read.
 - **Deleting the last provider** resets the entire OIDC configuration to a disabled state with an empty providers array.
 
 ## Import
@@ -206,9 +243,9 @@ Import using the provider ID:
 terraform import ory_social_provider.google google
 ```
 
-The `provider_id` is the unique identifier you chose when creating the provider. After import, you must provide write-only credentials in your configuration since they cannot be read from the API:
+The `provider_id` is the unique identifier you chose when creating the provider. After import, you must provide the secret credentials in your configuration since they cannot be read from the API (either the stateful attributes below or their `_wo` write-only equivalents):
 
-- **Non-Apple providers:** Set `client_secret`.
-- **Apple providers:** Set either `client_secret` (pre-generated JWT) or all three Apple-specific fields (`apple_team_id`, `apple_private_key_id`, and `apple_private_key`).
+- **Non-Apple providers:** Set `client_secret` (or `client_secret_wo`).
+- **Apple providers:** Set either `client_secret` (pre-generated JWT) or all three Apple-specific fields (`apple_team_id`, `apple_private_key_id`, and `apple_private_key` / `apple_private_key_wo`).
 
 {{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
## Description

Adds support for Terraform 1.11+ [write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only) so secrets can be sourced from ephemeral resources (such as Vault's `vault_kv_secret_v2`) without ever being stored in Terraform state or plan.

For each supported secret, a write-only (`_wo`) argument is added alongside the existing stateful attribute:

| Resource | Write-only argument(s) | Stateful counterpart(s) |
|----------|------------------------|-------------------------|
| `ory_social_provider` | `client_id_wo`, `client_secret_wo`, `apple_private_key_wo` | `client_id`, `client_secret`, `apple_private_key` |
| `ory_identity` | `password_wo` | `password` |
| `ory_action` | `webhook_auth_basic_auth_password_wo`, `webhook_auth_api_key_value_wo` | `webhook_auth_basic_auth_password`, `webhook_auth_api_key_value` |
| `ory_oauth2_client` | `jwks_wo` | `jwks` |
| `ory_project_config` | `smtp_connection_uri_wo` | `smtp_connection_uri` |

Key behaviors:

- Each `_wo` argument is **mutually exclusive** with its stateful counterpart and has a companion `*_wo_version` trigger. Because write-only values are never persisted, Terraform cannot diff them, so the version is changed to make the provider re-send the value on rotation.
- Write-only values are only available to the provider at create/update time, so they are read from `req.Config` (not the plan) and used solely to build the API payload. Read paths are gated so the value never lands in state.
- `client_id` (social provider) becomes `Optional` so it can be supplied write-only; `ImportState` seeds the stateful `client_id`/`jwks` so normal imports still round-trip.
- Resource-level `project_api_key` credential overrides and server-generated/`Computed` secrets are intentionally not write-only (the former is needed during read/delete where write-only values are unavailable; the latter cannot be write-only).

## Related Issues

Fixes #272

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

- Unit tests extend the social provider and action `ValidateConfig` suites for the new mutual-exclusion and required-field rules.
- Acceptance tests (gated to Terraform 1.11+ via `tfversion.SkipBelow`) cover each resource: they assert via `ConfigStateChecks` + `knownvalue.Null()` that the write-only value and its stateful counterpart are absent from state, that bumping `*_wo_version` rotates the secret, and that re-applying is idempotent.
- Verified against the staging environment with `ORY_SOCIAL_PROVIDER_TESTS_ENABLED=true`. The new write-only tests pass, and the existing per-resource suites continue to pass.
- `make build`, `make format` (lint: 0 issues), `make test-short`, and `make sec` (govulncheck, gosec: 0 issues, gitleaks: no leaks) all pass.

## Screenshots/Output

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Terraform write-only (“ephemeral”) credential arguments for multiple resources: identities, OAuth2 clients (JWKS), actions (webhook auth), project SMTP settings, and social providers.
  * Added `*_wo_version` rotation triggers to force re-sending secrets without storing them in Terraform state.
  * Extended examples to use Vault-sourced ephemeral values.

* **Documentation**
  * Updated `SECURITY.md` and refreshed resource docs to clarify read/refresh/import behavior and mutual exclusivity for write-only fields.

* **Tests**
  * Added acceptance and validation coverage for write-only secret handling, rotation, idempotency, and state non-persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->