### PR TITLE
feat: support saml auth method for ory_action webhooks

### DIFF
--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -41,6 +41,15 @@ resource "ory_action" "validate_login" {
   can_interrupt = true # Allow webhook to block login
 }
 
+# Post-login webhook for SAML single sign-on (SSO) logins
+resource "ory_action" "after_login_saml" {
+  flow        = "login"
+  timing      = "after"
+  auth_method = "saml"
+  url         = "https://api.example.com/webhooks/after-login-saml"
+  method      = "POST"
+}
+
 # Webhook with write-only (ephemeral) authentication secrets sourced from Vault.
 # The *_wo secrets are never stored in Terraform state or plan (Terraform 1.11+).
 # Bump the matching *_wo_version whenever a secret rotates so Terraform re-sends it.
@@ -139,6 +148,7 @@ The `auth_method` attribute specifies which authentication method triggers the w
 | `passkey` | Passkey authentication |
 | `totp` | Time-based one-time password |
 | `lookup_secret` | Recovery/backup codes |
+| `saml` | SAML single sign-on (SSO) |
 
 ~> **Note:** `auth_method` only applies to `timing = "after"` webhooks on the `login`, `registration`, and `settings` flows. The `recovery` and `verification` flows are **not** scoped by authentication method — their after-hooks always run — so `auth_method` is ignored for them and should be omitted. For `timing = "before"` hooks, the webhook runs before any authentication method is invoked.
 
@@ -236,7 +246,7 @@ terraform import ory_action.validate \
 1. **project_id**: Settings → General → Project ID
 2. **flow**: The flow type (login, registration, recovery, settings, verification)
 3. **timing**: "before" or "after"
-4. **auth_method**: for `login`/`registration`/`settings` "after" hooks, one of password, oidc, code, webauthn, passkey, totp, lookup_secret. For `recovery`/`verification` "after" hooks the value is ignored, but the import ID format still requires this segment — use `password` to match the provider default and avoid a post-import diff (keep `auth_method` omitted from the resource configuration itself).
+4. **auth_method**: for `login`/`registration`/`settings` "after" hooks, one of password, oidc, code, webauthn, passkey, totp, lookup_secret, saml. For `recovery`/`verification` "after" hooks the value is ignored, but the import ID format still requires this segment — use `password` to match the provider default and avoid a post-import diff (keep `auth_method` omitted from the resource configuration itself).
 5. **method**: The HTTP method (POST, GET, PUT, PATCH, DELETE)
 6. **url**: The exact webhook URL - must match exactly including protocol and trailing slashes
 
@@ -263,7 +273,7 @@ Common issues:
 
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
-- `auth_method` (String) Authentication method that triggers the webhook. In the Ory Console UI, this is the "Method" selector. Valid values: `password` (default), `oidc` (social login), `code` (magic link/OTP), `webauthn`, `passkey`, `totp`, `lookup_secret`. Only applies to `timing = "after"` webhooks on the `login`, `registration`, and `settings` flows; it is ignored for the `recovery` and `verification` flows.
+- `auth_method` (String) Authentication method that triggers the webhook. In the Ory Console UI, this is the "Method" selector. Valid values: `password` (default), `oidc` (social login), `code` (magic link/OTP), `webauthn`, `passkey`, `totp`, `lookup_secret`, `saml` (SAML single sign-on). Only applies to `timing = "after"` webhooks on the `login`, `registration`, and `settings` flows; it is ignored for the `recovery` and `verification` flows.
 - `body` (String) Jsonnet template for the request body.
 - `can_interrupt` (Boolean) Allow webhook to interrupt/block the flow (default: false).
 - `method` (String) HTTP method (default: POST).

--- a/examples/resources/ory_action/resource.tf
+++ b/examples/resources/ory_action/resource.tf
@@ -23,6 +23,15 @@ resource "ory_action" "validate_login" {
   can_interrupt = true # Allow webhook to block login
 }
 
