### PR TITLE
fix(action): delete hooks via array replace, not index remove

### DIFF
--- a/internal/resources/action/hooks_test.go
+++ b/internal/resources/action/hooks_test.go
@@ -211,3 +211,29 @@ func TestGetHooksFromProject_BeforeTiming(t *testing.T) {
 	config, _ := hooks[0]["config"].(map[string]interface{})
 	assert.Equal(t, "https://example.com/pre-login", config["url"])
 }
+
+// TestHooksExcluding verifies Delete rebuilds the hooks array without the
+// removed element, preserving order, for the `replace` patch it sends.
+func TestHooksExcluding(t *testing.T) {
+	a := actionTestWebhook("https://example.com/a")
+	b := actionTestWebhook("https://example.com/b")
+	c := actionTestWebhook("https://example.com/c")
+
+	t.Run("removes middle element, preserves order", func(t *testing.T) {
+		got := hooksExcluding([]map[string]interface{}{a, b, c}, 1)
+		require.Len(t, got, 2)
+		assert.Equal(t, "https://example.com/a", got[0].(map[string]interface{})["config"].(map[string]interface{})["url"])
+		assert.Equal(t, "https://example.com/c", got[1].(map[string]interface{})["config"].(map[string]interface{})["url"])
+	})
+
+	t.Run("removing the only hook yields a non-nil empty slice", func(t *testing.T) {
+		got := hooksExcluding([]map[string]interface{}{a}, 0)
+		assert.NotNil(t, got, "must be non-nil so replace sends [] rather than null")
+		assert.Empty(t, got)
+	})
+
+	t.Run("out-of-range index keeps all hooks", func(t *testing.T) {
+		got := hooksExcluding([]map[string]interface{}{a, b}, -1)
+		assert.Len(t, got, 2)
+	})
+}

--- a/internal/resources/action/resource.go
+++ b/internal/resources/action/resource.go
@@ -1129,9 +1129,15 @@ func (r *ActionResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	}
 
 	hookPath := r.hookPath(flow, timing, authMethod)
+
+	// Replace the whole array with the remaining hooks. A `remove` at
+	// `<hookPath>/<index>` is rejected by the project-config PATCH with a 400,
+	// leaving the webhook dangling; replacing the array matches Create.
+	newHooks := hooksExcluding(hooks, index)
 	patches := []ory.JsonPatch{{
-		Op:   "remove",
-		Path: fmt.Sprintf("%s/%d", hookPath, index),
+		Op:    "replace",
+		Path:  hookPath,
+		Value: newHooks,
 	}}
 
 	_, err = r.client.PatchProject(ctx, projectID, patches)
@@ -1139,6 +1145,20 @@ func (r *ActionResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		resp.Diagnostics.AddError("Error Deleting Action", err.Error())
 		return
 	}
+}
+
+// hooksExcluding returns hooks without the element at index, as a non-nil
+// []interface{} for a JSON Patch `replace` value (so removing the last hook
+// sends [] rather than null). An out-of-range index keeps all hooks.
+func hooksExcluding(hooks []map[string]interface{}, index int) []interface{} {
+	newHooks := make([]interface{}, 0, len(hooks))
+	for i, h := range hooks {
+		if i == index {
+			continue
+		}
+		newHooks = append(newHooks, h)
+	}
+	return newHooks
 }
 
 // isImportHTTPMethod reports whether s is one of the HTTP methods accepted in


### PR DESCRIPTION
## Problem

Deleting an `ory_action` fails with:

```
Error Deleting Action: patching project: 400 Bad Request (Request ID: ...)
```

`Delete` removes a webhook with a JSON Patch `remove` at `<hookPath>/<index>`:

```go
patches := []ory.JsonPatch{{
    Op:   "remove",
    Path: fmt.Sprintf("%s/%d", hookPath, index),
}}
```

Ory's project-config PATCH rejects that operation with a 400, so the delete fails and the webhook is left dangling in the project config. This reproduces on a plain single action (`flow=login, timing=after, auth_method=password`) with a fresh read and a valid index, so it isn't a concurrency or stale-index problem — the `remove`-by-index op itself is rejected.

The provider already knows the robust shape elsewhere:
- `Create` adds a hook by `replace`-ing the **whole** array (`hookPath`) with the new list.
- `cleanupDanglingWebhook` in the acceptance tests removes a hook the same way — read the array, drop the target, `replace` the whole path — precisely to clean up webhooks that `Delete` failed to remove.

`Delete` just never adopted that pattern.

## Fix

Rebuild the hooks array without the target hook and `replace` the whole path, mirroring `Create`/`cleanupDanglingWebhook`. A small `hooksExcluding` helper returns a non-nil `[]interface{}` so removing the last hook sends `[]` rather than `null`.

## Tests

- `TestHooksExcluding` covers middle removal (order preserved), removing the only hook (non-nil empty slice), and out-of-range index.
- Existing unit tests pass; `go build ./...` and `gofmt` are clean.

> Draft: the acceptance suite (`//go:build acceptance`) needs a live Ory project, which I couldn't run here — flagging for maintainer CI. Verified against a real project out-of-band: the current code 400s on delete, and the `replace` patch is the same op `cleanupDanglingWebhook` already uses successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hook deletion to reliably remove the selected hook without leaving behind a dangling webhook.
  * Preserved the remaining hooks in their original order.
  * Correctly sends an empty hook list when the final hook is deleted.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->