### PR TITLE
fix(project): change environment in place instead of forcing replacement

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -91,6 +91,8 @@ The `environment` attribute determines which features are available:
 ~> **Important:** If you plan to use `ory_organization` resources, you must use `prod` or `stage` environment.
 The `dev` environment does not support B2B features.
 
+-> **Changing the environment:** Unlike `home_region`, `environment` can be changed in place. Updating the value moves the project to the new tier **without destroying the project or its child resources** (OAuth2 clients, identity schemas, actions, social providers, custom domains, email templates, and so on). The change is validated server-side and fails, leaving the project untouched, if the project is not in a workspace, the workspace subscription does not permit the target tier (for example, moving to `prod` consumes a production-project slot), or the current configuration enables options unavailable in the target environment (for example, `dev`-only settings must be disabled before moving to `stage` or `prod`).
+
 ## Home Regions
 
 The `home_region` attribute determines where project data is stored:
@@ -103,6 +105,8 @@ The `home_region` attribute determines where project data is stored:
 | `us` | US |
 | `asia-northeast` | Asia Northeast |
 | `global` | Global |
+
+~> **Immutable:** Unlike `environment`, `home_region` cannot be changed after the project is created. Changing it forces the project to be destroyed and recreated.
 
 ## Plan Limits
 
@@ -137,7 +141,7 @@ output "project_state" {
 
 ### Optional
 
-- `environment` (String) The environment type. Must be one of: `prod` (production), `stage` (staging), or `dev` (development). Defaults to `prod`. **Cannot be changed after creation** - changing this will force a new resource. Note: `dev` environment does not support B2B Organizations.
+- `environment` (String) The environment type. Must be one of: `prod` (production), `stage` (staging), or `dev` (development). Defaults to `prod`. **Can be changed in place** — updating this value changes the project's tier without destroying the project, provided the project belongs to a workspace, the workspace subscription permits the target tier, and the project configuration has no options that are unavailable in the target environment. Note: `dev` environment does not support B2B Organizations.
 - `home_region` (String) The home region where the project data is stored. Must be one of: `eu-central` (Europe), `us-east`, `us-west`, `us`, `asia-northeast`, or `global`. Defaults to `eu-central`. **Cannot be changed after creation** - changing this will force a new resource.
 
 ### Read-Only

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -789,6 +789,80 @@ func (c *OryClient) GetCachedProject(projectID string) *ory.Project {
 	return nil
 }
 
+// SetProjectEnvironment changes a project's environment tier (dev, stage, prod)
+// in place via the Console API's PUT /projects/{id}/environment endpoint — the
+// same call the Ory Console makes.
+//
+// PatchProject cannot do this: it patches the project *configuration* and
+// silently ignores the top-level environment field (it returns 200 without
+// changing anything). This dedicated endpoint updates the environment directly.
+// The change is validated server-side: the project must belong to a workspace,
+// the workspace subscription must permit the target tier, and any
+// environment-specific configuration options must be compatible with the target
+// environment. A workspace API key is an accepted caller.
+//
+// The endpoint is not part of the generated client-go SDK, so the request is
+// issued directly against the console API, mirroring ListWorkspaceIdentitySchemas.
+// A successful (HTTP 200) call is the success signal; callers read the resulting
+// state via GetProject, which reflects the new environment immediately.
+func (c *OryClient) SetProjectEnvironment(ctx context.Context, projectID, environment string) error {
+	if c.consoleClient == nil {
+		return fmt.Errorf("setting project environment: %w. "+
+			"Set workspace_api_key (ORY_WORKSPACE_API_KEY)", ErrConsoleClientNotConfigured)
+	}
+	if err := c.checkProjectAllowed(projectID); err != nil {
+		return err
+	}
+
+	endpoint := strings.TrimRight(c.config.ConsoleAPIURL, "/") + "/projects/" + url.PathEscape(projectID) + "/environment"
+	payload, err := json.Marshal(map[string]string{"environment": environment})
+	if err != nil {
+		return fmt.Errorf("encoding set-environment request: %w", err)
+	}
+
+	resp, err := retryWithBackoff(ctx, "setting project environment", func() (*http.Response, error) {
+		// Build the request inside the retry closure so each attempt gets a
+		// fresh, unconsumed request body.
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, bytes.NewReader(payload))
+		if reqErr != nil {
+			return nil, reqErr
+		}
+		req.Header.Set("Authorization", "Bearer "+c.config.WorkspaceAPIKey)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+		if c.config.UserAgent != "" {
+			req.Header.Set("User-Agent", c.config.UserAgent)
+		}
+		r, doErr := consoleHTTPClient.Do(req)
+		if doErr != nil {
+			return nil, doErr
+		}
+		if r.StatusCode == http.StatusTooManyRequests {
+			body, _ := io.ReadAll(r.Body)
+			_ = r.Body.Close()
+			return nil, fmt.Errorf("429 Too Many Requests: %s", strings.TrimSpace(string(body)))
+		}
+		return r, nil
+	})
+	if err != nil {
+		return wrapAPIError(err, "setting project environment")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading set-environment response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return wrapAPIError(fmt.Errorf("unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(body))),
+			"setting project environment")
+	}
+	// The endpoint returns the updated project, but its serialization omits
+	// fields the SDK's Project model requires, so the body is intentionally not
+	// parsed — the 200 status is authoritative.
+	return nil
+}
+
 // =============================================================================
 // Workspace Operations (Console API)
 // =============================================================================

--- a/internal/resources/project/resource.go
+++ b/internal/resources/project/resource.go
@@ -85,7 +85,32 @@ The ` + "`dev`" + ` environment does not support B2B features.
 | ` + "`asia-northeast`" + ` | Asia Pacific (Tokyo) |
 | ` + "`global`" + ` | Global (multi-region) |
 
-**Note:** Home region cannot be changed after project creation.
+**Note:** Home region cannot be changed after project creation. Changing
+` + "`home_region`" + ` forces the project to be destroyed and recreated.
+
+## Changing the Environment
+
+Unlike ` + "`home_region`" + `, ` + "`environment`" + ` **can be changed in place**. Updating the
+value changes the project's tier without destroying the project or any of the
+resources that depend on it (OAuth2 clients, identity schemas, actions, social
+providers, custom domains, email templates, and so on):
+
+` + "```hcl" + `
+resource "ory_project" "main" {
+  name        = "My Application"
+  environment = "stage" # change to "prod" and apply — the project is updated, not replaced
+}
+` + "```" + `
+
+The change is validated server-side and fails (without modifying the project)
+if any of the following are not met:
+
+- The project belongs to a workspace.
+- The workspace subscription permits the target tier (for example, moving to
+  ` + "`prod`" + ` consumes a production-project slot in the subscription).
+- The project configuration does not enable options that are unavailable in the
+  target environment (for example, ` + "`dev`" + `-only settings must be disabled before
+  moving to ` + "`stage`" + ` or ` + "`prod`" + `).
 
 ## Import
 
@@ -127,14 +152,11 @@ func (r *ProjectResource) Schema(ctx context.Context, req resource.SchemaRequest
 				Required:            true,
 			},
 			"environment": schema.StringAttribute{
-				Description:         "The environment type: prod, stage, or dev. Defaults to prod. Cannot be changed after creation.",
-				MarkdownDescription: "The environment type. Must be one of: `prod` (production), `stage` (staging), or `dev` (development). Defaults to `prod`. **Cannot be changed after creation** - changing this will force a new resource. Note: `dev` environment does not support B2B Organizations.",
+				Description:         "The environment type: prod, stage, or dev. Defaults to prod. Can be changed in place after creation.",
+				MarkdownDescription: "The environment type. Must be one of: `prod` (production), `stage` (staging), or `dev` (development). Defaults to `prod`. **Can be changed in place** — updating this value changes the project's tier without destroying the project, provided the project belongs to a workspace, the workspace subscription permits the target tier, and the project configuration has no options that are unavailable in the target environment. Note: `dev` environment does not support B2B Organizations.",
 				Optional:            true,
 				Computed:            true,
 				Default:             stringdefault.StaticString("prod"),
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"home_region": schema.StringAttribute{
 				Description:         "The home region of the project. Defaults to eu-central. Cannot be changed after creation.",
@@ -266,6 +288,23 @@ func (r *ProjectResource) Update(ctx context.Context, req resource.UpdateRequest
 		}
 	}
 
+	// Update the environment tier if changed. This is a dedicated in-place
+	// operation: PatchProject silently ignores the top-level environment field,
+	// so the provider calls the Console's PUT /projects/{id}/environment endpoint
+	// instead. The API rejects the change (without modifying the project) if the
+	// project is not in a workspace, the subscription does not permit the target
+	// tier, or the current configuration is incompatible with it.
+	if !plan.Environment.Equal(state.Environment) {
+		if err := r.client.SetProjectEnvironment(ctx, state.ID.ValueString(), plan.Environment.ValueString()); err != nil {
+			resp.Diagnostics.AddError(
+				"Error Updating Project Environment",
+				"Could not change project environment from "+state.Environment.ValueString()+
+					" to "+plan.Environment.ValueString()+": "+err.Error(),
+			)
+			return
+		}
+	}
+
 	// Read back the current state
 	project, err := r.client.GetProject(ctx, state.ID.ValueString())
 	if err != nil {
@@ -276,6 +315,10 @@ func (r *ProjectResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
+	// environment and home_region carry their planned values: environment was
+	// confirmed by the successful SetProjectEnvironment call above (a possibly
+	// eventually-consistent GetProject could momentarily report the old tier),
+	// and home_region is immutable. Name/slug/state come from the API read-back.
 	plan.ID = state.ID
 	plan.Name = types.StringValue(project.GetName())
 	plan.Slug = types.StringValue(project.GetSlug())

--- a/internal/resources/project/resource_test.go
+++ b/internal/resources/project/resource_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/ory/terraform-provider-ory/internal/acctest"
 )
@@ -117,6 +118,70 @@ func TestAccProjectResource_regions(t *testing.T) {
 				},
 			})
 		})
