### PR TITLE
feat(social_provider): support update_identity_on_login and fix mapper_url drift

### DIFF
--- a/docs/resources/social_provider.md
+++ b/docs/resources/social_provider.md
@@ -147,6 +147,19 @@ resource "ory_social_provider" "google_fedcm" {
   fedcm_config_url = "https://accounts.google.com/gsi/fedcm.json"
 }
 
+# Google Sign-In that refreshes identity traits from OIDC claims on every login
+resource "ory_social_provider" "google_sync_on_login" {
+  provider_id   = "google-sync"
+  provider_type = "google"
+  client_id     = var.google_client_id
+  client_secret = var.google_client_secret
+  scope         = ["email", "profile"]
+
+  # "automatic" re-runs the claims mapper on each login and updates the identity.
+  # Omit or set "never" (the default) to keep the identity unchanged after sign-up.
+  update_identity_on_login = "automatic"
+}
+
 # Generic OIDC with a custom base redirect URI (e.g., when using a custom domain)
 resource "ory_social_provider" "corporate_sso_custom_domain" {
   provider_id       = "corporate-sso-custom-domain"
@@ -314,7 +327,7 @@ The `mapper_url` attribute controls how OIDC claims are mapped to Ory identity t
 
 If not set, the provider uses a default mapper that extracts the email claim.
 
-~> **Note:** The `mapper_url` value may be transformed by the API (e.g., stored as a GCS URL). The provider only tracks this field if you explicitly set it in your configuration to avoid false drift detection.
+~> **Note:** Ory rewrites the `mapper_url` you configure into an opaque, content-addressed URL (for example `https://storage.googleapis.com/.../<hash>.jsonnet`). The provider preserves the value exactly as you wrote it in your configuration and does **not** read the transformed value back into state, so a configured `mapper_url` no longer produces a perpetual diff. Because the transformed URL cannot be reversed, `mapper_url` is not populated on `terraform import`; add it back to your configuration after importing.
 
 ## Label
 
@@ -430,6 +443,29 @@ resource "ory_social_provider" "google" {
 
 Leave the attribute unset to disable FedCM for the provider. Removing it from your configuration clears the value server-side.
 
+## Update Identity on Login
+
+The `update_identity_on_login` attribute controls whether an identity's traits and metadata are refreshed from the upstream OIDC claims every time the user signs in:
+
+| Value | Description |
+|-------|-------------|
+| `never` (default) | The identity is populated from the claims mapper on first sign-up and left unchanged on subsequent logins. |
+| `automatic` | Ory re-runs the Jsonnet claims mapper on every login and updates the identity's traits and metadata to match the latest upstream claims. |
+
+```hcl
+resource "ory_social_provider" "google" {
+  provider_id   = "google"
+  provider_type = "google"
+  client_id     = var.google_client_id
+  client_secret = var.google_client_secret
+  scope         = ["email", "profile"]
+
+  update_identity_on_login = "automatic"
+}
+```
+
+Leave the attribute unset to use the Ory default (`never`). The API accepts only the values `never` and `automatic`.
+
 ## Base Redirect URI
 
 The `base_redirect_uri` attribute overrides the base URL Ory uses when constructing OIDC callback URLs. Use this when your project is accessible under a custom domain and you want callbacks to go to that domain rather than the default Ory project URL.
@@ -506,6 +542,7 @@ The `provider_id` is the unique identifier you chose when creating the provider.
 - `scope` (List of String) OAuth2 scopes to request.
 - `tenant` (String) Tenant ID (for Microsoft/Azure providers).
 - `token_url` (String) Custom token URL (for non-standard providers).
+- `update_identity_on_login` (String) Controls whether the identity's traits and metadata are refreshed from the upstream OIDC claims on every login. "never" (the API default) keeps the identity as-is after the initial sign-up. "automatic" re-runs the Jsonnet claims mapper on each login and updates the identity accordingly. Leave unset to use the Ory default ("never").
 
 ### Read-Only
 

--- a/examples/resources/ory_social_provider/resource.tf
+++ b/examples/resources/ory_social_provider/resource.tf
@@ -60,6 +60,19 @@ resource "ory_social_provider" "google_fedcm" {
   fedcm_config_url = "https://accounts.google.com/gsi/fedcm.json"
 }
 
+# Google Sign-In that refreshes identity traits from OIDC claims on every login
+resource "ory_social_provider" "google_sync_on_login" {
+  provider_id   = "google-sync"
+  provider_type = "google"
+  client_id     = var.google_client_id
+  client_secret = var.google_client_secret
+  scope         = ["email", "profile"]
+
+  # "automatic" re-runs the claims mapper on each login and updates the identity.
+  # Omit or set "never" (the default) to keep the identity unchanged after sign-up.
+  update_identity_on_login = "automatic"
+}
+
 # Generic OIDC with a custom base redirect URI (e.g., when using a custom domain)
 resource "ory_social_provider" "corporate_sso_custom_domain" {
   provider_id       = "corporate-sso-custom-domain"

--- a/internal/resources/socialprovider/resource.go
+++ b/internal/resources/socialprovider/resource.go
@@ -88,6 +88,7 @@ type SocialProviderResourceModel struct {
 	Aal2AmrValues              types.List   `tfsdk:"aal2_amr_values"`
 	Pkce                       types.String `tfsdk:"pkce"`
 	FedcmConfigURL             types.String `tfsdk:"fedcm_config_url"`
+	UpdateIdentityOnLogin      types.String `tfsdk:"update_identity_on_login"`
 }
 
 func (r *SocialProviderResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -281,6 +282,13 @@ func (r *SocialProviderResource) Schema(ctx context.Context, req resource.Schema
 			"fedcm_config_url": schema.StringAttribute{
 				Description: "URL of the provider's FedCM (Federated Credential Management) configuration file. When set, Ory can use the browser's FedCM API for sign-in with this provider instead of a full-page redirect. For example, Google's FedCM configuration is served at \"https://accounts.google.com/gsi/fedcm.json\". Leave unset to disable FedCM for this provider.",
 				Optional:    true,
+			},
+			"update_identity_on_login": schema.StringAttribute{
+				Description: "Controls whether the identity's traits and metadata are refreshed from the upstream OIDC claims on every login. \"never\" (the API default) keeps the identity as-is after the initial sign-up. \"automatic\" re-runs the Jsonnet claims mapper on each login and updates the identity accordingly. Leave unset to use the Ory default (\"never\").",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("never", "automatic"),
+				},
 			},
 		},
 	}
@@ -511,6 +519,13 @@ func (r *SocialProviderResource) buildProviderConfig(ctx context.Context, plan *
 
 	if !plan.Pkce.IsNull() && !plan.Pkce.IsUnknown() {
 		config["pkce"] = plan.Pkce.ValueString()
+	}
+
+	// update_identity_on_login — only send when set. Omitting it on the
+	// full-object replace performed by Update lets the API fall back to its
+	// default ("never"), which Read collapses to null.
+	if !plan.UpdateIdentityOnLogin.IsNull() && !plan.UpdateIdentityOnLogin.IsUnknown() {
+		config["update_identity_on_login"] = plan.UpdateIdentityOnLogin.ValueString()
 	}
 
 	// fedcm_config_url — only send when set to a non-empty value. Omitting it on
@@ -878,14 +893,16 @@ func (r *SocialProviderResource) Read(ctx context.Context, req resource.ReadRequ
 		}
 	}
 
-	// Read mapper_url only if user explicitly configured it
-	// When user doesn't set mapper_url, we use a default which gets transformed to a GCS URL by the API
-	// We only read it back if it was already in state (user configured it)
-	if !state.MapperURL.IsNull() && !state.MapperURL.IsUnknown() {
-		if mapper, ok := provider["mapper_url"].(string); ok && mapper != "" {
-			state.MapperURL = types.StringValue(mapper)
-		}
-	}
+	// mapper_url is intentionally NOT read back from the API. Ory rewrites the
+	// configured value (a base64://... blob or a hosted URL) into an opaque,
+	// content-addressed GCS URL (https://storage.googleapis.com/.../<hash>.jsonnet).
+	// Reading that transformed value into state makes it differ from the value in
+	// configuration on every plan, producing a perpetual diff that repeatedly
+	// replaces the whole provider object. Instead we preserve the configured value
+	// already held in state (written by Create/Update). A genuine change to
+	// mapper_url in configuration is still applied because Update writes the new
+	// value to state; only the API's cosmetic rewrite is ignored.
+	// See: https://github.com/ory/terraform-provider-ory/issues/278
 
 	// Read auth_url for custom providers
 	if authURL, ok := provider["auth_url"].(string); ok && authURL != "" {
@@ -930,6 +947,15 @@ func (r *SocialProviderResource) Read(ctx context.Context, req resource.ReadRequ
 		state.Pkce = types.StringValue(pkce)
 	} else {
 		state.Pkce = types.StringNull()
+	}
+
+	// Read update_identity_on_login from the API (returned on read), clearing
+	// stale state when the API omits it (which it does only when the attribute
+	// was never set; an explicit "never" round-trips as "never").
+	if uiol, ok := provider["update_identity_on_login"].(string); ok && uiol != "" {
+		state.UpdateIdentityOnLogin = types.StringValue(uiol)
+	} else {
+		state.UpdateIdentityOnLogin = types.StringNull()
 	}
 
 	// Read fedcm_config_url from the API (returned on read), clearing stale state

--- a/internal/resources/socialprovider/resource_test.go
+++ b/internal/resources/socialprovider/resource_test.go
@@ -616,6 +616,120 @@ func TestAccSocialProviderResource_aal2Values(t *testing.T) {
 	})
 }
 
+// TestAccSocialProviderResource_updateIdentityOnLogin exercises the
+// update_identity_on_login attribute across create ("automatic"), update to the
+// explicit default ("never"), removal, and import. The Ory API accepts only the
+// enum values "never" and "automatic"; when the attribute is omitted the API
+// omits it on read, which the provider collapses to null.
+// Regression test for https://github.com/ory/terraform-provider-ory/issues/278.
+func TestAccSocialProviderResource_updateIdentityOnLogin(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.AccPreCheck(t)
+			acctest.RequireSocialProviderTests(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create with update_identity_on_login = "automatic"
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_update_identity_on_login.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_social_provider.test", "id"),
+					resource.TestCheckResourceAttr("ory_social_provider.test", "provider_id", "test-google-uiol"),
+					resource.TestCheckResourceAttr("ory_social_provider.test", "update_identity_on_login", "automatic"),
+				),
+			},
+			// Verify no perpetual diff
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/with_update_identity_on_login.tf.tmpl", nil),
+				PlanOnly: true,
+			},
+			// Update to "never" — the explicit default; catches drift if the API
+			// normalizes "never" to absence.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_update_identity_on_login_never.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_social_provider.test", "update_identity_on_login", "never"),
+				),
+			},
+			// Verify no perpetual diff on "never"
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/with_update_identity_on_login_never.tf.tmpl", nil),
+				PlanOnly: true,
+			},
+			// Remove update_identity_on_login from config — should clear it server-side
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_update_identity_on_login_removed.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("ory_social_provider.test", "update_identity_on_login"),
+				),
+			},
+			// Verify no diff after removal
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/with_update_identity_on_login_removed.tf.tmpl", nil),
+				PlanOnly: true,
+			},
+			// ImportState
+			{
+				ResourceName:            "ory_social_provider.test",
+				ImportState:             true,
+				ImportStateId:           "test-google-uiol",
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"client_secret"},
+			},
+		},
+	})
+}
+
+// TestAccSocialProviderResource_mapperURLNoDrift verifies that a configured
+// base64:// mapper_url does not produce a perpetual diff even though Ory rewrites
+// it into an opaque GCS URL server-side. The provider preserves the configured
+// value in state instead of reading back the transformed value.
+// Regression test for https://github.com/ory/terraform-provider-ory/issues/278.
+func TestAccSocialProviderResource_mapperURLNoDrift(t *testing.T) {
+	const mapperURL = "base64://bG9jYWwgY2xhaW1zID0gc3RkLmV4dFZhcignY2xhaW1zJyk7CnsKICBpZGVudGl0eTogewogICAgdHJhaXRzOiB7CiAgICAgIGVtYWlsOiBjbGFpbXMuZW1haWwsCiAgICB9LAogIH0sCn0="
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.AccPreCheck(t)
+			acctest.RequireSocialProviderTests(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create with a base64 mapper_url
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_mapper_url.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_social_provider.test", "id"),
+					resource.TestCheckResourceAttr("ory_social_provider.test", "provider_id", "test-google-mapper"),
+					// State must hold the configured value, not the API's GCS rewrite.
+					resource.TestCheckResourceAttr("ory_social_provider.test", "mapper_url", mapperURL),
+				),
+			},
+			// The critical assertion: re-planning the same config must show no diff,
+			// even though the API stores a transformed mapper_url.
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/with_mapper_url.tf.tmpl", nil),
+				PlanOnly: true,
+			},
+			// A second refresh-and-plan cycle confirms the value stays stable.
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/with_mapper_url.tf.tmpl", nil),
+				PlanOnly: true,
+			},
+			// ImportState — mapper_url is not read back from the API (it cannot be
+			// reversed from the GCS URL), so it is not populated on import.
+			{
+				ResourceName:            "ory_social_provider.test",
+				ImportState:             true,
+				ImportStateId:           "test-google-mapper",
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"client_secret", "mapper_url"},
+			},
+		},
+	})
+}
+
 func TestAccSocialProviderResource_apple(t *testing.T) {
 	tmplData := struct{ PrivateKey string }{PrivateKey: generateTestPrivateKey(t)}
 

--- a/internal/resources/socialprovider/testdata/with_mapper_url.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/with_mapper_url.tf.tmpl
@@ -1,0 +1,12 @@
+resource "ory_social_provider" "test" {
+  provider_id   = "test-google-mapper"
+  provider_type = "google"
+  client_id     = "test-client-id.apps.googleusercontent.com"
+  client_secret = "test-client-secret"
+  scope         = ["email", "profile"]
+
+  # A base64-encoded Jsonnet mapper. Ory rewrites this into an opaque GCS URL
+  # server-side; the provider must preserve the configured value so this does
+  # not produce a perpetual diff. Regression test for issue #278.
+  mapper_url = "base64://bG9jYWwgY2xhaW1zID0gc3RkLmV4dFZhcignY2xhaW1zJyk7CnsKICBpZGVudGl0eTogewogICAgdHJhaXRzOiB7CiAgICAgIGVtYWlsOiBjbGFpbXMuZW1haWwsCiAgICB9LAogIH0sCn0="
+}

--- a/internal/resources/socialprovider/testdata/with_update_identity_on_login.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/with_update_identity_on_login.tf.tmpl
@@ -1,0 +1,8 @@
+resource "ory_social_provider" "test" {
+  provider_id              = "test-google-uiol"
+  provider_type            = "google"
+  client_id                = "test-client-id.apps.googleusercontent.com"
+  client_secret            = "test-client-secret"
+  scope                    = ["email", "profile"]
+  update_identity_on_login = "automatic"
+}

--- a/internal/resources/socialprovider/testdata/with_update_identity_on_login_never.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/with_update_identity_on_login_never.tf.tmpl
@@ -1,0 +1,8 @@
+resource "ory_social_provider" "test" {
+  provider_id              = "test-google-uiol"
+  provider_type            = "google"
+  client_id                = "test-client-id.apps.googleusercontent.com"
+  client_secret            = "test-client-secret"
+  scope                    = ["email", "profile"]
+  update_identity_on_login = "never"
+}

--- a/internal/resources/socialprovider/testdata/with_update_identity_on_login_removed.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/with_update_identity_on_login_removed.tf.tmpl
@@ -1,0 +1,8 @@
+resource "ory_social_provider" "test" {
+  provider_id   = "test-google-uiol"
+  provider_type = "google"
+  client_id     = "test-client-id.apps.googleusercontent.com"
+  client_secret = "test-client-secret"
+  scope         = ["email", "profile"]
+  # update_identity_on_login intentionally omitted to test removal
+}

--- a/internal/resources/socialprovider/validate_config_test.go
+++ b/internal/resources/socialprovider/validate_config_test.go
@@ -52,6 +52,7 @@ func buildTestConfig(t *testing.T, model SocialProviderResourceModel) resource.V
 		"aal2_amr_values":               tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
 		"pkce":                          tfStringValue(model.Pkce),
 		"fedcm_config_url":              tfStringValue(model.FedcmConfigURL),
+		"update_identity_on_login":      tfStringValue(model.UpdateIdentityOnLogin),
 	}
 
 	objType := tftypes.Object{
@@ -86,6 +87,7 @@ func buildTestConfig(t *testing.T, model SocialProviderResourceModel) resource.V
 			"aal2_amr_values":               tftypes.List{ElementType: tftypes.String},
 			"pkce":                          tftypes.String,
 			"fedcm_config_url":              tftypes.String,
+			"update_identity_on_login":      tftypes.String,
 		},
 	}
 

