### PR TITLE
fix(action): treat a deleted project as having no hooks

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -246,6 +246,20 @@ func wrapAPIError(err error, operation string) error {
 	return err
 }
 
+// IsNotFound reports whether err is an Ory API 404 (Not Found) — e.g. a project
+// that has been purged. Callers use it to treat a missing resource as already
+// gone rather than a hard failure.
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if extractDebugInfo(err).StatusCode == 404 {
+		return true
+	}
+	errStr := err.Error()
+	return strings.Contains(errStr, "404") || strings.Contains(errStr, "Not Found")
+}
+
 // isRateLimitError checks if the error is a rate limit (429) error.
 func isRateLimitError(err error) bool {
 	if err == nil {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -272,6 +272,8 @@ func IsNotFound(err error) bool {
 	}
 	errStr := err.Error()
 	return strings.Contains(errStr, "404") || strings.Contains(errStr, "Not Found")
+}
+
 // truncateErrorBody trims a raw response body to maxErrorBodyBytes so error
 // messages stay readable.
 func truncateErrorBody(body string) string {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -828,3 +828,14 @@ func TestPatchProject_SerialisedPerProject(t *testing.T) {
 		assert.GreaterOrEqual(t, atomic.LoadInt32(&maxConcurrent), int32(2), "expected concurrent patches across different projects")
 	})
 }
+
+// TestIsNotFound covers the 404 detection used to treat a purged project as
+// already gone (via parsed status code and via the bare status string), and that
+// non-404 errors and nil are not misclassified.
+func TestIsNotFound(t *testing.T) {
+	assert.False(t, IsNotFound(nil))
+	assert.True(t, IsNotFound(errors.New("404 Not Found")))
+	assert.True(t, IsNotFound(errors.New(`{"error":{"code":404,"status":"Not Found","message":"project not found"}}`)))
+	assert.False(t, IsNotFound(errors.New("400 Bad Request")))
+	assert.False(t, IsNotFound(errors.New("500 Internal Server Error")))
+}

--- a/internal/resources/action/hooks_deleted_project_test.go
+++ b/internal/resources/action/hooks_deleted_project_test.go
@@ -1,0 +1,91 @@
+package action
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/terraform-provider-ory/internal/client"
+)
+
+// actionResourceWithConsole builds an ActionResource whose console client (used
+// by GetProject) points at the given test server, so getHooks can be exercised
+// end-to-end against a fake Ory Console.
+func actionResourceWithConsole(t *testing.T, srvURL string) *ActionResource {
+	t.Helper()
+	c, err := client.NewOryClient(client.OryClientConfig{
+		WorkspaceAPIKey: "ws-test-key",
+		ConsoleAPIURL:   srvURL,
+	})
+	require.NoError(t, err)
+	return &ActionResource{client: c}
+}
+
+// liveProjectBody renders a 200 GetProject body for the given state that carries
+// a single login/after/password web_hook, so tests can assert whether that hook
+// is reported for a project in that state.
+func liveProjectBody(id, state string) string {
+	return `{
+		"id":"` + id + `","name":"n","slug":"s","environment":"prod",
+		"home_region":"eu-central","revision_id":"r","organizations":[],
+		"state":"` + state + `",
+		"services":{"identity":{"config":{"selfservice":{"flows":{"login":{"after":{"password":{"hooks":[
+			{"hook":"web_hook","config":{"url":"https://example.com/x","method":"POST"}}
+		]}}}}}}}}
+	}`
+}
+
+// TestGetHooks_PurgedProjectReturnsEmpty verifies that when GetProject 404s
+// (a fully purged project during teardown), getHooks reports no hooks instead of
+// erroring, so Delete/Read can converge.
+func TestGetHooks_PurgedProjectReturnsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":404,"status":"Not Found","request":"req-404","message":"project not found"}}`))
+	}))
+	defer srv.Close()
+
+	r := actionResourceWithConsole(t, srv.URL)
+	hooks, err := r.getHooks(context.Background(), "purged-project", "login", "after", "password")
+	require.NoError(t, err, "a 404 project must not surface as an error")
+	assert.Empty(t, hooks, "a purged project must report no hooks")
+}
+
+// TestGetHooks_DeletedProjectReturnsEmpty verifies that a soft-deleted project
+// (GetProject returns 200 with state "deleted") reports no hooks even when its
+// config still carries one.
+func TestGetHooks_DeletedProjectReturnsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(liveProjectBody("soft-deleted", "deleted")))
+	}))
+	defer srv.Close()
+
+	r := actionResourceWithConsole(t, srv.URL)
+	hooks, err := r.getHooks(context.Background(), "soft-deleted", "login", "after", "password")
+	require.NoError(t, err)
+	assert.Empty(t, hooks, "a soft-deleted project must report no hooks even if config still holds one")
+}
+
+// TestGetHooks_LiveProjectReturnsHooks is the control: a live (running) project
+// with a hook must still report it, proving the deleted-project handling does not
+// change behavior while the project is alive.
+func TestGetHooks_LiveProjectReturnsHooks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(liveProjectBody("live", "running")))
+	}))
+	defer srv.Close()
+
+	r := actionResourceWithConsole(t, srv.URL)
+	hooks, err := r.getHooks(context.Background(), "live", "login", "after", "password")
+	require.NoError(t, err)
+	require.Len(t, hooks, 1, "a live project must still report its hook")
+}

