### PR TITLE
fix: surface HTTP status and response body in wrapped API errors

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -38,6 +38,9 @@ const (
 	maxRetries = 3
 	// initialBackoff is the initial backoff duration before first retry.
 	initialBackoff = 1 * time.Second
+	// maxErrorBodyBytes is the maximum length of a raw response body included in
+	// a wrapped API error before it is truncated.
+	maxErrorBodyBytes = 2048
 )
 
 const (
@@ -238,12 +241,32 @@ func wrapAPIError(err error, operation string) error {
 			operation, debugInfo.RequestID, err)
 	}
 
-	// For any other error, include the request ID if available
+	// For any other error, surface the HTTP status and raw response body so the
+	// underlying cause is not masked by an SDK decode error.
+	detail := operation
+	if debugInfo.StatusCode != 0 {
+		detail += fmt.Sprintf(": HTTP %d", debugInfo.StatusCode)
+	}
 	if debugInfo.RequestID != "" {
-		return fmt.Errorf("%s: %w (Request ID: %s)", operation, err, debugInfo.RequestID)
+		detail += fmt.Sprintf(" (Request ID: %s)", debugInfo.RequestID)
+	}
+	if body := strings.TrimSpace(debugInfo.RawBody); body != "" && body != errStr {
+		return fmt.Errorf("%s: %w\nResponse body: %s", detail, err, truncateErrorBody(body))
+	}
+	if detail != operation {
+		return fmt.Errorf("%s: %w", detail, err)
 	}
 
 	return err
+}
+
+// truncateErrorBody trims a raw response body to maxErrorBodyBytes so error
+// messages stay readable.
+func truncateErrorBody(body string) string {
+	if len(body) <= maxErrorBodyBytes {
+		return body
+	}
+	return body[:maxErrorBodyBytes] + "... (truncated)"
 }
 
 // isRateLimitError checks if the error is a rate limit (429) error.
@@ -1176,7 +1199,7 @@ func (c *OryClient) CreateOAuth2Client(ctx context.Context, oauthClient ory.OAut
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
 	}
-	return result, err
+	return result, wrapAPIError(err, "creating OAuth2 client")
 }
 
 // GetOAuth2Client retrieves an OAuth2 client by ID.
@@ -1188,7 +1211,7 @@ func (c *OryClient) GetOAuth2Client(ctx context.Context, clientID string) (*ory.
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
 	}
-	return oauthClient, err
+	return oauthClient, wrapAPIError(err, "reading OAuth2 client")
 }
 
 // UpdateOAuth2Client updates an OAuth2 client.
@@ -1200,7 +1223,7 @@ func (c *OryClient) UpdateOAuth2Client(ctx context.Context, clientID string, oau
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
 	}
-	return result, err
+	return result, wrapAPIError(err, "updating OAuth2 client")
 }
 
 // DeleteOAuth2Client deletes an OAuth2 client.
@@ -1212,7 +1235,7 @@ func (c *OryClient) DeleteOAuth2Client(ctx context.Context, clientID string) err
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
 	}
-	return err
+	return wrapAPIError(err, "deleting OAuth2 client")
 }
 
 // =============================================================================

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -268,6 +268,40 @@ func TestPatchProject_WrapsFeatureNotAvailable(t *testing.T) {
 	assert.Contains(t, msg, "ory.com/pricing")
 }
 
