### PR TITLE
fix(deps): update golang.org/x/crypto to v0.52.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	go.opentelemetry.io/otel v1.41.0 // indirect
 	go.opentelemetry.io/otel/metric v1.41.0 // indirect
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
-	golang.org/x/crypto v0.51.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,8 @@ go.opentelemetry.io/otel/trace v1.41.0 h1:Vbk2co6bhj8L59ZJ6/xFTskY+tGAbOnCtQGVVa
 go.opentelemetry.io/otel/trace v1.41.0/go.mod h1:U1NU4ULCoxeDKc09yCWdWe+3QoyweJcISEVa1RBzOis=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
-golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 h1:nDVHiLt8aIbd/VzvPWN6kSOPE7+F/fNFDSXLVYkE/Iw=
 golang.org/x/exp v0.0.0-20250305212735-054e65f0b394/go.mod h1:sIifuuw/Yco/y6yb6+bDNfyeQ/MdPUy/hKEMYQV17cM=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=


### PR DESCRIPTION
## Description

Bumps the transitive dependency `golang.org/x/crypto` from `v0.51.0` to `v0.52.0` to resolve all open Dependabot security alerts on the repository.

All 13 open alerts are for `golang.org/x/crypto` at versions `< 0.52.0` (7 critical, 2 high, 4 moderate), each fixed in `v0.52.0`. The dependency is pulled in transitively via `golang.org/x/net`; the provider itself does not import or call `golang.org/x/crypto` (`go mod why golang.org/x/crypto` reports "main module does not need package golang.org/x/crypto"), and all of the advisories are in the `golang.org/x/crypto/ssh` code paths, which the provider does not use. The bump clears the alerts regardless.

Resolved advisories:

| Severity | GHSA |
|----------|------|
| Critical | GHSA-f5wc-c3c7-36mc, GHSA-jppx-rxg9-jmrx, GHSA-x527-x647-q7gg, GHSA-5cgq-3rg8-m6cv, GHSA-rm3j-f69w-wqmq, GHSA-89gr-r52h-f8rx, GHSA-vgwf-h737-ff37 |
| High | GHSA-w879-237q-wc7r, GHSA-q4h4-gmj2-qvw2 |
| Moderate | GHSA-9m57-25v3-79x9, GHSA-qpw4-5x99-6vjp, GHSA-78mq-xcr3-xm33, GHSA-45gg-vh54-h5m9 |

Only `go.mod` and `go.sum` change; no provider code, tests, or documentation are affected.

## Related Issues

No tracking issue. Addresses the open Dependabot security alerts: https://github.com/ory/terraform-provider-ory/security/dependabot

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [ ] I have added tests that prove my fix/feature works
- [ ] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

> No new tests or documentation are added: this is a transitive dependency version bump with no change to provider behavior. The existing unit test suite passing is the verification.

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [ ] Acceptance tests
- [x] Manual testing

- `make build` succeeds.
- `make format` reports 0 lint issues and produces no doc changes.
- `make test-short` (the CI-equivalent unit run) passes.
- `make sec` passes: `govulncheck` finds 0 vulnerabilities affecting the code, `gosec` reports 0 issues, `gitleaks` finds no leaks.

Acceptance tests were not run because this change contains no provider code changes (only a transitive dependency version bump), so there is no runtime behavior to exercise against the live API.

## Screenshots/Output

`go mod why` confirms the dependency is transitive and unused by the provider:

```
$ go mod why golang.org/x/crypto
# golang.org/x/crypto
(main module does not need package golang.org/x/crypto)
```

`govulncheck` after the bump:

```
$ make sec-vuln
=== Symbol Results ===

No vulnerabilities found.

Your code is affected by 0 vulnerabilities.
This scan also found 0 vulnerabilities in packages you import and 1
vulnerability in modules you require, but your code doesn't appear to call these
vulnerabilities.
```

The remaining informational note is `GO-2026-5932` (the `golang.org/x/crypto/openpgp` package is unmaintained). It has no fixed version available, is not one of the Dependabot alerts, and is not reachable from the provider's code, so no action is possible or required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying security-related dependency to the latest available version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->