+	}
+}
+
+// TestAccProjectResource_environmentInPlaceUpdate verifies that changing the
+// environment tier on an existing project updates it in place — the project
+// keeps its ID (and therefore all of its child resources) — instead of
+// destroying and recreating it. Regression test for issue #289, where a
+// one-line environment change forced a full project replacement.
+func TestAccProjectResource_environmentInPlaceUpdate(t *testing.T) {
+	projectName := testProjectName("env-inplace")
+	var projectID string
+
+	config := func(env string) string {
+		return acctest.LoadTestConfig(t, "testdata/basic.tf.tmpl", map[string]string{"Name": projectName, "Environment": env})
+	}
+
+	acctest.RunTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create a stage project and remember its ID.
+			{
+				Config: config("stage"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project.test", "environment", "stage"),
+					captureAttr("ory_project.test", "id", &projectID),
+				),
+			},
+			// Upgrade stage -> prod in place: environment changes, ID does not.
+			{
+				Config: config("prod"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project.test", "environment", "prod"),
+					resource.TestCheckResourceAttrPtr("ory_project.test", "id", &projectID),
+				),
+			},
+			// Downgrade prod -> dev in place: still the same project.
+			{
+				Config: config("dev"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project.test", "environment", "dev"),
+					resource.TestCheckResourceAttrPtr("ory_project.test", "id", &projectID),
+				),
+			},
+			// Import round-trips cleanly after the in-place changes.
+			{
+				ResourceName:      "ory_project.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// captureAttr stores the value of a resource attribute so it can be compared
+// across later test steps (e.g. to assert an ID did not change).
+func captureAttr(resourceName, attr string, dest *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+		*dest = rs.Primary.Attributes[attr]
+		return nil
 	}
 }
 

--- a/templates/resources/project.md.tmpl
+++ b/templates/resources/project.md.tmpl
@@ -33,6 +33,8 @@ The `environment` attribute determines which features are available:
 ~> **Important:** If you plan to use `ory_organization` resources, you must use `prod` or `stage` environment.
 The `dev` environment does not support B2B features.
 
+-> **Changing the environment:** Unlike `home_region`, `environment` can be changed in place. Updating the value moves the project to the new tier **without destroying the project or its child resources** (OAuth2 clients, identity schemas, actions, social providers, custom domains, email templates, and so on). The change is validated server-side and fails, leaving the project untouched, if the project is not in a workspace, the workspace subscription does not permit the target tier (for example, moving to `prod` consumes a production-project slot), or the current configuration enables options unavailable in the target environment (for example, `dev`-only settings must be disabled before moving to `stage` or `prod`).
+
 ## Home Regions
 
 The `home_region` attribute determines where project data is stored:
@@ -45,6 +47,8 @@ The `home_region` attribute determines where project data is stored:
 | `us` | US |
 | `asia-northeast` | Asia Northeast |
 | `global` | Global |
+
+~> **Immutable:** Unlike `environment`, `home_region` cannot be changed after the project is created. Changing it forces the project to be destroyed and recreated.
 
 ## Plan Limits
 


### PR DESCRIPTION
## Description

Changing the `environment` attribute on an `ory_project` resource previously forced the whole project to be destroyed and recreated. Because the project is the parent of every other resource, that also destroyed all child resources (OAuth2 clients, identity schemas, actions, social providers, custom domains, email templates) and required a full reimport after a one-line configuration change.

The attribute was marked `RequiresReplace` because the generated `client-go` SDK exposes no way to change a project's tier: `PatchProject` patches the project *configuration* and silently ignores the top-level `environment` field (it returns `200` without changing anything). The Ory Console, however, changes the tier in place through the public `PUT /projects/{id}/environment` endpoint, which accepts a workspace API key.

This change makes `environment` updatable in place:

- Adds a `SetProjectEnvironment` client method that calls `PUT /projects/{id}/environment` directly, mirroring the existing raw console API calls in the client.
- Drops `RequiresReplace` from `environment` and applies the change from the resource's `Update`.
- The API validates the change server-side (the project must belong to a workspace, the workspace subscription must permit the target tier, and the current configuration must be compatible with the target environment); any rejection is surfaced as a Terraform error and the project is left untouched.
- `home_region` intentionally remains immutable — there is no equivalent endpoint to relocate project data, so changing it still forces replacement. The documentation now states this contrast explicitly.

## Related Issues

Fixes #289

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

Details:

- `make test-short` — all unit packages pass.
- `make format` — clean (`golangci-lint`: 0 issues); docs regenerated from the template.
- Acceptance tests against a live workspace (`ORY_PROJECT_TESTS_ENABLED=true`):
  - `TestAccProjectResource_environmentInPlaceUpdate` (new) — creates a `stage` project, updates it to `prod` then `dev` in place asserting the project ID is unchanged, and verifies import.
  - `TestAccProjectResource_basic` — unchanged path (name update) still passes.
- Manual `terraform` run against a real project reproducing the issue and confirming the fix (below).

## Screenshots/Output

Before (current behavior) — a `stage` -> `prod` change destroys and recreates the project:

```
  # ory_project.repro must be replaced
-/+ resource "ory_project" "repro" {
      ~ environment = "stage" -> "prod" # forces replacement
      ~ id          = "925df1a2-..." -> (known after apply)
      ...
    }
Plan: 1 to add, 0 to change, 1 to destroy.
```

After (this PR) — the same change is applied in place, keeping the project ID:

```
  # ory_project.repro will be updated in-place
  ~ resource "ory_project" "repro" {
      ~ environment = "dev" -> "prod"
    }
Plan: 0 to add, 1 to change, 0 to destroy.

ory_project.repro: Modifying... [id=48ab676b-...]
ory_project.repro: Modifications complete after 6s [id=48ab676b-...]
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

A follow-up `terraform plan` reports `No changes` (no drift).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project environment changes now apply in place, allowing tier updates without recreating the project.
  * Added clearer guidance for environment updates, including cases where validation may block the change.
* **Bug Fixes**
  * Project updates now preserve the existing project ID when only the environment changes.
  * Improved handling of environment update failures with clearer user-facing errors.
* **Documentation**
  * Clarified that `home_region` remains immutable after creation and still requires recreate to change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->