+// gatewayUnauthorizedBody has a JSON-object "error" field, which the OAuth2 SDK
+// cannot decode into ErrorOAuth2 (string), so it returns an opaque unmarshal
+// error the wrapper must not surface alone.
+const gatewayUnauthorizedBody = `{"error":{"code":401,"status":"Unauthorized",` +
+	`"request":"a1b2c3d4-0000-1111-2222-333344445555",` +
+	`"message":"Access credentials are invalid"}}`
+
+// TestCreateOAuth2Client_SurfacesErrorBody verifies the wrapped error carries the
+// HTTP status, body, and request ID instead of the SDK decode error.
+func TestCreateOAuth2Client_SurfacesErrorBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(gatewayUnauthorizedBody))
+	}))
+	defer srv.Close()
+
+	client, err := NewOryClient(OryClientConfig{
+		ProjectAPIKey: testutil.TestProjectAPIKey,
+		ProjectSlug:   testutil.TestProjectSlug,
+		ProjectAPIURL: srv.URL + "/%s",
+	})
+	require.NoError(t, err)
+
+	_, createErr := client.CreateOAuth2Client(context.Background(), ory.OAuth2Client{})
+	require.Error(t, createErr)
+
+	msg := createErr.Error()
+	assert.Contains(t, msg, "creating OAuth2 client")
+	assert.Contains(t, msg, "401", "should surface the HTTP status")
+	assert.Contains(t, msg, "Access credentials are invalid", "should surface the raw response body")
+	assert.Contains(t, msg, "a1b2c3d4", "should surface the request ID for Ory support")
+}
+
 func TestNewOryClient_InvalidConsoleURL(t *testing.T) {
 	cfg := OryClientConfig{
 		WorkspaceAPIKey: testutil.TestWorkspaceAPIKey,

--- a/internal/client/oauth2_wrap_error_test.go
+++ b/internal/client/oauth2_wrap_error_test.go
@@ -1,0 +1,77 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	ory "github.com/ory/client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/terraform-provider-ory/internal/testutil"
+)
+
+// oauth2GatewayUnauthorizedBody is the oryapis.com gateway's object-"error" 401
+// body, which the OAuth2 SDK cannot decode into ErrorOAuth2 (error is a string),
+// so it returns an opaque unmarshal error the wrapper must enrich with the body.
+const oauth2GatewayUnauthorizedBody = `{"error":{"code":401,"status":"Unauthorized",` +
+	`"request":"rid-9999","message":"Access credentials are invalid"}}`
+
+func oauth2Unauthorized401Server() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(oauth2GatewayUnauthorizedBody))
+	}))
+}
+
+func oauth2TestClient(t *testing.T, url string) *OryClient {
+	t.Helper()
+	c, err := NewOryClient(OryClientConfig{
+		ProjectAPIKey: testutil.TestProjectAPIKey,
+		ProjectSlug:   testutil.TestProjectSlug,
+		ProjectAPIURL: url + "/%s",
+	})
+	require.NoError(t, err)
+	return c
+}
+
+// TestOAuth2Clients_SurfaceErrorBodyOnAllVerbs verifies that every OAuth2 client
+// wrapper (Get/Update/Delete — Create is covered by
+// TestCreateOAuth2Client_SurfacesErrorBody) routes through wrapAPIError and
+// surfaces the HTTP status, request ID, and raw response body rather than the
+// opaque SDK decode error.
+func TestOAuth2Clients_SurfaceErrorBodyOnAllVerbs(t *testing.T) {
+	assertSurfaced := func(t *testing.T, op string, err error) {
+		t.Helper()
+		require.Error(t, err)
+		msg := err.Error()
+		assert.Contains(t, msg, op, "should name the operation")
+		assert.Contains(t, msg, "401", "should surface the HTTP status")
+		assert.Contains(t, msg, "Access credentials are invalid", "should surface the raw response body")
+		assert.Contains(t, msg, "rid-9999", "should surface the request ID for Ory support")
+	}
+
+	t.Run("Get", func(t *testing.T) {
+		srv := oauth2Unauthorized401Server()
+		defer srv.Close()
+		_, err := oauth2TestClient(t, srv.URL).GetOAuth2Client(context.Background(), "cid")
+		assertSurfaced(t, "reading OAuth2 client", err)
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		srv := oauth2Unauthorized401Server()
+		defer srv.Close()
+		_, err := oauth2TestClient(t, srv.URL).UpdateOAuth2Client(context.Background(), "cid", ory.OAuth2Client{})
+		assertSurfaced(t, "updating OAuth2 client", err)
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		srv := oauth2Unauthorized401Server()
+		defer srv.Close()
+		err := oauth2TestClient(t, srv.URL).DeleteOAuth2Client(context.Background(), "cid")
+		assertSurfaced(t, "deleting OAuth2 client", err)
+	})
+}


### PR DESCRIPTION
## Problem

Some errors surface an opaque SDK decode message instead of the real cause:

- The OAuth2 client CRUD wrappers (`Create/Get/Update/DeleteOAuth2Client`) returned the raw SDK error, bypassing `wrapAPIError`.
- `wrapAPIError`'s generic fallback keyed off the SDK error *string* rather than the parsed status/body it already extracts in `extractDebugInfo`.

So a 401 from the gateway whose `error` field is a JSON object surfaces only as:

```
json: cannot unmarshal object into Go struct field _ErrorOAuth2.error of type string
```

masking the actual reason.

## Fix

- Route the OAuth2 client calls through `wrapAPIError`.
- In the generic fallback, append the parsed HTTP status and the raw response body (truncated to 2048 bytes) alongside the request ID.

## Why this matters (real example)

While tearing down an environment, deleting an `ory_action` failed with a bare `Error Deleting Action: patching project: 400 Bad Request`. That gave no clue, and led to a wrong diagnosis (I suspected the `remove`-by-index patch). Only after patching the provider to print the body did the true cause appear — Ory re-validates the whole project config on every PATCH and rejected it because an unrelated field, `oauth2.token_hook.url`, pointed at a host that no longer resolved:

```
Unable to set value for `oauth2.token_hook.url` with error: failed to resolve
https://…/api/internal/hooks/ory-token: lookup … no such host
```

With this change that reason is in the diagnostic directly — no provider rebuild needed.

## Tests

`TestCreateOAuth2Client_SurfacesErrorBody` serves the gateway's object-`error` 401 body and asserts the wrapped error contains the status, the message, and the request ID.

`go build ./...`, `gofmt`, and the `internal/client` unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth2 client error messages with clearer operation context, HTTP status, request IDs, and relevant API response details.
  * Added safeguards to limit the size of raw error responses included in error messages.
  * Updated OAuth2 client operations to consistently provide enriched error information across create, get, update, and delete actions.

* **Tests**
  * Added coverage for unauthorized responses and malformed API error payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->