### PR TITLE
fix(deps): bump Go to 1.26.5 to patch crypto/tls (GO-2026-5856)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ory/terraform-provider-ory
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.19.0


### PR DESCRIPTION
## Description

Bumps the `go` directive in `go.mod` from `1.26.4` to `1.26.5`.

The `Go Vulnerability Check` CI job (`make sec-vuln` / `govulncheck`) fails on
`GO-2026-5856`, an Encrypted Client Hello privacy leak in the `crypto/tls`
standard library. The provider serves plugin traffic over TLS and makes
outbound HTTPS calls, so the vulnerable symbols are reachable and cannot be
avoided at the code level. The flaw is fixed in the Go standard library as of
`go1.26.5`.

All CI jobs install Go via `go-version-file: go.mod`, so bumping the `go`
directive is the single source of truth that updates the toolchain used across
the build, vulnerability scan, and release pipelines. This is a repository-wide
failure (it also affects `main`); it surfaced on the renovate dependency PR
#287, which cannot pass CI until the toolchain is patched.

## Related Issues

No dedicated tracking issue. Resolves the `Go Vulnerability Check` failure
observed on `main` and on #287.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works (N/A - toolchain version bump; the regression is covered by the existing `govulncheck` CI job)
- [x] I have updated documentation as needed (N/A - `CONTRIBUTING.md` already points to `go.mod` for the required Go version)
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [ ] Acceptance tests (N/A - a toolchain version bump does not change any resource/provider behavior; the acceptance suite already passes on #287)
- [x] Manual testing

Local verification with `go1.26.5`:

- `go build ./...` succeeds
- `go test -short ./...` passes
- `make format` and `make lint` report `0 issues`
- `make sec` passes: `govulncheck` reports no vulnerabilities, `gosec` reports `Issues: 0`, `gitleaks` reports `no leaks found`

## Screenshots/Output

Before (`go 1.26.4`):

```
Vulnerability #1: GO-2026-5856
    Invoking Encrypted Client Hello privacy leak in crypto/tls
  Standard library
    Found in: crypto/tls@go1.26.4
    Fixed in: crypto/tls@go1.26.5
...
Your code is affected by 1 vulnerability from the Go standard library.
```

After (`go 1.26.5`):

```
=== Symbol Results ===

No vulnerabilities found.

Your code is affected by 0 vulnerabilities.
```
