### PR TITLE
feat(provider): add allowed_project_ids guardrail and clarify project-config credential requirement

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -133,6 +133,32 @@ terraform plan
 | `ory_identity`, `ory_oauth2_client`, `ory_relationship` | `project_api_key`, `project_slug` |
 | `ory_json_web_key_set` | `project_api_key`, `project_slug` |
 
+## Why project configuration requires a workspace API key
+
+Project configuration and project-level resources are managed through the Ory Console API, which requires a **workspace API key** (`ory_wak_...`). A **project API key** (`ory_pat_...`) authenticates project *data* operations such as identities, OAuth2 clients, and relationships, but is not authorized to read or change project *configuration*. This is a property of the Ory Network API, not the provider: the Console endpoints reject a project API key with `403 Forbidden`.
+
+As a result, `ory_project_config`, `ory_action`, `ory_email_template`, `ory_social_provider`, `ory_saml_provider`, `ory_identity_schema`, `ory_custom_domain`, `ory_event_stream`, `ory_organization`, and `ory_project_api_key` all require a workspace API key. For more detail, see [Manage Ory Network projects through the API](https://www.ory.com/docs/guides/manage-project-via-api).
+
+## Limiting blast radius with `allowed_project_ids`
+
+A workspace API key can read and modify every project in the workspace, including production. To reduce the risk of an accidental change to the wrong project, set `allowed_project_ids` to the project IDs this configuration is permitted to touch. When set, the provider refuses any project operation whose target project ID is not in the list, before any request is sent to Ory.
+
+```hcl
+provider "ory" {
+  workspace_api_key   = var.ory_workspace_api_key
+  project_id          = var.ory_project_id
+  allowed_project_ids = [var.ory_project_id] # only this project may be changed
+}
+```
+
+The list can also be supplied as a comma-separated `ORY_ALLOWED_PROJECT_IDS` environment variable:
+
+```bash
+export ORY_ALLOWED_PROJECT_IDS="3fa274fe-910d-4766-b1a4-0c0dd3b41429,7bc1e0c2-..."
+```
+
+When `allowed_project_ids` is unset, no restriction is applied.
+
 ## Import Requirements
 
 When importing existing resources, ensure you have the appropriate credentials configured **before** running `terraform import`.
@@ -142,6 +168,7 @@ When importing existing resources, ensure you have the appropriate credentials c
 
 ### Optional
 
+- `allowed_project_ids` (List of String) Optional safety guardrail. When set, the provider refuses any project-configuration operation (`ory_project_config`, `ory_action`, `ory_email_template`, `ory_social_provider`, `ory_saml_provider`, `ory_identity_schema`, `ory_custom_domain`, `ory_event_stream`, `ory_organization`, `ory_project_api_key`, and `ory_project` create/delete) that targets a project ID not in this list. This bounds the blast radius of a workspace API key so a mis-pointed `project_id` (such as production) cannot be read or changed. When unset, no restriction is applied. Can also be set via the `ORY_ALLOWED_PROJECT_IDS` environment variable as a comma-separated list.
 - `console_api_url` (String) Override the console API URL (default: `https://api.console.ory.sh`). Mainly for testing.
 - `project_api_key` (String, Sensitive) Ory Project API Key (`ory_pat_...`). Used for identity and OAuth2 operations. Can also be set via `ORY_PROJECT_API_KEY` environment variable.
 - `project_api_url` (String) Override the project API URL template (default: `https://%s.projects.oryapis.com`).

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -39,6 +39,12 @@ provider "ory" {
   project_api_key   = var.ory_project_api_key
   project_id        = var.ory_project_id
   project_slug      = var.ory_project_slug
+
+  # Optional safety guardrail. When set, the provider refuses any project
+  # operation targeting a project ID not in this list. This bounds the blast
+  # radius of a workspace API key so a mis-pointed project_id, such as
+  # production, cannot be read or changed. Omit for no restriction.
+  allowed_project_ids = var.ory_allowed_project_ids
 }
 
 # =============================================================================
@@ -82,6 +88,12 @@ variable "ory_project_id" {
 variable "ory_project_slug" {
   type        = string
   description = "Ory Project Slug (e.g., vibrant-moore-abc123)"
+  default     = null
+}
+
+variable "ory_allowed_project_ids" {
+  type        = list(string)
+  description = "Optional allowlist of project IDs the provider may read or modify. Null or empty means no restriction."
   default     = null
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -26,6 +27,11 @@ var ErrCustomDomainNotFound = errors.New("custom domain not found")
 // ErrConsoleClientNotConfigured is returned when a console API method is called
 // without a workspace API key configured. Callers can check with errors.Is.
 var ErrConsoleClientNotConfigured = errors.New("console API client not configured")
+
+// ErrProjectNotAllowed is returned when a console operation targets a project ID
+// that is not present in the configured allowed_project_ids allowlist. Callers
+// can check with errors.Is.
+var ErrProjectNotAllowed = errors.New("project not allowed by allowed_project_ids")
 
 const (
 	// maxRetries is the maximum number of retry attempts for rate-limited requests.
@@ -314,6 +320,38 @@ type OryClientConfig struct {
 	ConsoleAPIURL   string
 	ProjectAPIURL   string // URL template with %s placeholder for slug (e.g., "https://%s.projects.oryapis.com")
 	UserAgent       string
+
+	// AllowedProjectIDs optionally restricts which project IDs console
+	// operations may target. When non-empty, any console operation against a
+	// project ID not in this list is refused before the request is sent. When
+	// empty, no restriction is applied. See OryClient.checkProjectAllowed.
+	AllowedProjectIDs []string
+}
+
+// Equal reports whether two configs are equivalent. It is used to decide
+// whether a cached client can be reused. OryClientConfig contains a slice
+// (AllowedProjectIDs) and is therefore not comparable with ==, so this method
+// compares every field explicitly.
+func (c OryClientConfig) Equal(other OryClientConfig) bool {
+	if c.WorkspaceAPIKey != other.WorkspaceAPIKey ||
+		c.ProjectAPIKey != other.ProjectAPIKey ||
+		c.ProjectID != other.ProjectID ||
+		c.ProjectSlug != other.ProjectSlug ||
+		c.WorkspaceID != other.WorkspaceID ||
+		c.ConsoleAPIURL != other.ConsoleAPIURL ||
+		c.ProjectAPIURL != other.ProjectAPIURL ||
+		c.UserAgent != other.UserAgent {
+		return false
+	}
+	if len(c.AllowedProjectIDs) != len(other.AllowedProjectIDs) {
+		return false
+	}
+	for i := range c.AllowedProjectIDs {
+		if c.AllowedProjectIDs[i] != other.AllowedProjectIDs[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // OryClient wraps the Ory SDK clients.
@@ -322,6 +360,10 @@ type OryClientConfig struct {
 // 2. Project API ({slug}.projects.oryapis.com) - for identities, OAuth2 clients
 type OryClient struct {
 	config OryClientConfig
+
+	// allowedProjects is the set of project IDs console operations may target,
+	// derived from config.AllowedProjectIDs. When empty, no restriction applies.
+	allowedProjects map[string]struct{}
 
 	// Console API client (for organizations, projects, workspaces)
 	consoleClient *ory.APIClient
@@ -362,7 +404,7 @@ func (c *OryClient) patchProjectMutex(projectID string) *sync.Mutex {
 
 // NewOryClient creates a new Ory API client.
 func NewOryClient(cfg OryClientConfig) (*OryClient, error) {
-	client := &OryClient{config: cfg}
+	client := &OryClient{config: cfg, allowedProjects: buildProjectSet(cfg.AllowedProjectIDs)}
 
 	// Initialize console client if workspace API key is provided
 	if cfg.WorkspaceAPIKey != "" {
@@ -489,6 +531,9 @@ func (c *OryClient) ResolveProjectSlug(ctx context.Context, projectID string) (s
 	if projectID == "" {
 		return "", fmt.Errorf("project_id must not be empty")
 	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
+		return "", err
+	}
 	if slug, ok := c.cachedSlugs.Load(projectID); ok {
 		return slug.(string), nil
 	}
@@ -530,11 +575,57 @@ func (c *OryClient) WithProjectCredentials(slug, apiKey string) *OryClient {
 	newConfig.ProjectAPIKey = apiKey
 
 	return &OryClient{
-		config:        newConfig,
-		consoleClient: c.consoleClient,
+		config:          newConfig,
+		allowedProjects: c.allowedProjects,
+		consoleClient:   c.consoleClient,
 		// projectClient is nil — ensureProjectClient will lazily initialize it
 		// projectClientMu and cachedProjects are zero-valued (valid)
 	}
+}
+
+// buildProjectSet converts a slice of project IDs into a lookup set, trimming
+// whitespace and dropping empty entries. Returns nil for an empty input so the
+// allowlist is treated as "unset" (no restriction).
+func buildProjectSet(ids []string) map[string]struct{} {
+	if len(ids) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			set[id] = struct{}{}
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	return set
+}
+
+// checkProjectAllowed enforces the optional allowed_project_ids allowlist.
+// When the allowlist is non-empty, any console operation targeting a project ID
+// outside the list is refused before the request is sent. This bounds the blast
+// radius of a workspace API key: a mis-pointed project_id (for example a
+// production project) cannot be read or modified. When the allowlist is empty
+// the check is a no-op and behavior is unchanged.
+func (c *OryClient) checkProjectAllowed(projectID string) error {
+	if len(c.allowedProjects) == 0 {
+		return nil
+	}
+	if _, ok := c.allowedProjects[projectID]; ok {
+		return nil
+	}
+	allowed := make([]string, 0, len(c.allowedProjects))
+	for id := range c.allowedProjects {
+		allowed = append(allowed, id)
+	}
+	sort.Strings(allowed)
+	return fmt.Errorf("%w: project %q is not in the allowed_project_ids allowlist [%s]. "+
+		"This guardrail prevents accidental changes to projects outside the allowlist, "+
+		"such as production. Add the project ID to allowed_project_ids, or remove the "+
+		"allowlist to disable this check",
+		ErrProjectNotAllowed, projectID, strings.Join(allowed, ", "))
 }
 
 // ensureProjectClient lazily initializes the project API client.
@@ -584,7 +675,12 @@ func (c *OryClient) ensureProjectClient() error {
 func (c *OryClient) requireConsoleClient(operation string) error {
 	if c.consoleClient == nil {
 		return fmt.Errorf("%s: %w. "+
-			"Set workspace_api_key (ORY_WORKSPACE_API_KEY) in the provider configuration",
+			"This operation manages project configuration, which the Ory Console API "+
+			"requires a workspace API key (ORY_WORKSPACE_API_KEY, ory_wak_...) to perform. "+
+			"A project API key (ory_pat_...) can manage project data such as identities and "+
+			"OAuth2 clients, but cannot read or change project configuration. "+
+			"To limit which projects a workspace key may touch, set allowed_project_ids. "+
+			"See https://www.ory.com/docs/guides/manage-project-via-api",
 			operation, ErrConsoleClientNotConfigured)
 	}
 	return nil
@@ -620,6 +716,9 @@ func (c *OryClient) GetProject(ctx context.Context, projectID string) (*ory.Proj
 	if err := c.requireConsoleClient("getting project"); err != nil {
 		return nil, err
 	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
+		return nil, err
+	}
 	project, httpResp, err := c.consoleClient.ProjectAPI.GetProject(ctx, projectID).Execute()
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
@@ -630,6 +729,9 @@ func (c *OryClient) GetProject(ctx context.Context, projectID string) (*ory.Proj
 // DeleteProject purges a project.
 func (c *OryClient) DeleteProject(ctx context.Context, projectID string) error {
 	if err := c.requireConsoleClient("deleting project"); err != nil {
+		return err
+	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
 		return err
 	}
 	httpResp, err := c.consoleClient.ProjectAPI.PurgeProject(ctx, projectID).Execute()
@@ -646,6 +748,9 @@ func (c *OryClient) DeleteProject(ctx context.Context, projectID string) error {
 // silently drop writes from a stale revision.
 func (c *OryClient) PatchProject(ctx context.Context, projectID string, patches []ory.JsonPatch) (*ory.SuccessfulProjectUpdate, error) {
 	if err := c.requireConsoleClient("patching project"); err != nil {
+		return nil, err
+	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
 		return nil, err
 	}
 	mu := c.patchProjectMutex(projectID)
@@ -759,6 +864,9 @@ func (c *OryClient) GetProjectEnvironment(ctx context.Context, projectID string)
 	if c.consoleClient == nil {
 		return "", fmt.Errorf("console API client not configured")
 	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
+		return "", err
+	}
 	project, httpResp, err := c.consoleClient.ProjectAPI.GetProject(ctx, projectID).Execute()
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
@@ -782,6 +890,9 @@ func (c *OryClient) CreateOrganization(ctx context.Context, projectID, label str
 	if c.consoleClient == nil {
 		return nil, fmt.Errorf("creating organization: console API client not configured. " +
 			"Organizations require workspace_api_key (ORY_WORKSPACE_API_KEY) to be set")
+	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
+		return nil, err
 	}
 
 	// Ory API requires domains to be an array, not null
@@ -810,6 +921,9 @@ func (c *OryClient) GetOrganization(ctx context.Context, projectID, orgID string
 	if c.consoleClient == nil {
 		return nil, fmt.Errorf("reading organization: console API client not configured. " +
 			"Set workspace_api_key (ORY_WORKSPACE_API_KEY)")
+	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
+		return nil, err
 	}
 
 	// Retry with backoff for 404 errors (eventual consistency)
@@ -850,6 +964,9 @@ func (c *OryClient) UpdateOrganization(ctx context.Context, projectID, orgID, la
 	if c.consoleClient == nil {
 		return nil, fmt.Errorf("updating organization: console API client not configured. " +
 			"Set workspace_api_key (ORY_WORKSPACE_API_KEY)")
+	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
+		return nil, err
 	}
 
 	// Ory API requires domains to be an array, not null
@@ -900,6 +1017,9 @@ func (c *OryClient) DeleteOrganization(ctx context.Context, projectID, orgID str
 	if c.consoleClient == nil {
 		return fmt.Errorf("deleting organization: console API client not configured. " +
 			"Set workspace_api_key (ORY_WORKSPACE_API_KEY)")
+	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
+		return err
 	}
 	httpResp, err := c.consoleClient.ProjectAPI.DeleteOrganization(ctx, projectID, orgID).Execute()
 	if httpResp != nil {
@@ -1030,6 +1150,9 @@ func (c *OryClient) CreateProjectAPIKey(ctx context.Context, projectID string, b
 	if err := c.requireConsoleClient("creating project API key"); err != nil {
 		return nil, err
 	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
+		return nil, err
+	}
 	key, httpResp, err := c.consoleClient.ProjectAPI.CreateProjectApiKey(ctx, projectID).CreateProjectApiKeyRequest(body).Execute()
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
@@ -1042,6 +1165,9 @@ func (c *OryClient) ListProjectAPIKeys(ctx context.Context, projectID string) ([
 	if err := c.requireConsoleClient("listing project API keys"); err != nil {
 		return nil, err
 	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
+		return nil, err
+	}
 	keys, httpResp, err := c.consoleClient.ProjectAPI.ListProjectApiKeys(ctx, projectID).Execute()
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
@@ -1052,6 +1178,9 @@ func (c *OryClient) ListProjectAPIKeys(ctx context.Context, projectID string) ([
 // DeleteProjectAPIKey deletes an API key with retry logic for transient errors.
 func (c *OryClient) DeleteProjectAPIKey(ctx context.Context, projectID, keyID string) error {
 	if err := c.requireConsoleClient("deleting project API key"); err != nil {
+		return err
+	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
 		return err
 	}
 	var lastErr error
@@ -1199,6 +1328,9 @@ func (c *OryClient) CreateEventStream(ctx context.Context, projectID string, bod
 	if err := c.requireConsoleClient("creating event stream"); err != nil {
 		return nil, err
 	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
+		return nil, err
+	}
 	stream, httpResp, err := c.consoleClient.EventsAPI.CreateEventStream(ctx, projectID).CreateEventStreamBody(body).Execute()
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
@@ -1213,6 +1345,9 @@ func (c *OryClient) CreateEventStream(ctx context.Context, projectID string, bod
 // The Ory API does not have a direct GET endpoint for event streams.
 func (c *OryClient) GetEventStream(ctx context.Context, projectID, streamID string) (*ory.EventStream, error) {
 	if err := c.requireConsoleClient("getting event stream"); err != nil {
+		return nil, err
+	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
 		return nil, err
 	}
 	list, httpResp, err := c.consoleClient.EventsAPI.ListEventStreams(ctx, projectID).Execute()
@@ -1236,6 +1371,9 @@ func (c *OryClient) SetEventStream(ctx context.Context, projectID, streamID stri
 	if err := c.requireConsoleClient("updating event stream"); err != nil {
 		return nil, err
 	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
+		return nil, err
+	}
 	stream, httpResp, err := c.consoleClient.EventsAPI.SetEventStream(ctx, projectID, streamID).SetEventStreamBody(body).Execute()
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
@@ -1251,6 +1389,9 @@ func (c *OryClient) DeleteEventStream(ctx context.Context, projectID, streamID s
 	if err := c.requireConsoleClient("deleting event stream"); err != nil {
 		return err
 	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
+		return err
+	}
 	httpResp, err := c.consoleClient.EventsAPI.DeleteEventStream(ctx, projectID, streamID).Execute()
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
@@ -1261,6 +1402,9 @@ func (c *OryClient) DeleteEventStream(ctx context.Context, projectID, streamID s
 // ListEventStreams lists all event streams for a project.
 func (c *OryClient) ListEventStreams(ctx context.Context, projectID string) ([]ory.EventStream, error) {
 	if err := c.requireConsoleClient("listing event streams"); err != nil {
+		return nil, err
+	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
 		return nil, err
 	}
 	list, httpResp, err := c.consoleClient.EventsAPI.ListEventStreams(ctx, projectID).Execute()
@@ -1422,6 +1566,9 @@ func (c *OryClient) ListOAuth2Clients(ctx context.Context) ([]ory.OAuth2Client, 
 // ListOrganizations lists all organizations in a project.
 func (c *OryClient) ListOrganizations(ctx context.Context, projectID string) ([]ory.Organization, error) {
 	if err := c.requireConsoleClient("listing organizations"); err != nil {
+		return nil, err
+	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
 		return nil, err
 	}
 	resp, httpResp, err := c.consoleClient.ProjectAPI.ListOrganizations(ctx, projectID).Execute()
@@ -1931,6 +2078,9 @@ func (c *OryClient) consoleHTTPDo(ctx context.Context, method, path string, body
 
 // ListCustomDomains lists all custom domains for a project.
 func (c *OryClient) ListCustomDomains(ctx context.Context, projectID string) ([]ory.CustomDomain, error) {
+	if err := c.checkProjectAllowed(projectID); err != nil {
+		return nil, err
+	}
 	httpResp, err := c.consoleHTTPDo(ctx, http.MethodGet, "/projects/"+projectID+"/cname", nil)
 	if err != nil {
 		return nil, wrapAPIError(err, "listing custom domains")
@@ -1968,6 +2118,9 @@ func (c *OryClient) GetCustomDomain(ctx context.Context, projectID, domainID str
 
 // CreateCustomDomain creates a new custom domain for a project.
 func (c *OryClient) CreateCustomDomain(ctx context.Context, projectID string, body ory.CreateCustomDomainBody) (*ory.CustomDomain, error) {
+	if err := c.checkProjectAllowed(projectID); err != nil {
+		return nil, err
+	}
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("creating custom domain: marshaling body: %w", err)
@@ -1996,6 +2149,9 @@ func (c *OryClient) CreateCustomDomain(ctx context.Context, projectID string, bo
 
 // UpdateCustomDomain updates an existing custom domain.
 func (c *OryClient) UpdateCustomDomain(ctx context.Context, projectID, domainID string, body ory.SetCustomDomainBody) (*ory.CustomDomain, error) {
+	if err := c.checkProjectAllowed(projectID); err != nil {
+		return nil, err
+	}
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("updating custom domain: marshaling body: %w", err)
@@ -2024,6 +2180,9 @@ func (c *OryClient) UpdateCustomDomain(ctx context.Context, projectID, domainID 
 
 // DeleteCustomDomain deletes a custom domain.
 func (c *OryClient) DeleteCustomDomain(ctx context.Context, projectID, domainID string) error {
+	if err := c.checkProjectAllowed(projectID); err != nil {
+		return err
+	}
 	httpResp, err := c.consoleHTTPDo(ctx, http.MethodDelete, "/projects/"+projectID+"/cname/"+domainID, nil)
 	if err != nil {
 		return wrapAPIError(err, "deleting custom domain")

--- a/internal/client/guardrail_test.go
+++ b/internal/client/guardrail_test.go
@@ -1,0 +1,128 @@
+package client
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildProjectSet(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string // expected keys (order-independent)
+	}{
+		{name: "nil input", in: nil, want: nil},
+		{name: "empty slice", in: []string{}, want: nil},
+		{name: "only empties and whitespace", in: []string{"", "  ", "\t"}, want: nil},
+		{name: "trims whitespace", in: []string{" abc ", "def"}, want: []string{"abc", "def"}},
+		{name: "dedupes", in: []string{"abc", "abc", "def"}, want: []string{"abc", "def"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildProjectSet(tt.in)
+			if tt.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Len(t, got, len(tt.want))
+			for _, id := range tt.want {
+				_, ok := got[id]
+				assert.Truef(t, ok, "expected %q in set", id)
+			}
+		})
+	}
+}
+
+func TestCheckProjectAllowed_NoAllowlist(t *testing.T) {
+	// An empty allowlist is a no-op: any project ID is permitted.
+	c := &OryClient{allowedProjects: buildProjectSet(nil)}
+	assert.NoError(t, c.checkProjectAllowed("any-project-id"))
+	assert.NoError(t, c.checkProjectAllowed(""))
+}
+
+func TestCheckProjectAllowed_Allowed(t *testing.T) {
+	c := &OryClient{allowedProjects: buildProjectSet([]string{"proj-a", "proj-b"})}
+	assert.NoError(t, c.checkProjectAllowed("proj-a"))
+	assert.NoError(t, c.checkProjectAllowed("proj-b"))
+}
+
+func TestCheckProjectAllowed_Disallowed(t *testing.T) {
+	c := &OryClient{allowedProjects: buildProjectSet([]string{"proj-b", "proj-a"})}
+	err := c.checkProjectAllowed("proj-c")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProjectNotAllowed)
+	// The message names the offending project and lists the allowlist sorted.
+	assert.Contains(t, err.Error(), "proj-c")
+	idx := strings.Index(err.Error(), "proj-a")
+	require.NotEqual(t, -1, idx)
+	assert.Less(t, idx, strings.Index(err.Error(), "proj-b"), "allowlist should be sorted")
+}
+
+func TestNewOryClient_BuildsAllowedProjects(t *testing.T) {
+	c, err := NewOryClient(OryClientConfig{AllowedProjectIDs: []string{"p1", " p2 "}})
+	require.NoError(t, err)
+	assert.NoError(t, c.checkProjectAllowed("p1"))
+	assert.NoError(t, c.checkProjectAllowed("p2"))
+	assert.ErrorIs(t, c.checkProjectAllowed("p3"), ErrProjectNotAllowed)
+}
+
+func TestWithProjectCredentials_CarriesAllowlist(t *testing.T) {
+	parent, err := NewOryClient(OryClientConfig{AllowedProjectIDs: []string{"p1"}})
+	require.NoError(t, err)
+	child := parent.WithProjectCredentials("some-slug", "ory_pat_x")
+	// The derived client must enforce the same allowlist.
+	assert.NoError(t, child.checkProjectAllowed("p1"))
+	assert.ErrorIs(t, child.checkProjectAllowed("p2"), ErrProjectNotAllowed)
+}
+
+func TestOryClientConfig_Equal(t *testing.T) {
+	base := OryClientConfig{
+		WorkspaceAPIKey:   "wak",
+		ProjectAPIKey:     "pat",
+		ProjectID:         "pid",
+		ProjectSlug:       "slug",
+		WorkspaceID:       "wid",
+		ConsoleAPIURL:     "https://console",
+		ProjectAPIURL:     "https://%s.projects",
+		UserAgent:         "ua",
+		AllowedProjectIDs: []string{"a", "b"},
+	}
+
+	same := base
+	same.AllowedProjectIDs = []string{"a", "b"}
+	assert.True(t, base.Equal(same))
+
+	scalarDiff := base
+	scalarDiff.ProjectID = "other"
+	scalarDiff.AllowedProjectIDs = []string{"a", "b"}
+	assert.False(t, base.Equal(scalarDiff))
+
+	lenDiff := base
+	lenDiff.AllowedProjectIDs = []string{"a"}
+	assert.False(t, base.Equal(lenDiff))
+
+	contentDiff := base
+	contentDiff.AllowedProjectIDs = []string{"a", "c"}
+	assert.False(t, base.Equal(contentDiff))
+
+	// Order is significant: the provider normalizes ordering before comparison,
+	// so a reordered slice is treated as a config change and rebuilds the client.
+	orderDiff := base
+	orderDiff.AllowedProjectIDs = []string{"b", "a"}
+	assert.False(t, base.Equal(orderDiff))
+
+	emptyBoth := OryClientConfig{}
+	assert.True(t, emptyBoth.Equal(OryClientConfig{}))
+}
+
+// errorsIsSanity guards against accidental removal of the sentinel wrapping.
+func TestErrProjectNotAllowed_Sentinel(t *testing.T) {
+	c := &OryClient{allowedProjects: buildProjectSet([]string{"x"})}
+	err := c.checkProjectAllowed("y")
+	assert.True(t, errors.Is(err, ErrProjectNotAllowed))
+}

--- a/internal/datasources/project/guardrail_test.go
+++ b/internal/datasources/project/guardrail_test.go
@@ -1,0 +1,55 @@
+//go:build acceptance
+
+package project_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/ory/terraform-provider-ory/internal/acctest"
+)
+
+// TestAccProject_allowedProjectIDsBlocksDisallowed verifies the
+// allowed_project_ids guardrail end to end: when the allowlist does not include
+// the target project, the provider refuses the console operation (here a
+// read-only GetProject via the data source) before any request reaches Ory.
+func TestAccProject_allowedProjectIDsBlocksDisallowed(t *testing.T) {
+	// A well-formed UUID that is deliberately not the test project.
+	t.Setenv("ORY_ALLOWED_PROJECT_IDS", "00000000-0000-0000-0000-000000000000")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/basic.tf.tmpl", nil),
+				// Terraform line-wraps rendered diagnostics, so match with flexible
+				// whitespace between words that may be split across a newline.
+				ExpectError: regexp.MustCompile(`is\s+not\s+in\s+the\s+allowed_project_ids\s+allowlist`),
+			},
+		},
+	})
+}
+
+// TestAccProject_allowedProjectIDsAllowsListed verifies that when the target
+// project is present in allowed_project_ids, operations proceed normally.
+func TestAccProject_allowedProjectIDsAllowsListed(t *testing.T) {
+	projectID := acctest.GetTestProjectID(t)
+	t.Setenv("ORY_ALLOWED_PROJECT_IDS", projectID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/basic.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ory_project.test", "id", projectID),
+					resource.TestCheckResourceAttrSet("data.ory_project.test", "slug"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/allowed_project_ids_test.go
+++ b/internal/provider/allowed_project_ids_test.go
@@ -1,0 +1,66 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeStringList(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{name: "nil", in: nil, want: nil},
+		{name: "all empty or whitespace", in: []string{"", "  ", "\t"}, want: nil},
+		{name: "trims and drops empties", in: []string{" a ", "", "b"}, want: []string{"a", "b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeStringList(tt.in))
+		})
+	}
+}
+
+func TestResolveStringList_FromConfig(t *testing.T) {
+	var diags diag.Diagnostics
+	list := types.ListValueMust(types.StringType, []attr.Value{
+		types.StringValue(" p1 "),
+		types.StringValue("p2"),
+		types.StringValue(""),
+	})
+	got := resolveAllowedProjectIDs(context.Background(), list, &diags)
+	require.False(t, diags.HasError())
+	assert.Equal(t, []string{"p1", "p2"}, got)
+}
+
+func TestResolveStringList_FromEnvFallback(t *testing.T) {
+	var diags diag.Diagnostics
+	t.Setenv("ORY_ALLOWED_PROJECT_IDS", " p1 , p2 ,,p3")
+	got := resolveAllowedProjectIDs(context.Background(), types.ListNull(types.StringType), &diags)
+	require.False(t, diags.HasError())
+	assert.Equal(t, []string{"p1", "p2", "p3"}, got)
+}
+
+func TestResolveStringList_ConfigTakesPrecedenceOverEnv(t *testing.T) {
+	var diags diag.Diagnostics
+	t.Setenv("ORY_ALLOWED_PROJECT_IDS", "env-id")
+	list := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("config-id")})
+	got := resolveAllowedProjectIDs(context.Background(), list, &diags)
+	require.False(t, diags.HasError())
+	assert.Equal(t, []string{"config-id"}, got)
+}
+
+func TestResolveStringList_Unset(t *testing.T) {
+	var diags diag.Diagnostics
+	t.Setenv("ORY_ALLOWED_PROJECT_IDS", "")
+	got := resolveAllowedProjectIDs(context.Background(), types.ListNull(types.StringType), &diags)
+	require.False(t, diags.HasError())
+	assert.Nil(t, got)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,8 +3,10 @@ package provider
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -72,6 +74,9 @@ type OryProviderModel struct {
 	ProjectID   types.String `tfsdk:"project_id"`
 	ProjectSlug types.String `tfsdk:"project_slug"`
 	WorkspaceID types.String `tfsdk:"workspace_id"`
+
+	// Optional safety guardrail: restrict which project IDs may be touched
+	AllowedProjectIDs types.List `tfsdk:"allowed_project_ids"`
 
 	// Optional: Override API URLs (for testing)
 	ConsoleAPIURL types.String `tfsdk:"console_api_url"`
@@ -185,6 +190,12 @@ When importing existing resources, ensure you have the appropriate credentials c
 				MarkdownDescription: "Ory Workspace ID. Can also be set via `ORY_WORKSPACE_ID` environment variable.",
 				Optional:            true,
 			},
+			"allowed_project_ids": schema.ListAttribute{
+				Description:         "Optional safety guardrail. When set, the provider refuses any project-configuration operation (project config, actions, email templates, social/SAML providers, identity schema, custom domains, event streams, organizations, project API keys, and project create/delete) that targets a project ID not in this list. This bounds the blast radius of a workspace API key so a mis-pointed project_id, such as production, cannot be read or changed. When unset, no restriction is applied. Can also be set via the ORY_ALLOWED_PROJECT_IDS environment variable as a comma-separated list.",
+				MarkdownDescription: "Optional safety guardrail. When set, the provider refuses any project-configuration operation (`ory_project_config`, `ory_action`, `ory_email_template`, `ory_social_provider`, `ory_saml_provider`, `ory_identity_schema`, `ory_custom_domain`, `ory_event_stream`, `ory_organization`, `ory_project_api_key`, and `ory_project` create/delete) that targets a project ID not in this list. This bounds the blast radius of a workspace API key so a mis-pointed `project_id` (such as production) cannot be read or changed. When unset, no restriction is applied. Can also be set via the `ORY_ALLOWED_PROJECT_IDS` environment variable as a comma-separated list.",
+				Optional:            true,
+				ElementType:         types.StringType,
+			},
 			"console_api_url": schema.StringAttribute{
 				Description:         "Override the console API URL (default: https://api.console.ory.sh). Mainly for testing.",
 				MarkdownDescription: "Override the console API URL (default: `https://api.console.ory.sh`). Mainly for testing.",
@@ -215,6 +226,10 @@ func (p *OryProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	workspaceID := resolveString(config.WorkspaceID, "ORY_WORKSPACE_ID")
 	consoleAPIURL := resolveStringDefault(config.ConsoleAPIURL, "ORY_CONSOLE_API_URL", DefaultConsoleAPIURL)
 	projectAPIURL := resolveStringDefault(config.ProjectAPIURL, "ORY_PROJECT_API_URL", DefaultProjectAPIURL)
+	allowedProjectIDs := resolveAllowedProjectIDs(ctx, config.AllowedProjectIDs, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// Validate required configuration
 	if workspaceAPIKey == "" && projectAPIKey == "" {
@@ -250,17 +265,18 @@ For more information: https://www.ory.sh/docs/guides/api-keys`,
 	// This preserves cached project state across Terraform operations
 	// (apply → plan/refresh) within the same provider server lifecycle.
 	newConfig := client.OryClientConfig{
-		WorkspaceAPIKey: workspaceAPIKey,
-		ProjectAPIKey:   projectAPIKey,
-		ProjectID:       projectID,
-		ProjectSlug:     projectSlug,
-		WorkspaceID:     workspaceID,
-		ConsoleAPIURL:   consoleAPIURL,
-		ProjectAPIURL:   projectAPIURL,
-		UserAgent:       userAgent,
+		WorkspaceAPIKey:   workspaceAPIKey,
+		ProjectAPIKey:     projectAPIKey,
+		ProjectID:         projectID,
+		ProjectSlug:       projectSlug,
+		WorkspaceID:       workspaceID,
+		ConsoleAPIURL:     consoleAPIURL,
+		ProjectAPIURL:     projectAPIURL,
+		UserAgent:         userAgent,
+		AllowedProjectIDs: allowedProjectIDs,
 	}
 
-	if p.oryClient == nil || p.lastConfig != newConfig {
+	if p.oryClient == nil || !p.lastConfig.Equal(newConfig) {
 		oryClient, err := client.NewOryClient(newConfig)
 		if err != nil {
 			resp.Diagnostics.AddError(
@@ -338,4 +354,36 @@ func resolveStringDefault(tfValue types.String, envVar, defaultValue string) str
 		return v
 	}
 	return defaultValue
+}
+
+// resolveAllowedProjectIDs resolves the allowed_project_ids list with a
+// comma-separated ORY_ALLOWED_PROJECT_IDS environment variable fallback. When
+// the Terraform value is set it takes precedence; otherwise the env var is split
+// on commas. Entries are trimmed and empty entries dropped. Returns nil when
+// neither source yields any value.
+func resolveAllowedProjectIDs(ctx context.Context, tfValue types.List, diags *diag.Diagnostics) []string {
+	if !tfValue.IsNull() && !tfValue.IsUnknown() {
+		var out []string
+		diags.Append(tfValue.ElementsAs(ctx, &out, false)...)
+		return normalizeStringList(out)
+	}
+	if v := os.Getenv("ORY_ALLOWED_PROJECT_IDS"); v != "" {
+		return normalizeStringList(strings.Split(v, ","))
+	}
+	return nil
+}
+
+// normalizeStringList trims whitespace from each entry and drops empty strings.
+// Returns nil when nothing remains.
+func normalizeStringList(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -133,6 +133,32 @@ terraform plan
 | `ory_identity`, `ory_oauth2_client`, `ory_relationship` | `project_api_key`, `project_slug` |
 | `ory_json_web_key_set` | `project_api_key`, `project_slug` |
 
+## Why project configuration requires a workspace API key
+
+Project configuration and project-level resources are managed through the Ory Console API, which requires a **workspace API key** (`ory_wak_...`). A **project API key** (`ory_pat_...`) authenticates project *data* operations such as identities, OAuth2 clients, and relationships, but is not authorized to read or change project *configuration*. This is a property of the Ory Network API, not the provider: the Console endpoints reject a project API key with `403 Forbidden`.
+
+As a result, `ory_project_config`, `ory_action`, `ory_email_template`, `ory_social_provider`, `ory_saml_provider`, `ory_identity_schema`, `ory_custom_domain`, `ory_event_stream`, `ory_organization`, and `ory_project_api_key` all require a workspace API key. For more detail, see [Manage Ory Network projects through the API](https://www.ory.com/docs/guides/manage-project-via-api).
+
+## Limiting blast radius with `allowed_project_ids`
+
+A workspace API key can read and modify every project in the workspace, including production. To reduce the risk of an accidental change to the wrong project, set `allowed_project_ids` to the project IDs this configuration is permitted to touch. When set, the provider refuses any project operation whose target project ID is not in the list, before any request is sent to Ory.
+
+```hcl
+provider "ory" {
+  workspace_api_key   = var.ory_workspace_api_key
+  project_id          = var.ory_project_id
+  allowed_project_ids = [var.ory_project_id] # only this project may be changed
+}
+```
+
+The list can also be supplied as a comma-separated `ORY_ALLOWED_PROJECT_IDS` environment variable:
+
+```bash
+export ORY_ALLOWED_PROJECT_IDS="3fa274fe-910d-4766-b1a4-0c0dd3b41429,7bc1e0c2-..."
+```
+
+When `allowed_project_ids` is unset, no restriction is applied.
+
 ## Import Requirements
 
 When importing existing resources, ensure you have the appropriate credentials configured **before** running `terraform import`.


### PR DESCRIPTION
## Description

A user asked to manage project configuration (`ory_project_config`, `ory_email_template`, `ory_action`, `ory_social_provider`, `ory_identity_schema`, `ory_custom_domain`, and related resources) with a project API key (`ory_pat_...`) instead of a workspace API key (`ory_wak_...`), to reduce blast radius when running Terraform locally or in CI.

Verification against the Console API, the `client-go` SDK, and the Ory docs shows this is not possible by API design: project configuration is managed through `PATCH /projects/{id}` on the Console API, which requires a workspace API key. A project API key is authenticated (ListProjects returns the owning project) but is not authorized for configuration read/write and receives `403 Forbidden`. The Ory CLI uses the same Console endpoint, so it is subject to the same authorization. The provider's workspace-key requirement is therefore correct.

Since a project-scoped credential is not available for configuration at the API level, this PR reduces the blast radius of the required workspace key and clarifies the credential model:

- Adds an optional `allowed_project_ids` provider argument (also `ORY_ALLOWED_PROJECT_IDS`, comma-separated). When set, the provider refuses any Console project operation whose target project ID is not in the list, before any request is sent to Ory. This prevents an accidental change to the wrong project, such as production. It is enforced on all project-scoped Console operations: project config, actions, email templates, social and SAML providers, identity schema, custom domains, event streams, organizations, project API keys, and project create/delete. Unset means no restriction, so existing behavior is unchanged.
- Improves the error returned when only a project API key is configured for a configuration resource, explaining the workspace-vs-project key split and linking to the Ory docs.
- Documents the credential model and the `allowed_project_ids` guardrail in the provider index.

## Related Issues

Fixes #281

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

Unit tests cover the allowlist set construction, the guard decision (empty allowlist is a no-op, listed IDs pass, unlisted IDs return the sentinel error), config equality with the new slice field, and the provider list resolution including the environment variable fallback and precedence.

Acceptance tests (against staging) exercise the full path through the `ory_project` data source, which performs a Console `GetProject`:

- A project not in `allowed_project_ids` is refused before any request reaches Ory.
- A project in `allowed_project_ids` proceeds normally.
- The existing data source test still passes with no allowlist set, confirming the guard is a no-op by default.

Manual API testing confirmed the motivation: with a project API key, the Console API returns `403 Forbidden` for `GET /projects/{id}` and `PATCH /projects/{id}`, and `200` for `GET /projects` (metadata only). This is why the change is a guardrail on the workspace key rather than a project-key configuration path.

## Screenshots/Output

```
=== RUN   TestAccProject_allowedProjectIDsBlocksDisallowed
--- PASS: TestAccProject_allowedProjectIDsBlocksDisallowed (0.63s)
=== RUN   TestAccProject_allowedProjectIDsAllowsListed
--- PASS: TestAccProject_allowedProjectIDsAllowsListed (2.72s)
PASS
ok  	github.com/ory/terraform-provider-ory/internal/datasources/project

Error: Error Reading Project
  with data.ory_project.test,
  on terraform_plugin_test.tf line 13, in data "ory_project" "test":
  13: data "ory_project" "test" {}
project not allowed by allowed_project_ids: project "<redacted>" is not in the
allowed_project_ids allowlist [00000000-0000-0000-0000-000000000000]. This
guardrail prevents accidental changes to projects outside the allowlist, such as
production. Add the project ID to allowed_project_ids, or remove the allowlist to
disable this check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `allowed_project_ids` setting to limit provider actions to specific projects.
  * Supports configuration via Terraform or the `ORY_ALLOWED_PROJECT_IDS` environment variable.

* **Bug Fixes**
  * Provider operations now stop early when a target project is not on the allowlist, reducing the chance of changes in the wrong project.
  * Documentation now clarifies which API keys are accepted for project and console actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->