### PR TITLE
fix(project_config): treat HTTP courier auth secrets as write-only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -402,11 +402,12 @@ These require hand-written code in `resource.go` because they have non-trivial s
 - `default_return_url` / `allowed_return_urls` (remove-on-empty semantics)
 - `mfa_enforcement` (maps string values to different API fields)
 
-> **Note:** `smtp_connection_uri` is fully codegen'd, but uses `write_only: true`
-> (see the mappings table above). The Ory API never returns the connection URI in
-> project-config responses, so the provider sends it on create/update but never
-> reads it back — this keeps it from showing a perpetual diff if the API returns an
-> empty value or a masked sentinel.
+> **Note:** `smtp_connection_uri`, `courier_http_request_config_auth_basic_auth_password`,
+> and `courier_http_request_config_auth_api_key_value` are fully codegen'd, but use
+> `write_only: true` (see the mappings table above). The Ory API does not return these
+> secrets in project-config responses, so the provider sends them on create/update but
+> never reads them back — this keeps them from showing a perpetual diff if the API
+> returns an empty value or a masked sentinel.
 
 ### Adding a New Resource
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,7 +38,7 @@ masked as sensitive. Because the provider does not refresh these from the API, i
 tolerates the API omitting the value or returning a masked sentinel (such as
 `****`) without producing a spurious diff:
 
-- `smtp_connection_uri` in `ory_project_config`
+- `smtp_connection_uri`, `courier_http_request_config_auth_basic_auth_password`, and `courier_http_request_config_auth_api_key_value` in `ory_project_config`
 - `client_secret` and `apple_private_key` in `ory_social_provider`
 - `password` in `ory_identity`
 - `client_secret` in `ory_oauth2_client` (server-generated; returned only on create, never on subsequent reads)

--- a/internal/codegen/mappings.yaml
+++ b/internal/codegen/mappings.yaml
@@ -725,6 +725,11 @@ attributes:
     openapi_property: kratos_courier_http_request_config_auth_api_key_value
     description: "API key value for HTTP courier authentication."
     sensitive: true
+    # The API does not return this secret — it is stripped/masked server-side.
+    # Reading it back would clobber the configured value with an empty string or a
+    # sentinel (e.g. "****") and cause a perpetual diff, so it is write-only:
+    # sent on create/update, never read into state.
+    write_only: true
 
   - name: courier_http_request_config_auth_basic_auth_password
     go_field: CourierHTTPRequestConfigAuthBasicAuthPassword
@@ -732,6 +737,11 @@ attributes:
     openapi_property: kratos_courier_http_request_config_auth_basic_auth_password
     description: "Password for HTTP courier basic authentication."
     sensitive: true
+    # The API does not return this secret — it is stripped/masked server-side.
+    # Reading it back would clobber the configured value with an empty string or a
+    # sentinel (e.g. "****") and cause a perpetual diff, so it is write-only:
+    # sent on create/update, never read into state.
+    write_only: true
 
   - name: courier_http_request_config_auth_basic_auth_user
     go_field: CourierHTTPRequestConfigAuthBasicAuthUser

--- a/internal/resources/projectconfig/generated_test.go
+++ b/internal/resources/projectconfig/generated_test.go
@@ -286,6 +286,63 @@ func TestSMTPConnectionURI_WriteOnly(t *testing.T) {
 	}
 }
 
+// TestCourierHTTPRequestConfigAuth_WriteOnly verifies the flat HTTP courier auth
+// secrets (basic-auth password and API-key value) are treated as write-only: they
+// are sent on create/update (they remain in the schema and patch tables) but are
+// never read back from the API. A value the API returns — empty or a masked
+// sentinel such as "****" — must never overwrite the configured value, otherwise
+// every plan would show a perpetual diff between the real secret in HCL and the
+// masked value in state.
+//
+// This is the provider-side guard for the Ory API stripping HTTP courier
+// credentials from project-config responses.
+func TestCourierHTTPRequestConfigAuth_WriteOnly(t *testing.T) {
+	const (
+		configuredPassword = "basic-auth-secret" //nolint:gosec // G101 false positive: test fixture, not a real credential
+		configuredAPIKey   = "api-key-secret"    //nolint:gosec // G101 false positive: test fixture, not a real credential
+	)
+
+	// 1. Both must be excluded from the generated read entries entirely.
+	state := &ProjectConfigResourceModel{
+		CourierHTTPRequestConfigAuthBasicAuthPassword: types.StringValue(configuredPassword),
+		CourierHTTPRequestConfigAuthAPIKeyValue:       types.StringValue(configuredAPIKey),
+	}
+	for _, e := range identityStringReadEntries(state) {
+		assert.NotSame(t, &state.CourierHTTPRequestConfigAuthBasicAuthPassword, e.Field,
+			"courier_http_request_config_auth_basic_auth_password must not appear in read entries — it is write-only")
+		assert.NotSame(t, &state.CourierHTTPRequestConfigAuthAPIKeyValue, e.Field,
+			"courier_http_request_config_auth_api_key_value must not appear in read entries — it is write-only")
+	}
+
+	// 2. readSimpleFields must preserve the configured values regardless of what
+	//    the API returns for the auth config secrets (absent, empty, or masked).
+	for _, apiValue := range []string{"", "****"} {
+		st := &ProjectConfigResourceModel{
+			CourierHTTPRequestConfigAuthBasicAuthPassword: types.StringValue(configuredPassword),
+			CourierHTTPRequestConfigAuthAPIKeyValue:       types.StringValue(configuredAPIKey),
+		}
+		project := projectWithIdentityConfig(map[string]interface{}{
+			"courier": map[string]interface{}{
+				"http": map[string]interface{}{
+					"request_config": map[string]interface{}{
+						"auth": map[string]interface{}{
+							"config": map[string]interface{}{
+								"password": apiValue,
+								"value":    apiValue,
+							},
+						},
+					},
+				},
+			},
+		})
+		readSimpleFields(context.Background(), project, st)
+		assert.Equal(t, configuredPassword, st.CourierHTTPRequestConfigAuthBasicAuthPassword.ValueString(),
+			"configured courier basic-auth password must be preserved when the API returns %q", apiValue)
+		assert.Equal(t, configuredAPIKey, st.CourierHTTPRequestConfigAuthAPIKeyValue.ValueString(),
+			"configured courier api-key value must be preserved when the API returns %q", apiValue)
+	}
+}
+
 // TestGeneratedSchemaAttributes_Count verifies generation produced a non-trivial
 // number of attributes. The AllOptional and ValidAndUnique tests verify correctness;
 // this test catches catastrophic generation failures (e.g., empty output).