--- a/internal/resources/action/hooks_test.go
+++ b/internal/resources/action/hooks_test.go
@@ -211,3 +211,18 @@ func TestGetHooksFromProject_BeforeTiming(t *testing.T) {
 	config, _ := hooks[0]["config"].(map[string]interface{})
 	assert.Equal(t, "https://example.com/pre-login", config["url"])
 }
+
+// TestGetHooksFromProject_DeletedProject verifies a soft-deleted project (which
+// GetProject still returns with state "deleted") reports no hooks, so Delete and
+// Read converge during teardown instead of trying to patch a gone project.
+func TestGetHooksFromProject_DeletedProject(t *testing.T) {
+	r := &ActionResource{}
+	cfg := afterConfig("login", map[string]interface{}{
+		"password": map[string]interface{}{
+			"hooks": []interface{}{actionTestWebhook("https://example.com/x")},
+		},
+	})
+	project := actionTestProject(cfg)
+	project.State = projectStateDeleted
+	assert.Empty(t, r.getHooksFromProject(project, "login", "after", "password"))
+}

--- a/internal/resources/action/resource.go
+++ b/internal/resources/action/resource.go
@@ -35,6 +35,9 @@ const (
 	timingAfter          = "after"
 	webhookAuthBasicAuth = "basic_auth"
 	webhookAuthAPIKey    = "api_key"
+	// projectStateDeleted is the state Ory reports for a project that has been
+	// deleted; its config no longer holds any hooks.
+	projectStateDeleted = "deleted"
 )
 
 var (
@@ -636,6 +639,11 @@ func (r *ActionResource) getHooks(ctx context.Context, projectID, flow, timing, 
 	}
 	project, err := r.client.GetProject(ctx, projectID)
 	if err != nil {
+		// A purged project has no hooks; treat it as empty so Delete/Read can
+		// converge instead of erroring during teardown.
+		if client.IsNotFound(err) {
+			return []map[string]interface{}{}, nil
+		}
 		return nil, fmt.Errorf("failed to get project %s: %w", projectID, err)
 	}
 	return r.getHooksFromProject(project, flow, timing, authMethod), nil
@@ -683,6 +691,12 @@ func (r *ActionResource) hookPath(flow, timing, authMethod string) string {
 }
 
 func (r *ActionResource) getHooksFromProject(project *ory.Project, flow, timing, authMethod string) []map[string]interface{} {
+	// A deleted project still returns 200 from GetProject (soft delete) but its
+	// config carries no hooks; report none so Delete/Read converge cleanly.
+	if project.GetState() == projectStateDeleted {
+		return []map[string]interface{}{}
+	}
+
 	if project.Services.Identity == nil {
 		return []map[string]interface{}{}
 	}


### PR DESCRIPTION
## Problem

Destroying an `ory_action` (or refreshing one) fails when the project has already been deleted — a common teardown situation where the project is purged before, or alongside, its actions:

- **Fully purged project** → `GetProject` 404s → `getHooks` returns `failed to get project …` → `Delete`/`Read` error out and destroy wedges.
- **Soft-deleted project** → `GetProject` still returns 200 with `state: "deleted"` → the read-modify-write delete proceeds and PATCHes a project that's gone.

`Delete` does a read-modify-write (read hooks → patch), so both cases surface as a hard failure instead of "the hook is already gone."

## Fix

Report no hooks when the project is gone, so `Delete` finds no matching hook and returns cleanly and `Read` drops the resource from state:

- `getHooks` treats a 404 from `GetProject` as an empty hook set (new exported `client.IsNotFound` helper).
- `getHooksFromProject` returns empty when `project.GetState() == "deleted"`.

No behavior change while the project is live.

## Tests

- `TestGetHooksFromProject_DeletedProject` — a soft-deleted project reports no hooks even when config still holds one.
- `TestIsNotFound` — 404 detection via parsed status code and bare status string; nil and non-404s not misclassified.

`go build ./...`, `gofmt`, and the `internal/resources/action` + `internal/client` unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of deleted or purged projects during hook operations.
  * Missing projects now return no hooks instead of causing errors.
  * Soft-deleted projects are correctly treated as having no hooks.

* **Tests**
  * Added coverage for live, soft-deleted, and purged project scenarios.
  * Added validation for reliable “not found” error detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->