+# Post-login webhook for SAML single sign-on (SSO) logins
+resource "ory_action" "after_login_saml" {
+  flow        = "login"
+  timing      = "after"
+  auth_method = "saml"
+  url         = "https://api.example.com/webhooks/after-login-saml"
+  method      = "POST"
+}
+
 # Webhook with write-only (ephemeral) authentication secrets sourced from Vault.
 # The *_wo secrets are never stored in Terraform state or plan (Terraform 1.11+).
 # Bump the matching *_wo_version whenever a secret rotates so Terraform re-sends it.

--- a/internal/resources/action/hooks_test.go
+++ b/internal/resources/action/hooks_test.go
@@ -1,8 +1,15 @@
 package action
 
 import (
+	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	ory "github.com/ory/client-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,6 +48,44 @@ func afterConfig(flow string, after map[string]interface{}) map[string]interface
 			},
 		},
 	}
+}
+
+// TestAuthMethodValidatorAcceptsSAML is the schema-level regression for issue
+// #305: the Ory Console UI offers "saml" as an after-login authentication
+// method, but the auth_method validator rejected it. Every documented method
+// (including saml) must pass validation, while an unknown method must still be
+// rejected so we know the validator is active.
+func TestAuthMethodValidatorAcceptsSAML(t *testing.T) {
+	ctx := context.Background()
+	r := &ActionResource{}
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+
+	attr, ok := schemaResp.Schema.Attributes["auth_method"].(schema.StringAttribute)
+	require.True(t, ok, "auth_method must be a StringAttribute")
+	validators := attr.StringValidators()
+	require.NotEmpty(t, validators, "auth_method must have validators")
+
+	validate := func(value string) diag.Diagnostics {
+		var diags diag.Diagnostics
+		for _, v := range validators {
+			resp := &validator.StringResponse{}
+			v.ValidateString(ctx, validator.StringRequest{
+				Path:        path.Root("auth_method"),
+				ConfigValue: types.StringValue(value),
+			}, resp)
+			diags.Append(resp.Diagnostics...)
+		}
+		return diags
+	}
+
+	for _, method := range []string{"password", "oidc", "code", "webauthn", "passkey", "totp", "lookup_secret", "saml"} {
+		t.Run(method, func(t *testing.T) {
+			assert.Falsef(t, validate(method).HasError(), "auth_method %q must be accepted", method)
+		})
+	}
+
+	assert.True(t, validate("magic").HasError(), "an unknown auth_method must be rejected")
 }
 
 func TestFlowSupportsAuthMethod(t *testing.T) {

--- a/internal/resources/action/resource.go
+++ b/internal/resources/action/resource.go
@@ -131,6 +131,7 @@ The ` + "`auth_method`" + ` attribute specifies which authentication method trig
 | ` + "`passkey`" + ` | Passkey authentication | "Passkey" |
 | ` + "`totp`" + ` | Time-based one-time password | "TOTP" |
 | ` + "`lookup_secret`" + ` | Recovery/backup codes | "Backup Codes" |
+| ` + "`saml`" + ` | SAML single sign-on (SSO) | "SAML" |
 
 **Note:** ` + "`auth_method`" + ` only applies to ` + "`timing = \"after\"`" + ` webhooks on the ` + "`login`" + `, ` + "`registration`" + `, and ` + "`settings`" + ` flows. The ` + "`recovery`" + ` and ` + "`verification`" + ` flows are not scoped by authentication method, so ` + "`auth_method`" + ` is ignored for them and should be omitted. For ` + "`timing = \"before\"`" + ` hooks, the webhook runs before any authentication method.
 
@@ -248,13 +249,13 @@ func (r *ActionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"auth_method": schema.StringAttribute{
-				Description:         "Authentication method to hook into (password, oidc, code, webauthn, passkey, totp, lookup_secret). Defaults to 'password'. Only applies to 'after' timing on the login, registration, and settings flows; ignored for the recovery and verification flows.",
-				MarkdownDescription: "Authentication method that triggers the webhook. In the Ory Console UI, this is the \"Method\" selector. Valid values: `password` (default), `oidc` (social login), `code` (magic link/OTP), `webauthn`, `passkey`, `totp`, `lookup_secret`. Only applies to `timing = \"after\"` webhooks on the `login`, `registration`, and `settings` flows; it is ignored for the `recovery` and `verification` flows.",
+				Description:         "Authentication method to hook into (password, oidc, code, webauthn, passkey, totp, lookup_secret, saml). Defaults to 'password'. Only applies to 'after' timing on the login, registration, and settings flows; ignored for the recovery and verification flows.",
+				MarkdownDescription: "Authentication method that triggers the webhook. In the Ory Console UI, this is the \"Method\" selector. Valid values: `password` (default), `oidc` (social login), `code` (magic link/OTP), `webauthn`, `passkey`, `totp`, `lookup_secret`, `saml` (SAML single sign-on). Only applies to `timing = \"after\"` webhooks on the `login`, `registration`, and `settings` flows; it is ignored for the `recovery` and `verification` flows.",
 				Optional:            true,
 				Computed:            true,
 				Default:             stringdefault.StaticString("password"),
 				Validators: []validator.String{
-					stringvalidator.OneOf("password", "oidc", "code", "webauthn", "passkey", "totp", "lookup_secret"),
+					stringvalidator.OneOf("password", "oidc", "code", "webauthn", "passkey", "totp", "lookup_secret", "saml"),
 				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/resources/action/resource_test.go
+++ b/internal/resources/action/resource_test.go
@@ -246,6 +246,45 @@ func TestAccActionResource_basic(t *testing.T) {
 	})
 }
 