--- a/templates/resources/social_provider.md.tmpl
+++ b/templates/resources/social_provider.md.tmpl
@@ -95,7 +95,7 @@ The `mapper_url` attribute controls how OIDC claims are mapped to Ory identity t
 
 If not set, the provider uses a default mapper that extracts the email claim.
 
-~> **Note:** The `mapper_url` value may be transformed by the API (e.g., stored as a GCS URL). The provider only tracks this field if you explicitly set it in your configuration to avoid false drift detection.
+~> **Note:** Ory rewrites the `mapper_url` you configure into an opaque, content-addressed URL (for example `https://storage.googleapis.com/.../<hash>.jsonnet`). The provider preserves the value exactly as you wrote it in your configuration and does **not** read the transformed value back into state, so a configured `mapper_url` no longer produces a perpetual diff. Because the transformed URL cannot be reversed, `mapper_url` is not populated on `terraform import`; add it back to your configuration after importing.
 
 ## Label
 
@@ -210,6 +210,29 @@ resource "ory_social_provider" "google" {
 ```
 
 Leave the attribute unset to disable FedCM for the provider. Removing it from your configuration clears the value server-side.
+
+## Update Identity on Login
+
+The `update_identity_on_login` attribute controls whether an identity's traits and metadata are refreshed from the upstream OIDC claims every time the user signs in:
+
+| Value | Description |
+|-------|-------------|
+| `never` (default) | The identity is populated from the claims mapper on first sign-up and left unchanged on subsequent logins. |
+| `automatic` | Ory re-runs the Jsonnet claims mapper on every login and updates the identity's traits and metadata to match the latest upstream claims. |
+
+```hcl
+resource "ory_social_provider" "google" {
+  provider_id   = "google"
+  provider_type = "google"
+  client_id     = var.google_client_id
+  client_secret = var.google_client_secret
+  scope         = ["email", "profile"]
+
+  update_identity_on_login = "automatic"
+}
+```
+
+Leave the attribute unset to use the Ory default (`never`). The API accepts only the values `never` and `automatic`.
 
 ## Base Redirect URI
 


### PR DESCRIPTION
## Description

Adds an `update_identity_on_login` attribute to the `ory_social_provider` resource and fixes the `mapper_url` drift that made the value hard to keep set.

`update_identity_on_login` controls whether an identity's traits and metadata are refreshed from the upstream OIDC claims on every login. The Ory API accepts only the enum values `never` (the default) and `automatic`. The attribute is validated with `OneOf("never", "automatic")`, sent on create/update, and read back so external drift is detected. Previously this could only be set by hand (for example `ory patch project --replace '/.../update_identity_on_login=true'`) and had to be re-applied after every change to the provider.

The reason it had to be re-applied so often was `mapper_url` drift. Ory rewrites a configured `base64://...` mapper (or hosted URL) into an opaque, content-addressed GCS URL (`https://storage.googleapis.com/.../<hash>.jsonnet`). The resource used to read that transformed value back into state, so it always differed from the value in configuration and produced a perpetual diff that replaced the entire provider object on every apply. That full-object replace is what silently discarded the manually-set `update_identity_on_login` value. The resource now preserves the configured `mapper_url` in state instead of reading back the rewritten value; genuine changes in configuration are still applied.

## Related Issues

Fixes #278

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

Verified the API contract directly first: the field accepts only the strings `never`/`automatic` (a boolean `true` is rejected with `value must be one of "never", "automatic"`), the API omits the field on read when it was never set, and it round-trips an explicit value. Also confirmed the API rewrites `base64://` mapper URLs into GCS URLs deterministically.

Added and ran acceptance tests against a live project:

- `TestAccSocialProviderResource_updateIdentityOnLogin` — create (`automatic`), update to `never`, remove, import, with no-diff checks at each step.
- `TestAccSocialProviderResource_mapperURLNoDrift` — regression test asserting a configured `base64://` `mapper_url` produces no perpetual diff.

```
--- PASS: TestAccSocialProviderResource_updateIdentityOnLogin (12.70s)
--- PASS: TestAccSocialProviderResource_mapperURLNoDrift (6.70s)
```

The full `ory_social_provider` acceptance suite, unit tests (`make test-short`), and security scans (`make sec`: gosec 0 issues, gitleaks no leaks) also pass.

## Screenshots/Output

N/A