### PR TITLE
feat(project-config): expose the Email verification hooks

### DIFF
--- a/docs/resources/project_config.md
+++ b/docs/resources/project_config.md
@@ -448,13 +448,14 @@ When `true`, the provider adds the `show_verification_ui` hook to the correspond
 
 The three toggles on the Ory Console **Email verification** page are also post-flow hooks, each with its own attribute:
 
-| Ory Console toggle | Attribute |
-|---|---|
-| Require verified address for login | `selfservice_flows_login_after_password_hook_require_verified_address` |
-| Verify new addresses | `selfservice_flows_settings_after_profile_hook_verify_new_address` |
-| Notify previous addresses | `selfservice_flows_settings_after_profile_hook_notify_previous_addresses` |
+| Ory Console toggle | Attribute | Flow |
+|---|---|---|
+| Require verified address for login | `selfservice_flows_login_after_password_hook_require_verified_address` | Password login |
+| (not in the Console) | `selfservice_flows_login_after_oidc_hook_require_verified_address` | Social login |
+| Verify new addresses | `selfservice_flows_settings_after_profile_hook_verify_new_address` | Profile settings |
+| Notify previous addresses | `selfservice_flows_settings_after_profile_hook_notify_previous_addresses` | Profile settings |
 
-The Ory Console toggle writes the password login flow only. The provider also exposes `selfservice_flows_login_after_oidc_hook_require_verified_address` for the social login flow, which the Ory config schema supports but the Console does not surface. Set both to require a verified address on every login path.
+The Ory Console toggle writes the password login flow only. The Ory config schema also supports the hook on the social login flow, so the provider exposes it there too. Set both to require a verified address on every login path.
 
 ```hcl
 resource "ory_project_config" "main" {
@@ -475,9 +476,11 @@ resource "ory_project_config" "main" {
 
 `selfservice_flows_settings_after_profile_hook_notify_previous_addresses_recipients` selects who is notified:
 
-- `removed` notifies only addresses that no longer exist after the change. This is the Ory default and applies when the attribute is unset.
+- `removed` notifies only addresses that no longer exist after the change. This is the Ory default.
 - `all_verified` notifies every address that was verified before the change.
 - `all` notifies every address on the identity before the change.
+
+Leave the attribute out and the provider writes no scope at all, so Ory applies `removed`. Removing the attribute after a scope was already applied is different: the provider stops managing the scope and leaves the project on its current value, in line with how every other optional attribute on this resource behaves. Set it back to `removed` explicitly to return to the default.
 
 -> **`verify_new_address` is not `show_verification_ui`.** `selfservice_flows_settings_after_profile_hook_verify_new_address` gates the address change on verification. `selfservice_flows_settings_after_profile_hook_show_verification_ui` only controls the redirect to the verification UI after the flow. Set both if you want the address gated *and* the user sent to the verification screen.
 
@@ -761,7 +764,7 @@ terraform plan  # verify no changes
 - `selfservice_flows_settings_after_password_default_browser_return_url` (String) Return URL after updating password in settings.
 - `selfservice_flows_settings_after_profile_default_browser_return_url` (String) Return URL after updating profile in settings.
 - `selfservice_flows_settings_after_profile_hook_notify_previous_addresses` (Boolean) Enable the `notify_previous_addresses` hook after a profile settings update, emailing the identity's previous addresses when its verified addresses change. Mirrors the Ory Console "Notify previous addresses" toggle. Existing hooks at this path (e.g., `organization`) are preserved.
-- `selfservice_flows_settings_after_profile_hook_notify_previous_addresses_recipients` (String) Which previous addresses the `notify_previous_addresses` hook notifies: `removed` for addresses that no longer exist after the change, `all_verified` for every address verified before the change, or `all` for every address on the identity before the change. Requires `selfservice_flows_settings_after_profile_hook_notify_previous_addresses = true`. When unset, the Ory default of `removed` applies.
+- `selfservice_flows_settings_after_profile_hook_notify_previous_addresses_recipients` (String) Which previous addresses the `notify_previous_addresses` hook notifies: `removed` for addresses that no longer exist after the change, `all_verified` for every address verified before the change, or `all` for every address on the identity before the change. Requires `selfservice_flows_settings_after_profile_hook_notify_previous_addresses` to be set. Leave this attribute out to let Ory apply its own default of `removed`. Note that removing it after a scope was already applied stops managing the scope rather than resetting it.
 - `selfservice_flows_settings_after_profile_hook_show_verification_ui` (Boolean) Enable the `show_verification_ui` hook after a successful profile settings update. When true, users are redirected to the verification UI after updating their profile (e.g., changing their email). Existing hooks at this path (e.g., `organization`) are preserved.
 - `selfservice_flows_settings_after_profile_hook_verify_new_address` (Boolean) Enable the `verify_new_address` hook after a profile settings update, requiring verification of an address the user just added or changed. Mirrors the Ory Console "Verify new addresses" toggle. Distinct from `selfservice_flows_settings_after_profile_hook_show_verification_ui`, which only controls the redirect to the verification UI. Existing hooks at this path (e.g., `organization`) are preserved.
 - `selfservice_flows_settings_after_totp_default_browser_return_url` (String) Return URL after updating TOTP in settings.

--- a/docs/resources/project_config.md
+++ b/docs/resources/project_config.md
@@ -318,8 +318,37 @@ resource "ory_project_config" "show_verification_ui" {
   selfservice_flows_registration_after_password_hook_show_verification_ui = true
   # Same for social (OIDC) registration.
   selfservice_flows_registration_after_oidc_hook_show_verification_ui = true
-  # When users change their email in profile settings, force re-verification.
+  # After a profile settings update, redirect users to the verification UI.
+  # This only controls the redirect. To gate the address change itself on
+  # verification, see selfservice_flows_settings_after_profile_hook_verify_new_address
+  # below.
   selfservice_flows_settings_after_profile_hook_show_verification_ui = true
+}
+
+# The three toggles on the Ory Console "Email verification" page. Like the
+# hooks above, each one is an entry in a flow's hooks array, so other hooks at
+# the same path are preserved.
+resource "ory_project_config" "email_verification_hooks" {
+  selfservice_flows_verification_enabled = true
+
+  # "Require verified address for login": block sign-in until the identity has
+  # a verified address. feature_flags_legacy_require_verified_login_error only
+  # changes how the failure is reported, it does not enable the check.
+  #
+  # The Ory Console toggle writes the password flow only. Set the OIDC flow too
+  # to cover social logins.
+  selfservice_flows_login_after_password_hook_require_verified_address = true
+  selfservice_flows_login_after_oidc_hook_require_verified_address     = true
+
+  # "Verify new addresses": require verification of an address the user just
+  # added or changed in profile settings.
+  selfservice_flows_settings_after_profile_hook_verify_new_address = true
+
+  # "Notify previous addresses": email the identity's previous addresses when
+  # its verified addresses change. Recipients is one of "removed" (the Ory
+  # default), "all_verified", or "all".
+  selfservice_flows_settings_after_profile_hook_notify_previous_addresses            = true
+  selfservice_flows_settings_after_profile_hook_notify_previous_addresses_recipients = "all_verified"
 }
 
 # Automatically sign users in after they register with email + password.
@@ -415,7 +444,46 @@ Three boolean attributes toggle the [`show_verification_ui`](https://www.ory.com
 
 When `true`, the provider adds the `show_verification_ui` hook to the corresponding flow; when `false`, it removes only that hook. Other hooks at the same path (for example `session` or `organization`) are preserved by reading the current hook list before each apply.
 
-To require a verified address before a user can log in (the "Require verified address for login" toggle in the Ory Console), set `feature_flags_legacy_require_verified_login_error = true`. When that flag is `false`, an unverified user is shown the `show_verification_ui` continuation step instead of receiving a form error.
+## Email Verification Hooks
+
+The three toggles on the Ory Console **Email verification** page are also post-flow hooks, each with its own attribute:
+
+| Ory Console toggle | Attribute |
+|---|---|
+| Require verified address for login | `selfservice_flows_login_after_password_hook_require_verified_address` |
+| Verify new addresses | `selfservice_flows_settings_after_profile_hook_verify_new_address` |
+| Notify previous addresses | `selfservice_flows_settings_after_profile_hook_notify_previous_addresses` |
+
+The Ory Console toggle writes the password login flow only. The provider also exposes `selfservice_flows_login_after_oidc_hook_require_verified_address` for the social login flow, which the Ory config schema supports but the Console does not surface. Set both to require a verified address on every login path.
+
+```hcl
+resource "ory_project_config" "main" {
+  selfservice_flows_verification_enabled = true
+
+  # Block sign-in until the identity has a verified address.
+  selfservice_flows_login_after_password_hook_require_verified_address = true
+  selfservice_flows_login_after_oidc_hook_require_verified_address     = true
+
+  # Require verification of an address the user just added or changed.
+  selfservice_flows_settings_after_profile_hook_verify_new_address = true
+
+  # Email the previous addresses when the verified addresses change.
+  selfservice_flows_settings_after_profile_hook_notify_previous_addresses            = true
+  selfservice_flows_settings_after_profile_hook_notify_previous_addresses_recipients = "all_verified"
+}
+```
+
+`selfservice_flows_settings_after_profile_hook_notify_previous_addresses_recipients` selects who is notified:
+
+- `removed` notifies only addresses that no longer exist after the change. This is the Ory default and applies when the attribute is unset.
+- `all_verified` notifies every address that was verified before the change.
+- `all` notifies every address on the identity before the change.
+
+-> **`verify_new_address` is not `show_verification_ui`.** `selfservice_flows_settings_after_profile_hook_verify_new_address` gates the address change on verification. `selfservice_flows_settings_after_profile_hook_show_verification_ui` only controls the redirect to the verification UI after the flow. Set both if you want the address gated *and* the user sent to the verification screen.
+
+-> **`feature_flags_legacy_require_verified_login_error` is not an enable switch.** It controls how a failed verified-address check is reported, a form error instead of a `continue_with` step. It has no effect unless `selfservice_flows_login_after_password_hook_require_verified_address` is `true`.
+
+The Ory Console additionally turns on `selfservice_flows_registration_after_password_hook_show_verification_ui` when you enable "Require verified address for login" on a project that signs users in after registration. The provider does not infer that for you. Set the attribute yourself if you want that behavior.
 
 ## Account Experience Branding
 
@@ -656,8 +724,10 @@ terraform plan  # verify no changes
 - `selfservice_flows_login_after_default_browser_return_url` (String) Default return URL after login.
 - `selfservice_flows_login_after_lookup_secret_default_browser_return_url` (String) Return URL after login via lookup secret method.
 - `selfservice_flows_login_after_oidc_default_browser_return_url` (String) Return URL after login via OIDC.
+- `selfservice_flows_login_after_oidc_hook_require_verified_address` (Boolean) Enable the `require_verified_address` hook after an OIDC (social) login, blocking sign-in until the identity has a verified address. The Ory Console "Require verified address for login" toggle only writes the password flow, so set this attribute as well to cover social logins. Existing hooks at this path (e.g., `organization`) are preserved.
 - `selfservice_flows_login_after_passkey_default_browser_return_url` (String) Return URL after login via passkey.
 - `selfservice_flows_login_after_password_default_browser_return_url` (String) Return URL after login via password.
+- `selfservice_flows_login_after_password_hook_require_verified_address` (Boolean) Enable the `require_verified_address` hook after a password login, blocking sign-in until the identity has a verified address. Mirrors the Ory Console "Require verified address for login" toggle. Use `feature_flags_legacy_require_verified_login_error` to control how the failure is reported, not whether the check runs. Existing hooks at this path (e.g., `organization`) are preserved.
 - `selfservice_flows_login_after_totp_default_browser_return_url` (String) Return URL after login via TOTP.
 - `selfservice_flows_login_after_webauthn_default_browser_return_url` (String) Return URL after login via WebAuthn.
 - `selfservice_flows_login_lifespan` (String) Lifespan of the login flow (e.g. '1h').
@@ -690,7 +760,10 @@ terraform plan  # verify no changes
 - `selfservice_flows_settings_after_passkey_default_browser_return_url` (String) Return URL after updating passkey in settings.
 - `selfservice_flows_settings_after_password_default_browser_return_url` (String) Return URL after updating password in settings.
 - `selfservice_flows_settings_after_profile_default_browser_return_url` (String) Return URL after updating profile in settings.
+- `selfservice_flows_settings_after_profile_hook_notify_previous_addresses` (Boolean) Enable the `notify_previous_addresses` hook after a profile settings update, emailing the identity's previous addresses when its verified addresses change. Mirrors the Ory Console "Notify previous addresses" toggle. Existing hooks at this path (e.g., `organization`) are preserved.
+- `selfservice_flows_settings_after_profile_hook_notify_previous_addresses_recipients` (String) Which previous addresses the `notify_previous_addresses` hook notifies: `removed` for addresses that no longer exist after the change, `all_verified` for every address verified before the change, or `all` for every address on the identity before the change. Requires `selfservice_flows_settings_after_profile_hook_notify_previous_addresses = true`. When unset, the Ory default of `removed` applies.
 - `selfservice_flows_settings_after_profile_hook_show_verification_ui` (Boolean) Enable the `show_verification_ui` hook after a successful profile settings update. When true, users are redirected to the verification UI after updating their profile (e.g., changing their email). Existing hooks at this path (e.g., `organization`) are preserved.
+- `selfservice_flows_settings_after_profile_hook_verify_new_address` (Boolean) Enable the `verify_new_address` hook after a profile settings update, requiring verification of an address the user just added or changed. Mirrors the Ory Console "Verify new addresses" toggle. Distinct from `selfservice_flows_settings_after_profile_hook_show_verification_ui`, which only controls the redirect to the verification UI. Existing hooks at this path (e.g., `organization`) are preserved.
 - `selfservice_flows_settings_after_totp_default_browser_return_url` (String) Return URL after updating TOTP in settings.
 - `selfservice_flows_settings_after_webauthn_default_browser_return_url` (String) Return URL after updating WebAuthn in settings.
 - `selfservice_flows_settings_lifespan` (String) Lifespan of the settings flow (e.g., '30m0s'). Controls how long a settings flow session remains valid.

--- a/examples/resources/ory_project_config/resource.tf
+++ b/examples/resources/ory_project_config/resource.tf
@@ -289,8 +289,37 @@ resource "ory_project_config" "show_verification_ui" {
   selfservice_flows_registration_after_password_hook_show_verification_ui = true
   # Same for social (OIDC) registration.
   selfservice_flows_registration_after_oidc_hook_show_verification_ui = true
-  # When users change their email in profile settings, force re-verification.
+  # After a profile settings update, redirect users to the verification UI.
+  # This only controls the redirect. To gate the address change itself on
+  # verification, see selfservice_flows_settings_after_profile_hook_verify_new_address
+  # below.
   selfservice_flows_settings_after_profile_hook_show_verification_ui = true
+}
+
+# The three toggles on the Ory Console "Email verification" page. Like the
+# hooks above, each one is an entry in a flow's hooks array, so other hooks at
+# the same path are preserved.
+resource "ory_project_config" "email_verification_hooks" {
+  selfservice_flows_verification_enabled = true
+
+  # "Require verified address for login": block sign-in until the identity has
+  # a verified address. feature_flags_legacy_require_verified_login_error only
+  # changes how the failure is reported, it does not enable the check.
+  #
+  # The Ory Console toggle writes the password flow only. Set the OIDC flow too
+  # to cover social logins.
+  selfservice_flows_login_after_password_hook_require_verified_address = true
+  selfservice_flows_login_after_oidc_hook_require_verified_address     = true
+
+  # "Verify new addresses": require verification of an address the user just
+  # added or changed in profile settings.
+  selfservice_flows_settings_after_profile_hook_verify_new_address = true
+
+  # "Notify previous addresses": email the identity's previous addresses when
+  # its verified addresses change. Recipients is one of "removed" (the Ory
+  # default), "all_verified", or "all".
+  selfservice_flows_settings_after_profile_hook_notify_previous_addresses            = true
+  selfservice_flows_settings_after_profile_hook_notify_previous_addresses_recipients = "all_verified"
 }
 
 # Automatically sign users in after they register with email + password.

--- a/internal/resources/projectconfig/build_patches_test.go
+++ b/internal/resources/projectconfig/build_patches_test.go
@@ -1027,3 +1027,65 @@ func TestBuildHookPatches_EmailVerificationHooksMergedAtProfilePath(t *testing.T
 	assert.Equal(t, 1, seen["show_verification_ui"])
 	assert.Equal(t, 1, seen["organization"])
 }
+
+// Kratos runs a flow's hooks in list order, so the order the provider writes is
+// part of its contract rather than an accident of the merge. Every hook is
+// prepended as it is added, which is what the Ory Console does too, so the
+// merged array comes out in reverse hookEntries order with pre-existing hooks
+// last. Changing hookEntries order therefore changes execution order.
+func TestBuildHookPatches_MergedProfileHookOrderIsStable(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsSettingsAfterProfileHookShowVerificationUI:      types.BoolValue(true),
+		SelfserviceFlowsSettingsAfterProfileHookVerifyNewAddress:        types.BoolValue(true),
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses: types.BoolValue(true),
+	}
+	current := settingsAfterProfileProject(map[string]interface{}{"hook": "organization"})
+
+	patches := buildHookPatches(plan, current)
+	require.Len(t, patches, 1)
+	hooks, _ := patches[0].Value.([]map[string]interface{})
+
+	names := make([]string, 0, len(hooks))
+	for _, h := range hooks {
+		name, _ := h["hook"].(string)
+		names = append(names, name)
+	}
+	assert.Equal(t, []string{
+		"notify_previous_addresses",
+		"verify_new_address",
+		"show_verification_ui",
+		"organization",
+	}, names)
+}
+
+// require_verified_address must run before anything else on its login flow, so
+// it stays at the head of the array even when other hooks are already there.
+func TestBuildHookPatches_RequireVerifiedAddressStaysFirstAmongExistingHooks(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsLoginAfterPasswordHookRequireVerifiedAddress: types.BoolValue(true),
+	}
+	current := projectWithIdentityConfig(map[string]interface{}{
+		"selfservice": map[string]interface{}{
+			"flows": map[string]interface{}{
+				"login": map[string]interface{}{
+					"after": map[string]interface{}{
+						"password": map[string]interface{}{
+							"hooks": []interface{}{
+								map[string]interface{}{"hook": "revoke_active_sessions"},
+								map[string]interface{}{"hook": "organization"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	patches := buildHookPatches(plan, current)
+	require.Len(t, patches, 1)
+	hooks, _ := patches[0].Value.([]map[string]interface{})
+	require.Len(t, hooks, 3)
+	assert.Equal(t, "require_verified_address", hooks[0]["hook"])
+	assert.Equal(t, "revoke_active_sessions", hooks[1]["hook"])
+	assert.Equal(t, "organization", hooks[2]["hook"])
+}

--- a/internal/resources/projectconfig/build_patches_test.go
+++ b/internal/resources/projectconfig/build_patches_test.go
@@ -750,3 +750,280 @@ func TestBuildHookPatches_MultipleHooksAtSamePathMerged(t *testing.T) {
 	assert.Equal(t, 1, seen["session"], "expected session to be present once")
 	assert.Equal(t, 1, seen["organization"], "expected organization to be preserved")
 }
+
+// settingsAfterProfileProject builds a project whose settings.after.profile
+// hooks array holds the given entries.
+func settingsAfterProfileProject(hooks ...interface{}) *ory.Project {
+	return projectWithIdentityConfig(map[string]interface{}{
+		"selfservice": map[string]interface{}{
+			"flows": map[string]interface{}{
+				"settings": map[string]interface{}{
+					"after": map[string]interface{}{
+						"profile": map[string]interface{}{
+							"hooks": hooks,
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+// hookByName returns the hooks-array entry with the given name.
+func hookByName(t *testing.T, hooks []map[string]interface{}, name string) map[string]interface{} {
+	t.Helper()
+	for _, h := range hooks {
+		if h["hook"] == name {
+			return h
+		}
+	}
+	t.Fatalf("hook %q not found in %v", name, hooks)
+	return nil
+}
+
+// The Ory Console writes require_verified_address to the password login flow,
+// and it must run before any other hook on that flow.
+func TestBuildHookPatches_RequireVerifiedAddressAddedFirst(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsLoginAfterPasswordHookRequireVerifiedAddress: types.BoolValue(true),
+	}
+	current := projectWithIdentityConfig(map[string]interface{}{
+		"selfservice": map[string]interface{}{
+			"flows": map[string]interface{}{
+				"login": map[string]interface{}{
+					"after": map[string]interface{}{
+						"password": map[string]interface{}{
+							"hooks": []interface{}{
+								map[string]interface{}{"hook": "organization"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	patches := buildHookPatches(plan, current)
+	require.Len(t, patches, 1)
+	assert.Equal(t, "/services/identity/config/selfservice/flows/login/after/password/hooks", patches[0].Path)
+	hooks, ok := patches[0].Value.([]map[string]interface{})
+	require.True(t, ok, "expected []map[string]interface{} value, got %T", patches[0].Value)
+	require.Len(t, hooks, 2)
+	assert.Equal(t, "require_verified_address", hooks[0]["hook"], "expected require_verified_address first")
+	assert.Equal(t, "organization", hooks[1]["hook"], "expected organization preserved")
+	assert.NotContains(t, hooks[0], "config", "require_verified_address carries no config")
+}
+
+// The password and OIDC login flows have separate hooks arrays, so the two
+// attributes must produce two independent patches.
+func TestBuildHookPatches_RequireVerifiedAddressPasswordAndOIDCAreSeparate(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsLoginAfterPasswordHookRequireVerifiedAddress: types.BoolValue(true),
+		SelfserviceFlowsLoginAfterOIDCHookRequireVerifiedAddress:     types.BoolValue(false),
+	}
+	current := projectWithIdentityConfig(map[string]interface{}{
+		"selfservice": map[string]interface{}{
+			"flows": map[string]interface{}{
+				"login": map[string]interface{}{
+					"after": map[string]interface{}{
+						"password": map[string]interface{}{"hooks": []interface{}{}},
+						"oidc": map[string]interface{}{
+							"hooks": []interface{}{
+								map[string]interface{}{"hook": "require_verified_address"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	patches := buildHookPatches(plan, current)
+	require.Len(t, patches, 2, "expected one patch per login flow")
+
+	password := findPatch(patches, "/services/identity/config/selfservice/flows/login/after/password/hooks")
+	require.NotNil(t, password)
+	passwordHooks, _ := password.Value.([]map[string]interface{})
+	require.Len(t, passwordHooks, 1)
+	assert.Equal(t, "require_verified_address", passwordHooks[0]["hook"])
+
+	oidc := findPatch(patches, "/services/identity/config/selfservice/flows/login/after/oidc/hooks")
+	require.NotNil(t, oidc)
+	oidcHooks, _ := oidc.Value.([]map[string]interface{})
+	assert.Empty(t, oidcHooks, "expected the OIDC hook to be removed")
+}
+
+func TestBuildHookPatches_RequireVerifiedAddressRemoveKeepsOthers(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsLoginAfterPasswordHookRequireVerifiedAddress: types.BoolValue(false),
+	}
+	current := projectWithIdentityConfig(map[string]interface{}{
+		"selfservice": map[string]interface{}{
+			"flows": map[string]interface{}{
+				"login": map[string]interface{}{
+					"after": map[string]interface{}{
+						"password": map[string]interface{}{
+							"hooks": []interface{}{
+								map[string]interface{}{"hook": "require_verified_address"},
+								map[string]interface{}{"hook": "organization"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	patches := buildHookPatches(plan, current)
+	require.Len(t, patches, 1)
+	hooks, _ := patches[0].Value.([]map[string]interface{})
+	require.Len(t, hooks, 1)
+	assert.Equal(t, "organization", hooks[0]["hook"])
+}
+
+func TestBuildHookPatches_VerifyNewAddressAdded(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsSettingsAfterProfileHookVerifyNewAddress: types.BoolValue(true),
+	}
+	current := settingsAfterProfileProject(map[string]interface{}{"hook": "organization"})
+
+	patches := buildHookPatches(plan, current)
+	require.Len(t, patches, 1)
+	assert.Equal(t, "/services/identity/config/selfservice/flows/settings/after/profile/hooks", patches[0].Path)
+	hooks, _ := patches[0].Value.([]map[string]interface{})
+	require.Len(t, hooks, 2)
+	assert.NotContains(t, hookByName(t, hooks, "verify_new_address"), "config", "verify_new_address carries no config")
+}
+
+// verify_new_address and show_verification_ui share a hooks array but are
+// distinct toggles: enabling one must not imply the other.
+func TestBuildHookPatches_VerifyNewAddressIndependentOfShowVerificationUI(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsSettingsAfterProfileHookVerifyNewAddress:   types.BoolValue(true),
+		SelfserviceFlowsSettingsAfterProfileHookShowVerificationUI: types.BoolValue(false),
+	}
+	current := settingsAfterProfileProject(map[string]interface{}{"hook": "show_verification_ui"})
+
+	patches := buildHookPatches(plan, current)
+	require.Len(t, patches, 1, "expected one merged patch for the profile hooks path")
+	hooks, _ := patches[0].Value.([]map[string]interface{})
+	require.Len(t, hooks, 1)
+	assert.Equal(t, "verify_new_address", hooks[0]["hook"])
+}
+
+func TestBuildHookPatches_NotifyPreviousAddressesWithRecipients(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses:           types.BoolValue(true),
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddressesRecipients: types.StringValue("all_verified"),
+	}
+	current := settingsAfterProfileProject()
+
+	patches := buildHookPatches(plan, current)
+	require.Len(t, patches, 1)
+	hooks, _ := patches[0].Value.([]map[string]interface{})
+	require.Len(t, hooks, 1)
+	assert.Equal(t, "notify_previous_addresses", hooks[0]["hook"])
+	assert.Equal(t, map[string]interface{}{"recipients": "all_verified"}, hooks[0]["config"])
+}
+
+// Without an explicit recipient scope the hook is written bare, which lets Ory
+// apply its own default instead of the provider inventing one.
+func TestBuildHookPatches_NotifyPreviousAddressesWithoutRecipientsOmitsConfig(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses: types.BoolValue(true),
+	}
+	current := settingsAfterProfileProject()
+
+	patches := buildHookPatches(plan, current)
+	require.Len(t, patches, 1)
+	hooks, _ := patches[0].Value.([]map[string]interface{})
+	require.Len(t, hooks, 1)
+	assert.NotContains(t, hooks[0], "config", "expected no config key when recipients is unset")
+}
+
+// Changing the recipient scope updates the existing entry in place rather than
+// leaving the old scope behind.
+func TestBuildHookPatches_NotifyPreviousAddressesRecipientsUpdatedInPlace(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses:           types.BoolValue(true),
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddressesRecipients: types.StringValue("all"),
+	}
+	current := settingsAfterProfileProject(
+		map[string]interface{}{
+			"hook":   "notify_previous_addresses",
+			"config": map[string]interface{}{"recipients": "removed"},
+		},
+		map[string]interface{}{"hook": "organization"},
+	)
+
+	patches := buildHookPatches(plan, current)
+	require.Len(t, patches, 1)
+	hooks, _ := patches[0].Value.([]map[string]interface{})
+	require.Len(t, hooks, 2, "expected no duplicate notify_previous_addresses entry")
+	notify := hookByName(t, hooks, "notify_previous_addresses")
+	assert.Equal(t, map[string]interface{}{"recipients": "all"}, notify["config"])
+	assert.Equal(t, "organization", hooks[1]["hook"], "expected organization preserved")
+}
+
+// An unset recipients attribute means "not managed here", so an existing scope
+// on the project is left alone.
+func TestBuildHookPatches_NotifyPreviousAddressesPreservesExistingConfigWhenUnset(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses: types.BoolValue(true),
+	}
+	current := settingsAfterProfileProject(map[string]interface{}{
+		"hook":   "notify_previous_addresses",
+		"config": map[string]interface{}{"recipients": "all_verified"},
+	})
+
+	patches := buildHookPatches(plan, current)
+	require.Len(t, patches, 1)
+	hooks, _ := patches[0].Value.([]map[string]interface{})
+	require.Len(t, hooks, 1)
+	assert.Equal(t, map[string]interface{}{"recipients": "all_verified"}, hooks[0]["config"])
+}
+
+func TestBuildHookPatches_NotifyPreviousAddressesRemoved(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses: types.BoolValue(false),
+	}
+	current := settingsAfterProfileProject(
+		map[string]interface{}{
+			"hook":   "notify_previous_addresses",
+			"config": map[string]interface{}{"recipients": "all"},
+		},
+		map[string]interface{}{"hook": "verify_new_address"},
+	)
+
+	patches := buildHookPatches(plan, current)
+	require.Len(t, patches, 1)
+	hooks, _ := patches[0].Value.([]map[string]interface{})
+	require.Len(t, hooks, 1)
+	assert.Equal(t, "verify_new_address", hooks[0]["hook"])
+}
+
+// All three email-verification toggles that share the profile hooks array must
+// land in a single patch.
+func TestBuildHookPatches_EmailVerificationHooksMergedAtProfilePath(t *testing.T) {
+	plan := &ProjectConfigResourceModel{
+		SelfserviceFlowsSettingsAfterProfileHookVerifyNewAddress:                  types.BoolValue(true),
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses:           types.BoolValue(true),
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddressesRecipients: types.StringValue("removed"),
+		SelfserviceFlowsSettingsAfterProfileHookShowVerificationUI:                types.BoolValue(true),
+	}
+	current := settingsAfterProfileProject(map[string]interface{}{"hook": "organization"})
+
+	patches := buildHookPatches(plan, current)
+	require.Len(t, patches, 1, "expected exactly 1 merged patch for the profile hooks path")
+	hooks, _ := patches[0].Value.([]map[string]interface{})
+	seen := map[string]int{}
+	for _, h := range hooks {
+		if name, ok := h["hook"].(string); ok {
+			seen[name]++
+		}
+	}
+	assert.Equal(t, 1, seen["verify_new_address"])
+	assert.Equal(t, 1, seen["notify_previous_addresses"])
+	assert.Equal(t, 1, seen["show_verification_ui"])
+	assert.Equal(t, 1, seen["organization"])
+}

--- a/internal/resources/projectconfig/hooks_read_test.go
+++ b/internal/resources/projectconfig/hooks_read_test.go
@@ -1,0 +1,149 @@
+package projectconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	ory "github.com/ory/client-go"
+	"github.com/stretchr/testify/assert"
+)
+
+// readStateFromHooks runs the resource read path over a project whose
+// settings.after.profile and login.after.password hook arrays hold the given
+// entries. The OIDC login flow mirrors the password flow, so a caller that
+// only cares about the password flow still exercises both.
+func readStateFromHooks(state *ProjectConfigResourceModel, loginPasswordHooks, settingsProfileHooks []interface{}) {
+	project := &ory.Project{
+		Services: ory.ProjectServices{
+			Identity: &ory.ProjectServiceIdentity{
+				Config: map[string]interface{}{
+					"selfservice": map[string]interface{}{
+						"flows": map[string]interface{}{
+							"login": map[string]interface{}{
+								"after": map[string]interface{}{
+									"password": map[string]interface{}{"hooks": loginPasswordHooks},
+									"oidc":     map[string]interface{}{"hooks": loginPasswordHooks},
+								},
+							},
+							"settings": map[string]interface{}{
+								"after": map[string]interface{}{
+									"profile": map[string]interface{}{"hooks": settingsProfileHooks},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	(&ProjectConfigResource{}).readProjectConfig(context.Background(), project, state)
+}
+
+func TestReadProjectConfig_EmailVerificationHooksPresent(t *testing.T) {
+	state := &ProjectConfigResourceModel{
+		SelfserviceFlowsLoginAfterPasswordHookRequireVerifiedAddress:    types.BoolValue(false),
+		SelfserviceFlowsLoginAfterOIDCHookRequireVerifiedAddress:        types.BoolValue(false),
+		SelfserviceFlowsSettingsAfterProfileHookVerifyNewAddress:        types.BoolValue(false),
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses: types.BoolValue(false),
+	}
+
+	readStateFromHooks(state,
+		[]interface{}{map[string]interface{}{"hook": "require_verified_address"}},
+		[]interface{}{
+			map[string]interface{}{"hook": "verify_new_address"},
+			map[string]interface{}{"hook": "notify_previous_addresses"},
+		},
+	)
+
+	assert.True(t, state.SelfserviceFlowsLoginAfterPasswordHookRequireVerifiedAddress.ValueBool())
+	assert.True(t, state.SelfserviceFlowsLoginAfterOIDCHookRequireVerifiedAddress.ValueBool())
+	assert.True(t, state.SelfserviceFlowsSettingsAfterProfileHookVerifyNewAddress.ValueBool())
+	assert.True(t, state.SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses.ValueBool())
+}
+
+// A hook removed out of band shows up as false rather than staying true.
+func TestReadProjectConfig_EmailVerificationHooksAbsent(t *testing.T) {
+	state := &ProjectConfigResourceModel{
+		SelfserviceFlowsLoginAfterPasswordHookRequireVerifiedAddress:    types.BoolValue(true),
+		SelfserviceFlowsLoginAfterOIDCHookRequireVerifiedAddress:        types.BoolValue(true),
+		SelfserviceFlowsSettingsAfterProfileHookVerifyNewAddress:        types.BoolValue(true),
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses: types.BoolValue(true),
+	}
+
+	readStateFromHooks(state, []interface{}{}, []interface{}{map[string]interface{}{"hook": "organization"}})
+
+	assert.False(t, state.SelfserviceFlowsLoginAfterPasswordHookRequireVerifiedAddress.ValueBool())
+	assert.False(t, state.SelfserviceFlowsLoginAfterOIDCHookRequireVerifiedAddress.ValueBool())
+	assert.False(t, state.SelfserviceFlowsSettingsAfterProfileHookVerifyNewAddress.ValueBool())
+	assert.False(t, state.SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses.ValueBool())
+}
+
+// An attribute the practitioner never set stays null, so an untracked hook
+// does not start showing up as drift.
+func TestReadProjectConfig_UntrackedEmailVerificationHooksStayNull(t *testing.T) {
+	state := &ProjectConfigResourceModel{}
+
+	readStateFromHooks(state,
+		[]interface{}{map[string]interface{}{"hook": "require_verified_address"}},
+		[]interface{}{
+			map[string]interface{}{"hook": "verify_new_address"},
+			map[string]interface{}{
+				"hook":   "notify_previous_addresses",
+				"config": map[string]interface{}{"recipients": "all"},
+			},
+		},
+	)
+
+	assert.True(t, state.SelfserviceFlowsLoginAfterPasswordHookRequireVerifiedAddress.IsNull())
+	assert.True(t, state.SelfserviceFlowsLoginAfterOIDCHookRequireVerifiedAddress.IsNull())
+	assert.True(t, state.SelfserviceFlowsSettingsAfterProfileHookVerifyNewAddress.IsNull())
+	assert.True(t, state.SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses.IsNull())
+	assert.True(t, state.SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddressesRecipients.IsNull())
+}
+
+func TestReadProjectConfig_NotifyPreviousAddressesRecipientsRefreshed(t *testing.T) {
+	state := &ProjectConfigResourceModel{
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses:           types.BoolValue(true),
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddressesRecipients: types.StringValue("removed"),
+	}
+
+	readStateFromHooks(state, nil, []interface{}{
+		map[string]interface{}{
+			"hook":   "notify_previous_addresses",
+			"config": map[string]interface{}{"recipients": "all_verified"},
+		},
+	})
+
+	assert.Equal(t, "all_verified", state.SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddressesRecipients.ValueString())
+}
+
+// Ory drops the config key when the hook runs with its default scope, which
+// must read back as that default instead of an empty string.
+func TestReadProjectConfig_NotifyPreviousAddressesMissingConfigReadsAsDefault(t *testing.T) {
+	state := &ProjectConfigResourceModel{
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses:           types.BoolValue(true),
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddressesRecipients: types.StringValue("all"),
+	}
+
+	readStateFromHooks(state, nil, []interface{}{
+		map[string]interface{}{"hook": "notify_previous_addresses"},
+	})
+
+	assert.Equal(t, notifyPreviousAddressesDefaultRecipients,
+		state.SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddressesRecipients.ValueString())
+}
+
+// With the hook gone there is no scope to read, so the tracked scope is left
+// as configured and the boolean alone reports the divergence.
+func TestReadProjectConfig_NotifyPreviousAddressesRecipientsKeptWhenHookAbsent(t *testing.T) {
+	state := &ProjectConfigResourceModel{
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses:           types.BoolValue(true),
+		SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddressesRecipients: types.StringValue("all"),
+	}
+
+	readStateFromHooks(state, nil, []interface{}{})
+
+	assert.False(t, state.SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses.ValueBool())
+	assert.Equal(t, "all", state.SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddressesRecipients.ValueString())
+}

--- a/internal/resources/projectconfig/resource.go
+++ b/internal/resources/projectconfig/resource.go
@@ -852,8 +852,9 @@ func (r *ProjectConfigResource) Schema(ctx context.Context, req resource.SchemaR
 		Description: "Which previous addresses the `notify_previous_addresses` hook notifies: " +
 			"`removed` for addresses that no longer exist after the change, `all_verified` for every address " +
 			"verified before the change, or `all` for every address on the identity before the change. " +
-			"Requires `selfservice_flows_settings_after_profile_hook_notify_previous_addresses = true`. " +
-			"When unset, the Ory default of `removed` applies.",
+			"Requires `selfservice_flows_settings_after_profile_hook_notify_previous_addresses` to be set. " +
+			"Leave this attribute out to let Ory apply its own default of `removed`. Note that removing it " +
+			"after a scope was already applied stops managing the scope rather than resetting it.",
 		Optional: true,
 		Validators: []validator.String{
 			stringvalidator.OneOf("removed", "all_verified", "all"),
@@ -1272,6 +1273,11 @@ type hookEntry struct {
 	SetConfig func(state *ProjectConfigResourceModel, config map[string]interface{})
 }
 
+// The order of this slice is part of the provider's contract: Kratos runs a
+// flow's hooks in list order, and buildHookPatches prepends each hook as it is
+// added, so entries sharing a path end up in reverse order of their appearance
+// here. See TestBuildHookPatches_MergedProfileHookOrderIsStable.
+//
 // hookEntries returns every hook attribute the provider exposes. Adding a new
 // hook toggle is a matter of appending one entry here, declaring the model
 // field, and registering the schema attribute.

--- a/internal/resources/projectconfig/resource.go
+++ b/internal/resources/projectconfig/resource.go
@@ -426,6 +426,15 @@ type ProjectConfigResourceModel struct {
 	// the Ory Console "Enable sign in after registration" toggle.
 	SelfserviceFlowsRegistrationAfterPasswordHookSession types.Bool `tfsdk:"selfservice_flows_registration_after_password_hook_session"`
 
+	// Email verification hooks (custom: not in OpenAPI spec). These back the
+	// three toggles on the Ory Console "Email verification" page.
+	SelfserviceFlowsLoginAfterPasswordHookRequireVerifiedAddress types.Bool `tfsdk:"selfservice_flows_login_after_password_hook_require_verified_address"`
+	SelfserviceFlowsLoginAfterOIDCHookRequireVerifiedAddress     types.Bool `tfsdk:"selfservice_flows_login_after_oidc_hook_require_verified_address"`
+	SelfserviceFlowsSettingsAfterProfileHookVerifyNewAddress     types.Bool `tfsdk:"selfservice_flows_settings_after_profile_hook_verify_new_address"`
+
+	SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses           types.Bool   `tfsdk:"selfservice_flows_settings_after_profile_hook_notify_previous_addresses"`
+	SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddressesRecipients types.String `tfsdk:"selfservice_flows_settings_after_profile_hook_notify_previous_addresses_recipients"`
+
 	// Auto-discovered (review naming before release)
 	SelfserviceMethodsDeviceauthnEnabled types.Bool `tfsdk:"selfservice_methods_deviceauthn_enabled"`
 
@@ -801,6 +810,55 @@ func (r *ProjectConfigResource) Schema(ctx context.Context, req resource.SchemaR
 			"\"Enable sign in after registration\" toggle. " +
 			"Existing hooks at this path (e.g., `organization`) are preserved.",
 		Optional: true,
+	}
+
+	// Email verification hooks: the three toggles on the Ory Console
+	// "Email verification" page. Like the hooks above, each one is an entry in
+	// a flow's hooks array rather than a scalar config property.
+	attrs["selfservice_flows_login_after_password_hook_require_verified_address"] = schema.BoolAttribute{
+		Description: "Enable the `require_verified_address` hook after a password login, " +
+			"blocking sign-in until the identity has a verified address. Mirrors the Ory Console " +
+			"\"Require verified address for login\" toggle. " +
+			"Use `feature_flags_legacy_require_verified_login_error` to control how the failure is " +
+			"reported, not whether the check runs. " +
+			"Existing hooks at this path (e.g., `organization`) are preserved.",
+		Optional: true,
+	}
+	attrs["selfservice_flows_login_after_oidc_hook_require_verified_address"] = schema.BoolAttribute{
+		Description: "Enable the `require_verified_address` hook after an OIDC (social) login, " +
+			"blocking sign-in until the identity has a verified address. The Ory Console " +
+			"\"Require verified address for login\" toggle only writes the password flow, so set this " +
+			"attribute as well to cover social logins. " +
+			"Existing hooks at this path (e.g., `organization`) are preserved.",
+		Optional: true,
+	}
+	attrs["selfservice_flows_settings_after_profile_hook_verify_new_address"] = schema.BoolAttribute{
+		Description: "Enable the `verify_new_address` hook after a profile settings update, " +
+			"requiring verification of an address the user just added or changed. Mirrors the Ory Console " +
+			"\"Verify new addresses\" toggle. Distinct from " +
+			"`selfservice_flows_settings_after_profile_hook_show_verification_ui`, which only controls the " +
+			"redirect to the verification UI. " +
+			"Existing hooks at this path (e.g., `organization`) are preserved.",
+		Optional: true,
+	}
+	attrs["selfservice_flows_settings_after_profile_hook_notify_previous_addresses"] = schema.BoolAttribute{
+		Description: "Enable the `notify_previous_addresses` hook after a profile settings update, " +
+			"emailing the identity's previous addresses when its verified addresses change. Mirrors the Ory Console " +
+			"\"Notify previous addresses\" toggle. " +
+			"Existing hooks at this path (e.g., `organization`) are preserved.",
+		Optional: true,
+	}
+	attrs["selfservice_flows_settings_after_profile_hook_notify_previous_addresses_recipients"] = schema.StringAttribute{
+		Description: "Which previous addresses the `notify_previous_addresses` hook notifies: " +
+			"`removed` for addresses that no longer exist after the change, `all_verified` for every address " +
+			"verified before the change, or `all` for every address on the identity before the change. " +
+			"Requires `selfservice_flows_settings_after_profile_hook_notify_previous_addresses = true`. " +
+			"When unset, the Ory default of `removed` applies.",
+		Optional: true,
+		Validators: []validator.String{
+			stringvalidator.OneOf("removed", "all_verified", "all"),
+			stringvalidator.AlsoRequires(path.MatchRoot("selfservice_flows_settings_after_profile_hook_notify_previous_addresses")),
+		},
 	}
 
 	// Courier HTTP Delivery
@@ -1195,11 +1253,23 @@ func (r *ProjectConfigResource) buildPatches(ctx context.Context, plan *ProjectC
 // hookEntry describes one boolean hook attribute: the field on the model, the
 // identity-config path whose hooks array it controls, the hook name within
 // that array, and a setter that writes the read-back value into state.
+//
+// Most hooks are bare `{"hook": "<name>"}` entries. A hook that carries
+// settings also populates Config and SetConfig, which write and read back the
+// entry's "config" object.
 type hookEntry struct {
 	Field    types.Bool
 	PathKeys []string // path under /services/identity/config, ending at the parent of "hooks"
 	HookName string
 	Set      func(state *ProjectConfigResourceModel, value types.Bool)
+
+	// Config is written under the hook entry's "config" key. A nil or empty
+	// map leaves whatever config the hook already has untouched, matching how
+	// the rest of the resource treats unconfigured attributes.
+	Config map[string]interface{}
+	// SetConfig writes a config object read back from the API into state. Nil
+	// for hooks that carry no config.
+	SetConfig func(state *ProjectConfigResourceModel, config map[string]interface{})
 }
 
 // hookEntries returns every hook attribute the provider exposes. Adding a new
@@ -1239,7 +1309,70 @@ func hookEntries(plan *ProjectConfigResourceModel) []hookEntry {
 				s.SelfserviceFlowsRegistrationAfterPasswordHookSession = v
 			},
 		},
+		{
+			// The Ory Console writes this hook to the password login flow only.
+			// The config schema also allows it on the OIDC flow, exposed below.
+			Field:    plan.SelfserviceFlowsLoginAfterPasswordHookRequireVerifiedAddress,
+			PathKeys: []string{"selfservice", "flows", "login", "after", "password"},
+			HookName: "require_verified_address",
+			Set: func(s *ProjectConfigResourceModel, v types.Bool) {
+				s.SelfserviceFlowsLoginAfterPasswordHookRequireVerifiedAddress = v
+			},
+		},
+		{
+			Field:    plan.SelfserviceFlowsLoginAfterOIDCHookRequireVerifiedAddress,
+			PathKeys: []string{"selfservice", "flows", "login", "after", "oidc"},
+			HookName: "require_verified_address",
+			Set: func(s *ProjectConfigResourceModel, v types.Bool) {
+				s.SelfserviceFlowsLoginAfterOIDCHookRequireVerifiedAddress = v
+			},
+		},
+		{
+			Field:    plan.SelfserviceFlowsSettingsAfterProfileHookVerifyNewAddress,
+			PathKeys: []string{"selfservice", "flows", "settings", "after", "profile"},
+			HookName: "verify_new_address",
+			Set: func(s *ProjectConfigResourceModel, v types.Bool) {
+				s.SelfserviceFlowsSettingsAfterProfileHookVerifyNewAddress = v
+			},
+		},
+		{
+			Field:    plan.SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses,
+			PathKeys: []string{"selfservice", "flows", "settings", "after", "profile"},
+			HookName: "notify_previous_addresses",
+			Config:   notifyPreviousAddressesConfig(plan),
+			Set: func(s *ProjectConfigResourceModel, v types.Bool) {
+				s.SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddresses = v
+			},
+			SetConfig: func(s *ProjectConfigResourceModel, config map[string]interface{}) {
+				// Only refresh a recipient scope the practitioner tracks, so an
+				// unset attribute does not start showing drift.
+				if s.SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddressesRecipients.IsNull() {
+					return
+				}
+				recipients, _ := config["recipients"].(string)
+				if recipients == "" {
+					// The hook is present without an explicit scope, so Ory
+					// applies its default.
+					recipients = notifyPreviousAddressesDefaultRecipients
+				}
+				s.SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddressesRecipients = types.StringValue(recipients)
+			},
+		},
 	}
+}
+
+// notifyPreviousAddressesDefaultRecipients is the recipient scope Ory applies
+// when the notify_previous_addresses hook carries no config.
+const notifyPreviousAddressesDefaultRecipients = "removed"
+
+// notifyPreviousAddressesConfig builds the config object for the
+// notify_previous_addresses hook entry, or nil when no scope is configured.
+func notifyPreviousAddressesConfig(plan *ProjectConfigResourceModel) map[string]interface{} {
+	recipients := plan.SelfserviceFlowsSettingsAfterProfileHookNotifyPreviousAddressesRecipients
+	if recipients.IsNull() || recipients.IsUnknown() {
+		return nil
+	}
+	return map[string]interface{}{"recipients": recipients.ValueString()}
 }
 
 // buildHookPatches reconciles every configured hook attribute by merging the
@@ -1281,7 +1414,7 @@ func buildHookPatches(plan *ProjectConfigResourceModel, currentProject *ory.Proj
 			accumulators[pathKey] = acc
 			order = append(order, pathKey)
 		}
-		acc.hooks = setHookPresent(acc.hooks, e.HookName, e.Field.ValueBool())
+		acc.hooks = setHookPresent(acc.hooks, e.HookName, e.Field.ValueBool(), e.Config)
 	}
 
 	for _, pathKey := range order {
@@ -1317,7 +1450,11 @@ func readHookList(identityConfig map[string]interface{}, pathKeys []string) []ma
 // setHookPresent returns a copy of hooks with the given hook name either
 // prepended (if present == true and missing) or removed (if present == false).
 // Other hook entries are preserved in their original order.
-func setHookPresent(hooks []map[string]interface{}, hookName string, present bool) []map[string]interface{} {
+//
+// A non-empty config replaces the config of the matching entry, so a change to
+// a hook's settings applies without removing and re-adding the hook. An empty
+// config leaves an existing entry untouched.
+func setHookPresent(hooks []map[string]interface{}, hookName string, present bool, config map[string]interface{}) []map[string]interface{} {
 	filtered := make([]map[string]interface{}, 0, len(hooks)+1)
 	alreadyPresent := false
 	for _, h := range hooks {
@@ -1327,13 +1464,29 @@ func setHookPresent(hooks []map[string]interface{}, hookName string, present boo
 			if !present {
 				continue
 			}
+			if len(config) > 0 {
+				h = hookMap(hookName, config)
+			}
 		}
 		filtered = append(filtered, h)
 	}
 	if present && !alreadyPresent {
-		filtered = append([]map[string]interface{}{{"hook": hookName}}, filtered...)
+		// Prepended rather than appended: require_verified_address must run
+		// before any other hook on its flow, and the Ory Console orders it the
+		// same way.
+		filtered = append([]map[string]interface{}{hookMap(hookName, config)}, filtered...)
 	}
 	return filtered
+}
+
+// hookMap builds a single hooks-array entry, omitting the "config" key when
+// the hook carries no settings.
+func hookMap(hookName string, config map[string]interface{}) map[string]interface{} {
+	entry := map[string]interface{}{"hook": hookName}
+	if len(config) > 0 {
+		entry["config"] = config
+	}
+	return entry
 }
 
 // hookListContains reports whether the hooks list at the given path includes
@@ -1345,6 +1498,20 @@ func hookListContains(identityConfig map[string]interface{}, pathKeys []string, 
 		}
 	}
 	return false
+}
+
+// readHookConfig returns the "config" object of the named hook at the given
+// path, or nil when the hook is absent or carries no config. Ory omits the key
+// entirely when a hook runs with its defaults.
+func readHookConfig(identityConfig map[string]interface{}, pathKeys []string, hookName string) map[string]interface{} {
+	for _, h := range readHookList(identityConfig, pathKeys) {
+		if name, _ := h["hook"].(string); name != hookName {
+			continue
+		}
+		config, _ := h["config"].(map[string]interface{})
+		return config
+	}
+	return nil
 }
 
 // needsHookPrefetch reports whether any hook attribute is set in the plan, in
@@ -1730,6 +1897,9 @@ func (r *ProjectConfigResource) readProjectConfig(ctx context.Context, project *
 			}
 			present := hookListContains(identityConfig, e.PathKeys, e.HookName)
 			e.Set(state, types.BoolValue(present))
+			if present && e.SetConfig != nil {
+				e.SetConfig(state, readHookConfig(identityConfig, e.PathKeys, e.HookName))
+			}
 		}
 	}
 

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -1147,6 +1147,93 @@ func TestAccProjectConfigResource_showVerificationUIHooks(t *testing.T) {
 	})
 }
 
+func TestAccProjectConfigResource_emailVerificationHooks(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Enable all three Email verification hooks.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/email_verification_hooks.tf.tmpl", map[string]string{
+					"RequireVerifiedAddress":     "true",
+					"RequireVerifiedAddressOIDC": "true",
+					"VerifyNewAddress":           "true",
+					"NotifyPreviousAddresses":    "true",
+					"Recipients":                 "all_verified",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_project_config.test", "id"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_login_after_password_hook_require_verified_address", "true"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_login_after_oidc_hook_require_verified_address", "true"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_settings_after_profile_hook_verify_new_address", "true"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_settings_after_profile_hook_notify_previous_addresses", "true"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_settings_after_profile_hook_notify_previous_addresses_recipients", "all_verified"),
+				),
+			},
+			// Re-apply the same config to confirm no perpetual diff.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/email_verification_hooks.tf.tmpl", map[string]string{
+					"RequireVerifiedAddress":     "true",
+					"RequireVerifiedAddressOIDC": "true",
+					"VerifyNewAddress":           "true",
+					"NotifyPreviousAddresses":    "true",
+					"Recipients":                 "all_verified",
+				}),
+				PlanOnly: true,
+			},
+			// Change only the recipient scope: the hook is updated in place.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/email_verification_hooks.tf.tmpl", map[string]string{
+					"RequireVerifiedAddress":     "true",
+					"RequireVerifiedAddressOIDC": "true",
+					"VerifyNewAddress":           "true",
+					"NotifyPreviousAddresses":    "true",
+					"Recipients":                 "all",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_settings_after_profile_hook_notify_previous_addresses_recipients", "all"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_settings_after_profile_hook_notify_previous_addresses", "true"),
+				),
+			},
+			// Disable the login and notify hooks, keep verify_new_address on.
+			// Both hooks share the profile hooks array, so this also covers a
+			// removal that must not disturb its neighbour.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/email_verification_hooks.tf.tmpl", map[string]string{
+					"RequireVerifiedAddress":     "false",
+					"RequireVerifiedAddressOIDC": "false",
+					"VerifyNewAddress":           "true",
+					"NotifyPreviousAddresses":    "false",
+					"Recipients":                 "all",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_login_after_password_hook_require_verified_address", "false"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_login_after_oidc_hook_require_verified_address", "false"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_settings_after_profile_hook_verify_new_address", "true"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "selfservice_flows_settings_after_profile_hook_notify_previous_addresses", "false"),
+				),
+			},
+			// Import then verify state.
+			{
+				ResourceName:      "ory_project_config.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"selfservice_flows_login_after_password_hook_require_verified_address",
+					"selfservice_flows_login_after_oidc_hook_require_verified_address",
+					"selfservice_flows_settings_after_profile_hook_verify_new_address",
+					"selfservice_flows_settings_after_profile_hook_notify_previous_addresses",
+					"selfservice_flows_settings_after_profile_hook_notify_previous_addresses_recipients",
+					"selfservice_flows_verification_enabled",
+					"cors_enabled",
+					"selfservice_methods_password_config_min_password_length",
+					"smtp_connection_uri",
+				},
+			},
+		},
+	})
+}
+
 func TestAccProjectConfigResource_oauth2Advanced(t *testing.T) {
 	// The pairwise salt is here to cover its read path. The API accepts the write
 	// at oidc.subject_identifiers.pairwise_salt and reports the value back under

--- a/internal/resources/projectconfig/testdata/email_verification_hooks.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/email_verification_hooks.tf.tmpl
@@ -1,0 +1,10 @@
+resource "ory_project_config" "test" {
+  selfservice_flows_verification_enabled = true
+
+  selfservice_flows_login_after_password_hook_require_verified_address = [[ .RequireVerifiedAddress ]]
+  selfservice_flows_login_after_oidc_hook_require_verified_address     = [[ .RequireVerifiedAddressOIDC ]]
+  selfservice_flows_settings_after_profile_hook_verify_new_address     = [[ .VerifyNewAddress ]]
+
+  selfservice_flows_settings_after_profile_hook_notify_previous_addresses            = [[ .NotifyPreviousAddresses ]]
+  selfservice_flows_settings_after_profile_hook_notify_previous_addresses_recipients = "[[ .Recipients ]]"
+}

--- a/templates/resources/project_config.md.tmpl
+++ b/templates/resources/project_config.md.tmpl
@@ -115,13 +115,14 @@ When `true`, the provider adds the `show_verification_ui` hook to the correspond
 
 The three toggles on the Ory Console **Email verification** page are also post-flow hooks, each with its own attribute:
 
-| Ory Console toggle | Attribute |
-|---|---|
-| Require verified address for login | `selfservice_flows_login_after_password_hook_require_verified_address` |
-| Verify new addresses | `selfservice_flows_settings_after_profile_hook_verify_new_address` |
-| Notify previous addresses | `selfservice_flows_settings_after_profile_hook_notify_previous_addresses` |
+| Ory Console toggle | Attribute | Flow |
+|---|---|---|
+| Require verified address for login | `selfservice_flows_login_after_password_hook_require_verified_address` | Password login |
+| (not in the Console) | `selfservice_flows_login_after_oidc_hook_require_verified_address` | Social login |
+| Verify new addresses | `selfservice_flows_settings_after_profile_hook_verify_new_address` | Profile settings |
+| Notify previous addresses | `selfservice_flows_settings_after_profile_hook_notify_previous_addresses` | Profile settings |
 
-The Ory Console toggle writes the password login flow only. The provider also exposes `selfservice_flows_login_after_oidc_hook_require_verified_address` for the social login flow, which the Ory config schema supports but the Console does not surface. Set both to require a verified address on every login path.
+The Ory Console toggle writes the password login flow only. The Ory config schema also supports the hook on the social login flow, so the provider exposes it there too. Set both to require a verified address on every login path.
 
 ```hcl
 resource "ory_project_config" "main" {
@@ -142,9 +143,11 @@ resource "ory_project_config" "main" {
 
 `selfservice_flows_settings_after_profile_hook_notify_previous_addresses_recipients` selects who is notified:
 
-- `removed` notifies only addresses that no longer exist after the change. This is the Ory default and applies when the attribute is unset.
+- `removed` notifies only addresses that no longer exist after the change. This is the Ory default.
 - `all_verified` notifies every address that was verified before the change.
 - `all` notifies every address on the identity before the change.
+
+Leave the attribute out and the provider writes no scope at all, so Ory applies `removed`. Removing the attribute after a scope was already applied is different: the provider stops managing the scope and leaves the project on its current value, in line with how every other optional attribute on this resource behaves. Set it back to `removed` explicitly to return to the default.
 
 -> **`verify_new_address` is not `show_verification_ui`.** `selfservice_flows_settings_after_profile_hook_verify_new_address` gates the address change on verification. `selfservice_flows_settings_after_profile_hook_show_verification_ui` only controls the redirect to the verification UI after the flow. Set both if you want the address gated *and* the user sent to the verification screen.
 

--- a/templates/resources/project_config.md.tmpl
+++ b/templates/resources/project_config.md.tmpl
@@ -111,7 +111,46 @@ Three boolean attributes toggle the [`show_verification_ui`](https://www.ory.com
 
 When `true`, the provider adds the `show_verification_ui` hook to the corresponding flow; when `false`, it removes only that hook. Other hooks at the same path (for example `session` or `organization`) are preserved by reading the current hook list before each apply.
 
-To require a verified address before a user can log in (the "Require verified address for login" toggle in the Ory Console), set `feature_flags_legacy_require_verified_login_error = true`. When that flag is `false`, an unverified user is shown the `show_verification_ui` continuation step instead of receiving a form error.
+## Email Verification Hooks
+
+The three toggles on the Ory Console **Email verification** page are also post-flow hooks, each with its own attribute:
+
+| Ory Console toggle | Attribute |
+|---|---|
+| Require verified address for login | `selfservice_flows_login_after_password_hook_require_verified_address` |
+| Verify new addresses | `selfservice_flows_settings_after_profile_hook_verify_new_address` |
+| Notify previous addresses | `selfservice_flows_settings_after_profile_hook_notify_previous_addresses` |
+
+The Ory Console toggle writes the password login flow only. The provider also exposes `selfservice_flows_login_after_oidc_hook_require_verified_address` for the social login flow, which the Ory config schema supports but the Console does not surface. Set both to require a verified address on every login path.
+
+```hcl
+resource "ory_project_config" "main" {
+  selfservice_flows_verification_enabled = true
+
+  # Block sign-in until the identity has a verified address.
+  selfservice_flows_login_after_password_hook_require_verified_address = true
+  selfservice_flows_login_after_oidc_hook_require_verified_address     = true
+
+  # Require verification of an address the user just added or changed.
+  selfservice_flows_settings_after_profile_hook_verify_new_address = true
+
+  # Email the previous addresses when the verified addresses change.
+  selfservice_flows_settings_after_profile_hook_notify_previous_addresses            = true
+  selfservice_flows_settings_after_profile_hook_notify_previous_addresses_recipients = "all_verified"
+}
+```
+
+`selfservice_flows_settings_after_profile_hook_notify_previous_addresses_recipients` selects who is notified:
+
+- `removed` notifies only addresses that no longer exist after the change. This is the Ory default and applies when the attribute is unset.
+- `all_verified` notifies every address that was verified before the change.
+- `all` notifies every address on the identity before the change.
+
+-> **`verify_new_address` is not `show_verification_ui`.** `selfservice_flows_settings_after_profile_hook_verify_new_address` gates the address change on verification. `selfservice_flows_settings_after_profile_hook_show_verification_ui` only controls the redirect to the verification UI after the flow. Set both if you want the address gated *and* the user sent to the verification screen.
+
+-> **`feature_flags_legacy_require_verified_login_error` is not an enable switch.** It controls how a failed verified-address check is reported, a form error instead of a `continue_with` step. It has no effect unless `selfservice_flows_login_after_password_hook_require_verified_address` is `true`.
+
+The Ory Console additionally turns on `selfservice_flows_registration_after_password_hook_show_verification_ui` when you enable "Require verified address for login" on a project that signs users in after registration. The provider does not infer that for you. Set the attribute yourself if you want that behavior.
 
 ## Account Experience Branding
 


### PR DESCRIPTION
## Description

The Ory Console **Email verification** page has three toggles that write hooks into the identity config. None of them had an `ory_project_config` attribute, so the only way to set them was by hand, per project, which is how environments silently diverge on whether an unverified address can log in.

| Ory Console toggle | Config path written | New attribute |
|---|---|---|
| Require verified address for login | `selfservice.flows.login.after.password.hooks[]` | `selfservice_flows_login_after_password_hook_require_verified_address` |
| Verify new addresses | `selfservice.flows.settings.after.profile.hooks[]` | `selfservice_flows_settings_after_profile_hook_verify_new_address` |
| Notify previous addresses | `selfservice.flows.settings.after.profile.hooks[]` plus `config.recipients` | `selfservice_flows_settings_after_profile_hook_notify_previous_addresses` and `..._recipients` |

These are entries in a hooks array rather than scalar config properties, so the project-config codegen cannot produce them. It reads only the flat properties of `normalizedProjectRevision`, and array membership cannot be expressed as a derived JSON Patch path. `make check-coverage` passes on current main with client-go v1.22.66 and yields none of these, so no dependency bump will surface them. They are hand-written into the existing `hookEntry` framework, alongside the `show_verification_ui` and `session` toggles.

`require_verified_address` is also exposed on the OIDC login flow as `selfservice_flows_login_after_oidc_hook_require_verified_address`. The Ory config schema allows the hook there and the API accepts it, but the Console toggle only ever writes the password flow, which leaves social logins unguarded unless the flow is set explicitly.

`notify_previous_addresses` carries a recipient scope, which `setHookPresent` could not express because it always wrote a bare `{"hook": name}` entry. A hook entry can now carry a config payload, written on add and replaced in place on change, so changing the scope no longer removes and re-adds the hook. Leaving the scope unset writes no config key at all, so Ory applies its own default of `removed`.

### Documentation fix

The docs stated that `feature_flags_legacy_require_verified_login_error = true` enables "Require verified address for login". It does not. That flag only selects how a failed check is reported, a form error instead of a `continue_with` step, and has no effect unless the hook is on. Corrected, along with the example that described `selfservice_flows_settings_after_profile_hook_show_verification_ui` as forcing re-verification on email change, which conflated it with `verify_new_address`.

## Related Issues

Fixes #314

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

**Unit tests.** 20 new tests. `build_patches_test.go` covers add, remove, prepend ordering, idempotent add, the password and OIDC login flows being independent, in-place scope change, config omitted when the scope is unset, an existing scope preserved when the attribute is unset, and all profile-path hooks merging into one patch. `hooks_read_test.go` covers read-back present and absent, untracked attributes staying null, scope refresh, and a missing config key reading back as the Ory default.

**Manual API testing.** Against a throwaway project, since the shared test project is in use. All four hooks `PATCH` with HTTP 200 and survive a fresh `GET`:

```
login.after.password:   [{"hook": "require_verified_address"}]
login.after.oidc:       [{"hook": "require_verified_address"}]
settings.after.profile: [{"hook": "verify_new_address"},
                         {"hook": "notify_previous_addresses",
                          "config": {"recipients": "all_verified"}}]
```

Changing the scope to `all` updates the entry in place. A bare `notify_previous_addresses` with no config reads back with no `config` key, which is what the default-scope read path expects. Removing one hook from the profile array leaves its neighbour intact. The probe project was deleted afterwards.

**Acceptance tests.** `TestAccProjectConfigResource_emailVerificationHooks` covers enable all, no-diff re-apply, recipient scope change, partial disable, and import verify.

```
--- PASS: TestAccProjectConfigResource_emailVerificationHooks (22.78s)
ok  github.com/ory/terraform-provider-ory/internal/resources/projectconfig  23.739s
```

The neighbouring hook tests were re-run for regressions:

```
--- PASS: TestAccProjectConfigResource_sessionHookOnPasswordRegistration (14.02s)
--- PASS: TestAccProjectConfigResource_showVerificationUIHooks (5.69s)
```

`make lint` and `make sec` both report clean.

## Screenshots/Output

Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration options requiring verified email addresses for password and OIDC login.
  * Added verification for newly added profile addresses.
  * Added notifications to previously verified addresses, with configurable recipient settings.
  * Added support for verification UI redirects after profile updates.

* **Documentation**
  * Expanded project configuration guidance with examples, supported settings, defaults, and clarification of verification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->