--- a/internal/resources/projectconfig/read_gen.go
+++ b/internal/resources/projectconfig/read_gen.go
@@ -408,8 +408,6 @@ func identityStringReadEntries(state *ProjectConfigResourceModel) []StringReadEn
 		{&state.CookiesSameSite, nil, []string{"cookies", "same_site"}, false},
 		{&state.CourierHTTPRequestConfigAuthAPIKeyIn, nil, []string{"courier", "http", "request_config", "auth", "config", "in"}, false},
 		{&state.CourierHTTPRequestConfigAuthAPIKeyName, nil, []string{"courier", "http", "request_config", "auth", "config", "name"}, false},
-		{&state.CourierHTTPRequestConfigAuthAPIKeyValue, nil, []string{"courier", "http", "request_config", "auth", "config", "value"}, false},
-		{&state.CourierHTTPRequestConfigAuthBasicAuthPassword, nil, []string{"courier", "http", "request_config", "auth", "config", "password"}, false},
 		{&state.CourierHTTPRequestConfigAuthBasicAuthUser, nil, []string{"courier", "http", "request_config", "auth", "config", "user"}, false},
 		{&state.CourierHTTPRequestConfigBody, nil, []string{"courier", "http", "request_config", "body"}, false},
 		{&state.CourierHTTPRequestConfigURL, nil, []string{"courier", "http", "request_config", "url"}, false},


### PR DESCRIPTION
## Description

The Ory API does not return the HTTP courier authentication secrets in project-config responses (they are stripped/masked server-side, the same as the SMTP connection URI). The generated read path read them back into state, so an empty or masked value returned by the API overwrites the configured secret and produces a perpetual diff on every plan.

This treats the two flat, code-generated HTTP courier auth secrets as write-only (the same mechanism already used for `smtp_connection_uri`):

- `courier_http_request_config_auth_basic_auth_password`
- `courier_http_request_config_auth_api_key_value`

`write_only: true` in `internal/codegen/mappings.yaml` makes the generator omit them from the read path (`read_gen.go`) — they are still sent on create/update and remain in the schema, but are never read back into state. The value configured in Terraform stays the source of truth (still stored in state, masked as sensitive).

Only the flat attributes were affected. The nested `courier_http_request_config` object, `courier_channels`, and the OAuth2 token-hook auth already read their secrets from state, so they were never at risk.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [ ] Manual testing

- Added `TestCourierHTTPRequestConfigAuth_WriteOnly`, asserting the two secrets are excluded from the generated read entries and that `readSimpleFields` preserves the configured values when the API returns an empty string or a masked sentinel (`****`).
- Regenerated code with `make generate`; the only generated change is the removal of the two entries from `read_gen.go` (schema and patch tables are unchanged, so the fields are still sent on create/update).
- Ran the existing `TestAccProjectConfigResource_courierHTTP` acceptance test against staging — passes, confirming no regression in the courier read/patch path.
- `make build`, `make format` (lint: 0 issues), `make test-short`, and `make sec` (govulncheck, gosec: 0 issues, gitleaks: no leaks) all pass.

## Screenshots/Output

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of secret connection settings so values are sent when saving changes but not re-read afterward, reducing unnecessary diffs.
  * Preserved configured secret values even when the API returns masked or empty responses.
* **Documentation**
  * Updated contributor and security notes to clarify which secret fields are treated as write-only and why they are not read back.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->