+// TestAccActionResource_samlLogin is the regression test for issue #305: the
+// SAML authentication method is offered in the Ory Console UI for after-login
+// hooks but the provider's auth_method validator rejected "saml". This exercises
+// create, read, import, and delete of a webhook bound to the SAML method on the
+// login flow (stored at .../login/after/saml/hooks, alongside any organization
+// hook already configured for SAML SSO).
+func TestAccActionResource_samlLogin(t *testing.T) {
+	webhookURL := testutil.ExampleWebhookURL + "/saml-after-login"
+	hookPath := "/services/identity/config/selfservice/flows/login/after/saml/hooks"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.AccPreCheck(t)
+			cleanupDanglingWebhook(t, hookPath, webhookURL)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create and Read
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/saml_login.tf.tmpl", map[string]string{"WebhookURL": testutil.ExampleWebhookURL}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_action.test", "id"),
+					resource.TestCheckResourceAttr("ory_action.test", "flow", "login"),
+					resource.TestCheckResourceAttr("ory_action.test", "timing", "after"),
+					resource.TestCheckResourceAttr("ory_action.test", "auth_method", "saml"),
+					resource.TestCheckResourceAttr("ory_action.test", "method", "POST"),
+				),
+			},
+			// Import using the 6-part format: project_id:flow:timing:auth_method:method:url
+			{
+				ResourceName:      "ory_action.test",
+				ImportState:       true,
+				ImportStateIdFunc: actionImportStateIDFunc,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 // TestAccActionResource_beforeTiming is the regression test for issue #280:
 // before-timing actions could not be imported because the url's own colons
 // (https://...) broke the segment-counting import ID parser. Both documented

--- a/internal/resources/action/testdata/saml_login.tf.tmpl
+++ b/internal/resources/action/testdata/saml_login.tf.tmpl
@@ -1,0 +1,7 @@
+resource "ory_action" "test" {
+  flow        = "login"
+  timing      = "after"
+  auth_method = "saml"
+  url         = "[[ .WebhookURL ]]/saml-after-login"
+  method      = "POST"
+}

--- a/templates/resources/action.md.tmpl
+++ b/templates/resources/action.md.tmpl
@@ -30,6 +30,7 @@ The `auth_method` attribute specifies which authentication method triggers the w
 | `passkey` | Passkey authentication |
 | `totp` | Time-based one-time password |
 | `lookup_secret` | Recovery/backup codes |
+| `saml` | SAML single sign-on (SSO) |
 
 ~> **Note:** `auth_method` only applies to `timing = "after"` webhooks on the `login`, `registration`, and `settings` flows. The `recovery` and `verification` flows are **not** scoped by authentication method — their after-hooks always run — so `auth_method` is ignored for them and should be omitted. For `timing = "before"` hooks, the webhook runs before any authentication method is invoked.
 
@@ -127,7 +128,7 @@ terraform import ory_action.validate \
 1. **project_id**: Settings → General → Project ID
 2. **flow**: The flow type (login, registration, recovery, settings, verification)
 3. **timing**: "before" or "after"
-4. **auth_method**: for `login`/`registration`/`settings` "after" hooks, one of password, oidc, code, webauthn, passkey, totp, lookup_secret. For `recovery`/`verification` "after" hooks the value is ignored, but the import ID format still requires this segment — use `password` to match the provider default and avoid a post-import diff (keep `auth_method` omitted from the resource configuration itself).
+4. **auth_method**: for `login`/`registration`/`settings` "after" hooks, one of password, oidc, code, webauthn, passkey, totp, lookup_secret, saml. For `recovery`/`verification` "after" hooks the value is ignored, but the import ID format still requires this segment — use `password` to match the provider default and avoid a post-import diff (keep `auth_method` omitted from the resource configuration itself).
 5. **method**: The HTTP method (POST, GET, PUT, PATCH, DELETE)
 6. **url**: The exact webhook URL - must match exactly including protocol and trailing slashes
 


### PR DESCRIPTION
## Description

The Ory Console UI offers **SAML** as a "Method" for after-login action webhooks (and after-registration/after-settings), but the provider's `auth_method` validator rejected `"saml"`:

```
Attribute auth_method value must be one of: ["password" "oidc" "code"
"webauthn" "passkey" "totp" "lookup_secret"], got: "saml"
```

SAML is a valid authentication method for exactly the `login`, `registration`, and `settings` flows the provider already scopes by auth method (`flowSupportsAuthMethod`), so the webhook routes to `.../selfservice/flows/<flow>/after/saml/hooks` with no path-construction changes required. This was verified against the live Console API: the path accepts and persists a `web_hook` and reads it back (an existing `organization` hook at that path is preserved).

Changes:

- Add `saml` to the `auth_method` `OneOf` validator.
- Document `saml` in the schema descriptions, the resource docs template, the auth-methods table, and the example.
- Add a schema-level unit test asserting every documented method (including `saml`) is accepted and an unknown method is still rejected.
- Add a create/read/import/delete acceptance test for a SAML after-login webhook.

## Related Issues

Fixes #305

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

- Manually verified against the live Console API (staging) that a `web_hook` PATCHed to `/services/identity/config/selfservice/flows/login/after/saml/hooks` persists and reads back, and that the pre-existing `organization` hook at that path is untouched.
- New unit test `TestAuthMethodValidatorAcceptsSAML` passes.
- New acceptance test `TestAccActionResource_samlLogin` passes end-to-end (create, read, import with `ImportStateVerify`, delete) against a real project; the test cleans up after itself.
- `make format` (fmt, docs regen, lint) reports 0 issues; `make test-short` passes; `make sec` (govulncheck, gosec, gitleaks) is clean.

## Screenshots/Output

```
=== RUN   TestAuthMethodValidatorAcceptsSAML
--- PASS: TestAuthMethodValidatorAcceptsSAML (0.00s)
    --- PASS: TestAuthMethodValidatorAcceptsSAML/saml (0.00s)

=== RUN   TestAccActionResource_samlLogin
--- PASS: TestAccActionResource_samlLogin (18.12s)
PASS
ok  	github.com/ory/terraform-provider-ory/internal/resources/action
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for SAML as an authentication method for post-login actions.
  - Added a Terraform example for configuring a SAML login webhook.
- **Documentation**
  - Updated action resource guidance, schemas, authentication-method tables, and import instructions to include SAML.
- **Tests**
  - Added coverage verifying SAML authentication methods are accepted and invalid values are rejected.
  - Added acceptance coverage for SAML post-login actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->