### PR TITLE
fix(deps): update module github.com/ory/client-go to v1.22.62

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/ory/client-go v1.22.61
+	github.com/ory/client-go v1.22.62
 	github.com/ory/x v0.0.729
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/nyaruka/phonenumbers v1.5.0 h1:0M+Gd9zl53QC4Nl5z1Yj1O/zPk2XXBUwR/vlzd
 github.com/nyaruka/phonenumbers v1.5.0/go.mod h1:gv+CtldaFz+G3vHHnasBSirAi3O2XLqZzVWz4V1pl2E=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
-github.com/ory/client-go v1.22.61 h1:wiu95f7+Q/fAMAoOsrWj+GnNwM+ZGfHiO+5T17Jwuqg=
-github.com/ory/client-go v1.22.61/go.mod h1:G1f+5+m/PJVvl40bsRn0QuyVIcXe7EHiWeM7iWpIDjw=
+github.com/ory/client-go v1.22.62 h1:T8p6TQ3BKXEQpiBVzvN/vWPF8kcHiXWEaNg0dC9YLko=
+github.com/ory/client-go v1.22.62/go.mod h1:G1f+5+m/PJVvl40bsRn0QuyVIcXe7EHiWeM7iWpIDjw=
 github.com/ory/herodot v0.10.3-0.20250318104651-3179543efba8 h1:bBFBzJ+sy1l/9+uYaz5TLGNNe0GWeXPMyqLhUEy9gPg=
 github.com/ory/herodot v0.10.3-0.20250318104651-3179543efba8/go.mod h1:aq2fDNzFXlh8wF6+ILtlEin2oZSrqR79/Zdsi05WEVA=
 github.com/ory/jsonschema/v3 v3.0.9-0.20250317235931-280c5fc7bf0e h1:4tUrC7x4YWRVMFp+c64KACNSGchW1zXo4l6Pa9/1hA8=

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -166,7 +166,7 @@ func createSharedProject(t *testing.T) {
 	t.Logf("Created test project: %s (slug: %s, environment: %s)", project.GetId(), project.GetSlug(), project.GetEnvironment())
 
 	// Create an API key for the project
-	apiKeyReq := ory.CreateProjectApiKeyRequest{
+	apiKeyReq := ory.CreateProjectApiKeyBody{
 		Name: "tf-acc-test-key",
 	}
 	apiKey, err := c.CreateProjectAPIKey(ctx, project.GetId(), apiKeyReq)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1220,14 +1220,14 @@ func (c *OryClient) DeleteOAuth2Client(ctx context.Context, clientID string) err
 // =============================================================================
 
 // CreateProjectAPIKey creates a new API key for a project.
-func (c *OryClient) CreateProjectAPIKey(ctx context.Context, projectID string, body ory.CreateProjectApiKeyRequest) (*ory.ProjectApiKey, error) {
+func (c *OryClient) CreateProjectAPIKey(ctx context.Context, projectID string, body ory.CreateProjectApiKeyBody) (*ory.ProjectApiKey, error) {
 	if err := c.requireConsoleClient("creating project API key"); err != nil {
 		return nil, err
 	}
 	if err := c.checkProjectAllowed(projectID); err != nil {
 		return nil, err
 	}
-	key, httpResp, err := c.consoleClient.ProjectAPI.CreateProjectApiKey(ctx, projectID).CreateProjectApiKeyRequest(body).Execute()
+	key, httpResp, err := c.consoleClient.ProjectAPI.CreateProjectApiKey(ctx, projectID).CreateProjectApiKeyBody(body).Execute()
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -524,7 +524,7 @@ func TestOryClient_RequireConsoleClient_NilReturnsError(t *testing.T) {
 
 	// Project API key operations
 	t.Run("CreateProjectAPIKey", func(t *testing.T) {
-		_, err := client.CreateProjectAPIKey(ctx, "any-project-id", ory.CreateProjectApiKeyRequest{Name: "test"})
+		_, err := client.CreateProjectAPIKey(ctx, "any-project-id", ory.CreateProjectApiKeyBody{Name: "test"})
 		requireSentinel(t, err)
 	})
 	t.Run("ListProjectAPIKeys", func(t *testing.T) {

--- a/internal/resources/projectapikey/resource.go
+++ b/internal/resources/projectapikey/resource.go
@@ -166,7 +166,7 @@ func (r *ProjectAPIKeyResource) Create(ctx context.Context, req resource.CreateR
 		projectID = r.client.ProjectID()
 	}
 
-	body := ory.CreateProjectApiKeyRequest{
+	body := ory.CreateProjectApiKeyBody{
 		Name: plan.Name.ValueString(),
 	}
 


### PR DESCRIPTION
## Description

Renovate PR #294 bumps `github.com/ory/client-go` to `v1.22.62`, but the build fails because `v1.22.62` renames the project API key request model from `CreateProjectApiKeyRequest` to `CreateProjectApiKeyBody` (and the matching request-builder setter method). This PR bumps the dependency and updates the call sites so the provider compiles against `v1.22.62`.

The renamed struct's fields (`name`, `expires_at`) and JSON wire format are unchanged, so there is no behavioral change. This aligns the type name with the existing `...Body` convention already used elsewhere (e.g. `CreateEventStreamBody`).

Updated call sites:
- `internal/client/client.go` — `CreateProjectAPIKey` parameter type and the request-builder setter
- `internal/resources/projectapikey/resource.go` — request body construction
- `internal/acctest/acctest.go` — acceptance test harness API key creation
- `internal/client/client_test.go` — unit test call site

## Related Issues

Supersedes #294 (Renovate bump that fails CI on the breaking rename).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works (existing unit and acceptance tests already cover this path; a generated-symbol rename needs no new test)
- [x] I have updated documentation as needed (no changes needed; `make format` regenerated docs with no diff)
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

Steps performed:
1. Reproduced the reported failure by bumping to `v1.22.62` and running `go build ./...` (undefined `ory.CreateProjectApiKeyRequest`).
2. Applied the rename, then confirmed `go build ./...` and `go vet ./...` pass.
3. `make test` — all unit tests pass.
4. `TestAccProjectAPIKeyResource_basic` — passes against a live project (create, import-state-verify, destroy).
5. `make format`, `make lint`, `make sec` (govulncheck, gosec, gitleaks) — all clean.

## Screenshots/Output

Before (reproduced build break):

```
internal/client/client.go:1223:89: undefined: ory.CreateProjectApiKeyRequest
internal/client/client.go:1230:87: c.consoleClient.ProjectAPI.CreateProjectApiKey(ctx, projectID).CreateProjectApiKeyRequest undefined (type "github.com/ory/client-go".ProjectAPICreateProjectApiKeyRequest has no field or method CreateProjectApiKeyRequest)
```

After:

```
$ go build ./...        # OK
$ make test             # all unit tests pass
$ TF_ACC=1 go test -tags acceptance -run '^TestAccProjectAPIKeyResource_basic$' ./internal/resources/projectapikey/...
--- PASS: TestAccProjectAPIKeyResource_basic (8.88s)
ok      github.com/ory/terraform-provider-ory/internal/resources/projectapikey  9.562s
$ make lint             # 0 issues
$ make sec              # govulncheck ok, gosec 0 issues, gitleaks no leaks
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated project API key creation to align with the latest API client version.
  * Improved compatibility and reliability when creating project API keys.
* **Chores**
  * Updated the API client dependency to the latest patch release.
  * Updated related test and integration code to use the revised request format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->