### PR TITLE
fix(project-config): resolve courier body storage URL on read

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,6 +330,7 @@ That's it — the field appears in the Terraform schema, JSON Patch operations, 
 | `sensitive` | No | If `true`, value is masked in Terraform output |
 | `skip_empty_read` | No | If `true`, skip reading empty strings from API (used for account_experience fields) |
 | `write_only` | No | If `true`, the attribute is sent on create/update but never read back from the API. Use for secrets the API does not return (or returns masked, e.g. `****`), so the configured value is always preserved and never produces a spurious diff |
+| `storage_url_content` | No | If `true`, the read path resolves an object-storage URL back to the configured `base64://` value. Use for a Jsonnet payload the API uploads and then reports as `https://storage.googleapis.com/.../<sha512>.jsonnet`. `string` only, and not combinable with `write_only` |
 | `validators` | No | `one_of: [...]` or `regex: "..."` + `regex_message: "..."` |
 | `deprecated_name` | No | Old terraform attribute name (shows deprecation warning in Terraform) |
 | `deprecated_go_field` | No | Old Go struct field name for the deprecated attribute |
@@ -408,6 +409,14 @@ These require hand-written code in `resource.go` because they have non-trivial s
 > secrets in project-config responses, so the provider sends them on create/update but
 > never reads them back — this keeps them from showing a perpetual diff if the API
 > returns an empty value or a masked sentinel.
+
+> **Note:** `courier_http_request_config_body` is codegen'd with
+> `storage_url_content: true`. The API uploads the decoded `base64://` payload to
+> object storage and reports an `https://storage.googleapis.com/.../<sha512>.jsonnet`
+> URL, so the read path resolves that URL back to the configured value. The
+> resolver lives in `resolveStorageURLContent` in `helpers.go`. It compares the
+> hash in the URL with the payload in state, and only downloads the stored payload
+> when the hash differs.
 
 ### Adding a New Resource
 

--- a/docs/resources/project_config.md
+++ b/docs/resources/project_config.md
@@ -277,6 +277,30 @@ resource "ory_project_config" "with_courier_http" {
   ]
 }
 
+locals {
+  courier_body = <<-JSONNET
+    {
+      "recipient": {{ .recipient }},
+      "subject": {{ .subject }},
+      "body": {{ .body }}
+    }
+  JSONNET
+}
+
+# The same courier HTTP delivery through the flat attributes. The body must be a
+# `base64://` value: the Ory API rejects a plain Jsonnet string. The API stores
+# the decoded payload and reports a storage URL, and the provider resolves that
+# URL back to this value, so plan stays empty while the payload matches.
+resource "ory_project_config" "with_courier_http_flat" {
+  courier_delivery_strategy       = "http"
+  courier_http_request_config_url = "https://mail-api.example.com/send"
+
+  courier_http_request_config_body = "base64://${base64encode(local.courier_body)}"
+
+  courier_http_request_config_auth_basic_auth_user     = "mailuser"
+  courier_http_request_config_auth_basic_auth_password = var.mail_password
+}
+
 variable "mail_password" {
   type        = string
   sensitive   = true
@@ -331,6 +355,23 @@ resource "ory_project_config" "sign_in_after_registration" {
   selfservice_flows_registration_after_password_hook_session = true
 }
 ```
+
+## Courier HTTP Request Body
+
+Set `courier_http_request_config_body` to a `base64://` value that carries the Jsonnet template inline. The Ory API rejects a plain Jsonnet string, and it rejects a URL outside its own storage:
+
+```hcl
+resource "ory_project_config" "main" {
+  courier_delivery_strategy       = "http"
+  courier_http_request_config_url = "https://mail.example.com/send"
+
+  courier_http_request_config_body = "base64://${base64encode(file("${path.module}/courier_body.jsonnet"))}"
+}
+```
+
+The API stores the decoded payload and reports an `https://storage.googleapis.com/.../<sha512>.jsonnet` URL instead of the value you set. The provider compares the hash in that URL with your configured payload, so a matching payload produces no change in plan. A payload edited in the Ory Console does not match the hash, so the provider downloads it and plan shows the difference in `base64://` form.
+
+The nested `courier_http_request_config` attribute and each entry in `courier_channels` take the same `base64://` value for their `body` field. For those two, the provider keeps the configured value whenever the API reports a URL, so a payload edited in the Ory Console is not reported as drift.
 
 ## Duration Format
 
@@ -525,7 +566,7 @@ terraform plan  # verify no changes
 - `courier_http_request_config_auth_basic_auth_password` (String, Sensitive) Password for HTTP courier basic authentication.
 - `courier_http_request_config_auth_basic_auth_user` (String) Username for HTTP courier basic authentication.
 - `courier_http_request_config_auth_type` (String) Authentication type for the courier HTTP request (basic_auth, api_key, or empty).
-- `courier_http_request_config_body` (String) Base64-encoded Jsonnet template for the HTTP courier request body.
+- `courier_http_request_config_body` (String) Jsonnet template for the HTTP courier request body, as a `base64://<base64-encoded-payload>` value. The API stores the payload in object storage and reports an https URL back, so the read path resolves that URL to the configured value.
 - `courier_http_request_config_method` (String) HTTP method for the courier HTTP request.
 - `courier_http_request_config_url` (String) URL of the remote HTTP email sending service.
 - `courier_smtp_from_address` (String) Email address to send from.

--- a/examples/resources/ory_project_config/resource.tf
+++ b/examples/resources/ory_project_config/resource.tf
@@ -248,6 +248,30 @@ resource "ory_project_config" "with_courier_http" {
   ]
 }
 
+locals {
+  courier_body = <<-JSONNET
+    {
+      "recipient": {{ .recipient }},
+      "subject": {{ .subject }},
+      "body": {{ .body }}
+    }
+  JSONNET
+}
+
+# The same courier HTTP delivery through the flat attributes. The body must be a
+# `base64://` value: the Ory API rejects a plain Jsonnet string. The API stores
+# the decoded payload and reports a storage URL, and the provider resolves that
+# URL back to this value, so plan stays empty while the payload matches.
+resource "ory_project_config" "with_courier_http_flat" {
+  courier_delivery_strategy       = "http"
+  courier_http_request_config_url = "https://mail-api.example.com/send"
+
+  courier_http_request_config_body = "base64://${base64encode(local.courier_body)}"
+
+  courier_http_request_config_auth_basic_auth_user     = "mailuser"
+  courier_http_request_config_auth_basic_auth_password = var.mail_password
+}
+
 variable "mail_password" {
   type        = string
   sensitive   = true

--- a/internal/codegen/cmd/generate/main.go
+++ b/internal/codegen/cmd/generate/main.go
@@ -48,8 +48,13 @@ type Attribute struct {
 	// differs from the path the value is written to. Reads use it instead of
 	// PatchPath. Always record the verification in a comment next to the
 	// attribute.
-	ReadPath   string     `yaml:"read_path"`
-	Validators *Validator `yaml:"validators"`
+	ReadPath string `yaml:"read_path"`
+	// StorageURLContent marks a string attribute whose content the Ory API
+	// uploads to object storage. The write sends `base64://<payload>` and the
+	// API reports an https URL instead, so Read resolves the URL back to the
+	// configured value. Only valid for `type: string`.
+	StorageURLContent bool       `yaml:"storage_url_content"`
+	Validators        *Validator `yaml:"validators"`
 
 	// Deprecated alias support: when set, generates a second schema attribute
 	// with the old name that shows a deprecation warning directing users to Name.
@@ -372,6 +377,12 @@ func main() {
 		}
 		if a.Description == "" {
 			log.Fatalf("attribute %q: description is required (set it in mappings.yaml or ensure openapi_property points to a spec entry with a description)", a.Name)
+		}
+		if a.StorageURLContent && a.Type != typeString {
+			log.Fatalf("attribute %q: storage_url_content is only supported for type string, got %q", a.Name, a.Type)
+		}
+		if a.StorageURLContent && a.WriteOnly {
+			log.Fatalf("attribute %q: storage_url_content and write_only are mutually exclusive (write_only removes the attribute from the read path)", a.Name)
 		}
 	}
 
@@ -1293,6 +1304,10 @@ type StringReadEntry struct {
 	// and for attributes it accepts but never reports, where a null would show a
 	// diff on every plan that no apply can settle.
 	PreserveOnMissing bool
+	// StorageURL marks a field whose content the API uploads to object storage
+	// and reports back as an https URL. Read resolves that URL to the value the
+	// configuration holds. See resolveStorageURLContent in helpers.go.
+	StorageURL bool
 }
 
 // BoolReadEntry maps a bool state field to its config read path.
@@ -1343,6 +1358,9 @@ func readSimpleFields(ctx context.Context, project *ory.Project, state *ProjectC
 			}
 			if !target.IsNull() {
 				if v, ok := getNestedString({{ varName $svc }}Config, e.Keys...); ok {
+					if e.StorageURL {
+						v = resolveStorageURLContent(ctx, v, target.ValueString())
+					}
 					if !e.SkipEmpty || v != "" {
 						*target = types.StringValue(v)
 					}
@@ -1465,7 +1483,7 @@ func {{ $svc }}StringReadEntries(state *ProjectConfigResourceModel) []StringRead
 	return []StringReadEntry{
 {{- range $strings }}
 {{- if not .WriteOnly }}
-		{&state.{{ .GoField }}, {{ if .DeprecatedGoField }}&state.{{ .DeprecatedGoField }}{{ else }}nil{{ end }}, []string{ {{ readKeys .ReadKeysPath }} }, {{ .SkipEmptyRead }}, {{ .ReadPreservesOnMissing }}},
+		{&state.{{ .GoField }}, {{ if .DeprecatedGoField }}&state.{{ .DeprecatedGoField }}{{ else }}nil{{ end }}, []string{ {{ readKeys .ReadKeysPath }} }, {{ .SkipEmptyRead }}, {{ .ReadPreservesOnMissing }}, {{ .StorageURLContent }}},
 {{- end }}
 {{- end }}
 	}

--- a/internal/codegen/mappings.yaml
+++ b/internal/codegen/mappings.yaml
@@ -774,7 +774,16 @@ attributes:
     go_field: CourierHTTPRequestConfigBody
     type: string
     openapi_property: kratos_courier_http_request_config_body
-    description: "Base64-encoded Jsonnet template for the HTTP courier request body."
+    description: >-
+      Jsonnet template for the HTTP courier request body, as a
+      `base64://<base64-encoded-payload>` value. The API stores the payload in
+      object storage and reports an https URL back, so the read path resolves
+      that URL to the configured value.
+    # The API never echoes the configured value: it uploads the decoded payload
+    # and reports `https://storage.googleapis.com/.../<sha512>.jsonnet`. Copying
+    # that URL into state makes every plan show a diff no apply can settle, so
+    # the read path resolves it. See issue #315.
+    storage_url_content: true
 
   - name: courier_http_request_config_url
     go_field: CourierHTTPRequestConfigURL

--- a/internal/resources/projectconfig/helpers.go
+++ b/internal/resources/projectconfig/helpers.go
@@ -1,5 +1,91 @@
 package projectconfig
 
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/ory/terraform-provider-ory/internal/client"
+	"github.com/ory/terraform-provider-ory/internal/helpers"
+)
+
+// base64ContentPrefix marks a config value that carries its payload inline,
+// base64-encoded, instead of pointing at a URL. The Ory API accepts this form
+// for Jsonnet payloads such as the courier HTTP request body.
+const base64ContentPrefix = "base64://"
+
+// storageURLContentFetcher downloads the payload behind a storage URL the API
+// reported. It is a package-level variable so unit tests can replace it. The
+// default implementation delegates to client.FetchSafeHTTPS, which rejects
+// non-HTTPS schemes, refuses private and loopback hosts, limits redirects, and
+// caps the response body at 1 MiB.
+var storageURLContentFetcher = func(ctx context.Context, rawURL string) ([]byte, error) {
+	return client.FetchSafeHTTPS(ctx, "project config content", rawURL)
+}
+
+// resolveStorageURLContent maps an API value back to the form the configuration
+// holds, for an attribute whose payload the Ory API uploads to object storage.
+//
+// A write sends `base64://<payload>`. The API stores the decoded payload and
+// reports an https URL whose filename is the lowercase hex SHA-512 of that
+// payload. Copying the URL into state makes every later plan show a change,
+// because the configuration still holds the base64 value, and no apply settles
+// it. See https://github.com/ory/terraform-provider-ory/issues/315.
+//
+// The function returns:
+//   - the API value, when it is empty, when it already equals the state value,
+//     or when it is not a storage URL;
+//   - the state value, when the hash in the storage URL matches the payload the
+//     state value carries, because the stored payload is the configured one;
+//   - the downloaded payload re-encoded as `base64://`, when the hash differs,
+//     because the payload changed outside Terraform and the plan must show it;
+//   - the API value, when the download fails, so a transient network error
+//     still surfaces drift instead of hiding it.
+func resolveStorageURLContent(ctx context.Context, apiValue, stateValue string) string {
+	if apiValue == "" || apiValue == stateValue {
+		return apiValue
+	}
+	if _, ok := helpers.HashFromURL(apiValue); !ok {
+		return apiValue
+	}
+	payload, ok := decodeBase64Content(stateValue)
+	if !ok {
+		// State holds a URL rather than an inline payload, so the API value is
+		// already comparable with it.
+		return apiValue
+	}
+	if helpers.URLHashMatchesContent(apiValue, payload) {
+		return stateValue
+	}
+	fetched, err := storageURLContentFetcher(ctx, apiValue)
+	if err != nil {
+		tflog.Warn(ctx, "Keeping the storage URL in state: downloading the stored payload failed",
+			map[string]interface{}{"url": apiValue, "error": err.Error()})
+		return apiValue
+	}
+	return base64ContentPrefix + base64.StdEncoding.EncodeToString(fetched)
+}
+
+// decodeBase64Content decodes a `base64://` config value to its payload. It
+// reports false when the value does not use that form, or when the encoded part
+// is not valid base64. The Ory API accepts both padded and unpadded base64, so
+// both are decoded here.
+func decodeBase64Content(value string) ([]byte, bool) {
+	if !strings.HasPrefix(value, base64ContentPrefix) {
+		return nil, false
+	}
+	encoded := strings.TrimPrefix(value, base64ContentPrefix)
+	if decoded, err := base64.StdEncoding.DecodeString(encoded); err == nil {
+		return decoded, true
+	}
+	if decoded, err := base64.RawStdEncoding.DecodeString(encoded); err == nil {
+		return decoded, true
+	}
+	return nil, false
+}
+
 // getNestedValue safely traverses nested maps to extract a value.
 func getNestedValue(config map[string]interface{}, keys ...string) interface{} {
 	current := interface{}(config)

--- a/internal/resources/projectconfig/read_gen.go
+++ b/internal/resources/projectconfig/read_gen.go
@@ -31,6 +31,10 @@ type StringReadEntry struct {
 	// and for attributes it accepts but never reports, where a null would show a
 	// diff on every plan that no apply can settle.
 	PreserveOnMissing bool
+	// StorageURL marks a field whose content the API uploads to object storage
+	// and reports back as an https URL. Read resolves that URL to the value the
+	// configuration holds. See resolveStorageURLContent in helpers.go.
+	StorageURL bool
 }
 
 // BoolReadEntry maps a bool state field to its config read path.
@@ -76,6 +80,9 @@ func readSimpleFields(ctx context.Context, project *ory.Project, state *ProjectC
 			}
 			if !target.IsNull() {
 				if v, ok := getNestedString(accountExperienceConfig, e.Keys...); ok {
+					if e.StorageURL {
+						v = resolveStorageURLContent(ctx, v, target.ValueString())
+					}
 					if !e.SkipEmpty || v != "" {
 						*target = types.StringValue(v)
 					}
@@ -167,6 +174,9 @@ func readSimpleFields(ctx context.Context, project *ory.Project, state *ProjectC
 			}
 			if !target.IsNull() {
 				if v, ok := getNestedString(identityConfig, e.Keys...); ok {
+					if e.StorageURL {
+						v = resolveStorageURLContent(ctx, v, target.ValueString())
+					}
 					if !e.SkipEmpty || v != "" {
 						*target = types.StringValue(v)
 					}
@@ -273,6 +283,9 @@ func readSimpleFields(ctx context.Context, project *ory.Project, state *ProjectC
 			}
 			if !target.IsNull() {
 				if v, ok := getNestedString(oauth2Config, e.Keys...); ok {
+					if e.StorageURL {
+						v = resolveStorageURLContent(ctx, v, target.ValueString())
+					}
 					if !e.SkipEmpty || v != "" {
 						*target = types.StringValue(v)
 					}
@@ -349,6 +362,9 @@ func readSimpleFields(ctx context.Context, project *ory.Project, state *ProjectC
 			}
 			if !target.IsNull() {
 				if v, ok := getNestedString(permissionConfig, e.Keys...); ok {
+					if e.StorageURL {
+						v = resolveStorageURLContent(ctx, v, target.ValueString())
+					}
 					if !e.SkipEmpty || v != "" {
 						*target = types.StringValue(v)
 					}
@@ -392,11 +408,11 @@ func readSimpleFields(ctx context.Context, project *ory.Project, state *ProjectC
 
 func account_experienceStringReadEntries(state *ProjectConfigResourceModel) []StringReadEntry {
 	return []StringReadEntry{
-		{&state.AccountExperienceLocale, nil, []string{"default_locale"}, true, true},
-		{&state.AccountExperienceLocaleBehavior, nil, []string{"locale_behavior"}, true, true},
-		{&state.AccountExperienceContactURL, nil, []string{"contact_url"}, false, false},
-		{&state.AccountExperiencePrivacyPolicyURL, nil, []string{"privacy_policy_url"}, false, false},
-		{&state.AccountExperienceTermsOfServiceURL, nil, []string{"terms_of_service_url"}, false, false},
+		{&state.AccountExperienceLocale, nil, []string{"default_locale"}, true, true, false},
+		{&state.AccountExperienceLocaleBehavior, nil, []string{"locale_behavior"}, true, true, false},
+		{&state.AccountExperienceContactURL, nil, []string{"contact_url"}, false, false, false},
+		{&state.AccountExperiencePrivacyPolicyURL, nil, []string{"privacy_policy_url"}, false, false, false},
+		{&state.AccountExperienceTermsOfServiceURL, nil, []string{"terms_of_service_url"}, false, false, false},
 	}
 }
 
@@ -424,79 +440,79 @@ func account_experienceMapStringReadEntries(state *ProjectConfigResourceModel) [
 
 func identityStringReadEntries(state *ProjectConfigResourceModel) []StringReadEntry {
 	return []StringReadEntry{
-		{&state.SessionLifespan, nil, []string{"session", "lifespan"}, false, false},
-		{&state.SessionEarliestPossibleExtend, nil, []string{"session", "earliest_possible_extend"}, false, true},
-		{&state.SessionCookieSameSite, nil, []string{"session", "cookie", "same_site"}, false, false},
-		{&state.SessionWhoamiRequiredAAL, nil, []string{"session", "whoami", "required_aal"}, false, false},
-		{&state.SelfserviceFlowsLoginUIURL, &state.LoginUIURL, []string{"selfservice", "flows", "login", "ui_url"}, false, false},
-		{&state.SelfserviceFlowsRegistrationUIURL, &state.RegistrationUIURL, []string{"selfservice", "flows", "registration", "ui_url"}, false, false},
-		{&state.SelfserviceFlowsRecoveryUIURL, &state.RecoveryUIURL, []string{"selfservice", "flows", "recovery", "ui_url"}, false, false},
-		{&state.SelfserviceFlowsVerificationUIURL, &state.VerificationUIURL, []string{"selfservice", "flows", "verification", "ui_url"}, false, false},
-		{&state.SelfserviceFlowsSettingsUIURL, &state.SettingsUIURL, []string{"selfservice", "flows", "settings", "ui_url"}, false, false},
-		{&state.SelfserviceFlowsErrorUIURL, &state.ErrorUIURL, []string{"selfservice", "flows", "error", "ui_url"}, false, false},
-		{&state.SelfserviceMethodsCodeConfigLifespan, &state.CodeLifespan, []string{"selfservice", "methods", "code", "config", "lifespan"}, false, false},
-		{&state.SelfserviceFlowsLoginStyle, &state.LoginStyle, []string{"selfservice", "flows", "login", "style"}, false, false},
-		{&state.SelfserviceFlowsSettingsLifespan, &state.SettingsLifespan, []string{"selfservice", "flows", "settings", "lifespan"}, false, false},
-		{&state.SelfserviceFlowsSettingsPrivilegedSessionMaxAge, &state.SettingsPrivilegedSessionMaxAge, []string{"selfservice", "flows", "settings", "privileged_session_max_age"}, false, false},
-		{&state.SelfserviceFlowsSettingsRequiredAAL, &state.RequiredAAL, []string{"selfservice", "flows", "settings", "required_aal"}, false, false},
-		{&state.SelfserviceFlowsVerificationUse, &state.VerificationUse, []string{"selfservice", "flows", "verification", "use"}, false, false},
-		{&state.SelfserviceFlowsVerificationLifespan, &state.VerificationLifespan, []string{"selfservice", "flows", "verification", "lifespan"}, false, false},
-		{&state.CourierSMTPFromAddress, &state.SMTPFromAddress, []string{"courier", "smtp", "from_address"}, false, false},
-		{&state.CourierSMTPFromName, &state.SMTPFromName, []string{"courier", "smtp", "from_name"}, false, false},
-		{&state.SelfserviceMethodsTOTPConfigIssuer, &state.TOTPIssuer, []string{"selfservice", "methods", "totp", "config", "issuer"}, false, false},
-		{&state.SelfserviceMethodsWebAuthnConfigRPDisplayName, &state.WebAuthnRPDisplayName, []string{"selfservice", "methods", "webauthn", "config", "rp", "display_name"}, false, false},
-		{&state.SelfserviceMethodsWebAuthnConfigRPID, &state.WebAuthnRPID, []string{"selfservice", "methods", "webauthn", "config", "rp", "id"}, false, false},
-		{&state.CourierDeliveryStrategy, nil, []string{"courier", "delivery_strategy"}, false, false},
-		{&state.CookiesSameSite, nil, []string{"cookies", "same_site"}, false, false},
-		{&state.CourierHTTPRequestConfigAuthAPIKeyIn, nil, []string{"courier", "http", "request_config", "auth", "config", "in"}, false, false},
-		{&state.CourierHTTPRequestConfigAuthAPIKeyName, nil, []string{"courier", "http", "request_config", "auth", "config", "name"}, false, false},
-		{&state.CourierHTTPRequestConfigAuthBasicAuthUser, nil, []string{"courier", "http", "request_config", "auth", "config", "user"}, false, false},
-		{&state.CourierHTTPRequestConfigBody, nil, []string{"courier", "http", "request_config", "body"}, false, false},
-		{&state.CourierHTTPRequestConfigURL, nil, []string{"courier", "http", "request_config", "url"}, false, false},
-		{&state.CourierSMTPLocalName, nil, []string{"courier", "smtp", "local_name"}, false, false},
-		{&state.FeatureFlagsCacheableSessionsMaxAge, nil, []string{"feature_flags", "cacheable_sessions_max_age"}, false, false},
-		{&state.OAuth2ProviderURL, nil, []string{"oauth2_provider", "url"}, false, false},
-		{&state.SelfserviceDefaultBrowserReturnURL, nil, []string{"selfservice", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsLoginAfterCodeDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "login", "after", "code", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsLoginAfterDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "login", "after", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsLoginAfterLookupSecretDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "login", "after", "lookup_secret", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsLoginAfterOIDCDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "login", "after", "oidc", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsLoginAfterPasskeyDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "login", "after", "passkey", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsLoginAfterPasswordDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "login", "after", "password", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsLoginAfterTOTPDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "login", "after", "totp", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsLoginAfterWebAuthnDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "login", "after", "webauthn", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsLoginLifespan, nil, []string{"selfservice", "flows", "login", "lifespan"}, false, false},
-		{&state.SelfserviceFlowsLogoutAfterDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "logout", "after", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsRecoveryAfterDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "recovery", "after", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsRecoveryLifespan, nil, []string{"selfservice", "flows", "recovery", "lifespan"}, false, false},
-		{&state.SelfserviceFlowsRecoveryUse, nil, []string{"selfservice", "flows", "recovery", "use"}, false, false},
-		{&state.SelfserviceFlowsRegistrationAfterCodeDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "registration", "after", "code", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsRegistrationAfterDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "registration", "after", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsRegistrationAfterOIDCDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "registration", "after", "oidc", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsRegistrationAfterPasskeyDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "registration", "after", "passkey", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsRegistrationAfterPasswordDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "registration", "after", "password", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsRegistrationAfterWebAuthnDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "registration", "after", "webauthn", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsRegistrationLifespan, nil, []string{"selfservice", "flows", "registration", "lifespan"}, false, false},
-		{&state.SelfserviceFlowsSettingsAfterDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "settings", "after", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsSettingsAfterLookupSecretDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "settings", "after", "lookup_secret", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsSettingsAfterOIDCDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "settings", "after", "oidc", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsSettingsAfterPasskeyDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "settings", "after", "passkey", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsSettingsAfterPasswordDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "settings", "after", "password", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsSettingsAfterProfileDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "settings", "after", "profile", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsSettingsAfterTOTPDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "settings", "after", "totp", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsSettingsAfterWebAuthnDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "settings", "after", "webauthn", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceFlowsVerificationAfterDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "verification", "after", "default_browser_return_url"}, false, false},
-		{&state.SelfserviceMethodsLinkConfigBaseURL, nil, []string{"selfservice", "methods", "link", "config", "base_url"}, false, false},
-		{&state.SelfserviceMethodsLinkConfigLifespan, nil, []string{"selfservice", "methods", "link", "config", "lifespan"}, false, false},
-		{&state.SelfserviceMethodsOIDCConfigBaseRedirectURI, nil, []string{"selfservice", "methods", "oidc", "config", "base_redirect_uri"}, false, false},
-		{&state.SelfserviceMethodsPasskeyConfigRPDisplayName, nil, []string{"selfservice", "methods", "passkey", "config", "rp", "display_name"}, false, false},
-		{&state.SelfserviceMethodsPasskeyConfigRPID, nil, []string{"selfservice", "methods", "passkey", "config", "rp", "id"}, false, false},
-		{&state.SelfserviceMethodsWebAuthnConfigRPIcon, nil, []string{"selfservice", "methods", "webauthn", "config", "rp", "icon"}, false, true},
-		{&state.PreviewDefaultReadConsistencyLevel, nil, []string{"preview", "default_read_consistency_level"}, false, false},
-		{&state.SelfserviceMethodsCaptchaConfigCFTurnstileSecret, nil, []string{"selfservice", "methods", "captcha", "config", "cf_turnstile", "secret"}, false, true},
-		{&state.SelfserviceMethodsCaptchaConfigCFTurnstileSitekey, nil, []string{"selfservice", "methods", "captcha", "config", "cf_turnstile", "sitekey"}, false, false},
-		{&state.CourierHTTPRequestConfigAuthType, nil, []string{"courier", "http", "request_config", "auth", "type"}, false, false},
-		{&state.CourierHTTPRequestConfigMethod, nil, []string{"courier", "http", "request_config", "method"}, false, false},
+		{&state.SessionLifespan, nil, []string{"session", "lifespan"}, false, false, false},
+		{&state.SessionEarliestPossibleExtend, nil, []string{"session", "earliest_possible_extend"}, false, true, false},
+		{&state.SessionCookieSameSite, nil, []string{"session", "cookie", "same_site"}, false, false, false},
+		{&state.SessionWhoamiRequiredAAL, nil, []string{"session", "whoami", "required_aal"}, false, false, false},
+		{&state.SelfserviceFlowsLoginUIURL, &state.LoginUIURL, []string{"selfservice", "flows", "login", "ui_url"}, false, false, false},
+		{&state.SelfserviceFlowsRegistrationUIURL, &state.RegistrationUIURL, []string{"selfservice", "flows", "registration", "ui_url"}, false, false, false},
+		{&state.SelfserviceFlowsRecoveryUIURL, &state.RecoveryUIURL, []string{"selfservice", "flows", "recovery", "ui_url"}, false, false, false},
+		{&state.SelfserviceFlowsVerificationUIURL, &state.VerificationUIURL, []string{"selfservice", "flows", "verification", "ui_url"}, false, false, false},
+		{&state.SelfserviceFlowsSettingsUIURL, &state.SettingsUIURL, []string{"selfservice", "flows", "settings", "ui_url"}, false, false, false},
+		{&state.SelfserviceFlowsErrorUIURL, &state.ErrorUIURL, []string{"selfservice", "flows", "error", "ui_url"}, false, false, false},
+		{&state.SelfserviceMethodsCodeConfigLifespan, &state.CodeLifespan, []string{"selfservice", "methods", "code", "config", "lifespan"}, false, false, false},
+		{&state.SelfserviceFlowsLoginStyle, &state.LoginStyle, []string{"selfservice", "flows", "login", "style"}, false, false, false},
+		{&state.SelfserviceFlowsSettingsLifespan, &state.SettingsLifespan, []string{"selfservice", "flows", "settings", "lifespan"}, false, false, false},
+		{&state.SelfserviceFlowsSettingsPrivilegedSessionMaxAge, &state.SettingsPrivilegedSessionMaxAge, []string{"selfservice", "flows", "settings", "privileged_session_max_age"}, false, false, false},
+		{&state.SelfserviceFlowsSettingsRequiredAAL, &state.RequiredAAL, []string{"selfservice", "flows", "settings", "required_aal"}, false, false, false},
+		{&state.SelfserviceFlowsVerificationUse, &state.VerificationUse, []string{"selfservice", "flows", "verification", "use"}, false, false, false},
+		{&state.SelfserviceFlowsVerificationLifespan, &state.VerificationLifespan, []string{"selfservice", "flows", "verification", "lifespan"}, false, false, false},
+		{&state.CourierSMTPFromAddress, &state.SMTPFromAddress, []string{"courier", "smtp", "from_address"}, false, false, false},
+		{&state.CourierSMTPFromName, &state.SMTPFromName, []string{"courier", "smtp", "from_name"}, false, false, false},
+		{&state.SelfserviceMethodsTOTPConfigIssuer, &state.TOTPIssuer, []string{"selfservice", "methods", "totp", "config", "issuer"}, false, false, false},
+		{&state.SelfserviceMethodsWebAuthnConfigRPDisplayName, &state.WebAuthnRPDisplayName, []string{"selfservice", "methods", "webauthn", "config", "rp", "display_name"}, false, false, false},
+		{&state.SelfserviceMethodsWebAuthnConfigRPID, &state.WebAuthnRPID, []string{"selfservice", "methods", "webauthn", "config", "rp", "id"}, false, false, false},
+		{&state.CourierDeliveryStrategy, nil, []string{"courier", "delivery_strategy"}, false, false, false},
+		{&state.CookiesSameSite, nil, []string{"cookies", "same_site"}, false, false, false},
+		{&state.CourierHTTPRequestConfigAuthAPIKeyIn, nil, []string{"courier", "http", "request_config", "auth", "config", "in"}, false, false, false},
+		{&state.CourierHTTPRequestConfigAuthAPIKeyName, nil, []string{"courier", "http", "request_config", "auth", "config", "name"}, false, false, false},
+		{&state.CourierHTTPRequestConfigAuthBasicAuthUser, nil, []string{"courier", "http", "request_config", "auth", "config", "user"}, false, false, false},
+		{&state.CourierHTTPRequestConfigBody, nil, []string{"courier", "http", "request_config", "body"}, false, false, true},
+		{&state.CourierHTTPRequestConfigURL, nil, []string{"courier", "http", "request_config", "url"}, false, false, false},
+		{&state.CourierSMTPLocalName, nil, []string{"courier", "smtp", "local_name"}, false, false, false},
+		{&state.FeatureFlagsCacheableSessionsMaxAge, nil, []string{"feature_flags", "cacheable_sessions_max_age"}, false, false, false},
+		{&state.OAuth2ProviderURL, nil, []string{"oauth2_provider", "url"}, false, false, false},
+		{&state.SelfserviceDefaultBrowserReturnURL, nil, []string{"selfservice", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsLoginAfterCodeDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "login", "after", "code", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsLoginAfterDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "login", "after", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsLoginAfterLookupSecretDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "login", "after", "lookup_secret", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsLoginAfterOIDCDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "login", "after", "oidc", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsLoginAfterPasskeyDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "login", "after", "passkey", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsLoginAfterPasswordDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "login", "after", "password", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsLoginAfterTOTPDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "login", "after", "totp", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsLoginAfterWebAuthnDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "login", "after", "webauthn", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsLoginLifespan, nil, []string{"selfservice", "flows", "login", "lifespan"}, false, false, false},
+		{&state.SelfserviceFlowsLogoutAfterDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "logout", "after", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsRecoveryAfterDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "recovery", "after", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsRecoveryLifespan, nil, []string{"selfservice", "flows", "recovery", "lifespan"}, false, false, false},
+		{&state.SelfserviceFlowsRecoveryUse, nil, []string{"selfservice", "flows", "recovery", "use"}, false, false, false},
+		{&state.SelfserviceFlowsRegistrationAfterCodeDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "registration", "after", "code", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsRegistrationAfterDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "registration", "after", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsRegistrationAfterOIDCDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "registration", "after", "oidc", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsRegistrationAfterPasskeyDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "registration", "after", "passkey", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsRegistrationAfterPasswordDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "registration", "after", "password", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsRegistrationAfterWebAuthnDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "registration", "after", "webauthn", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsRegistrationLifespan, nil, []string{"selfservice", "flows", "registration", "lifespan"}, false, false, false},
+		{&state.SelfserviceFlowsSettingsAfterDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "settings", "after", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsSettingsAfterLookupSecretDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "settings", "after", "lookup_secret", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsSettingsAfterOIDCDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "settings", "after", "oidc", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsSettingsAfterPasskeyDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "settings", "after", "passkey", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsSettingsAfterPasswordDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "settings", "after", "password", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsSettingsAfterProfileDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "settings", "after", "profile", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsSettingsAfterTOTPDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "settings", "after", "totp", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsSettingsAfterWebAuthnDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "settings", "after", "webauthn", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceFlowsVerificationAfterDefaultBrowserReturnURL, nil, []string{"selfservice", "flows", "verification", "after", "default_browser_return_url"}, false, false, false},
+		{&state.SelfserviceMethodsLinkConfigBaseURL, nil, []string{"selfservice", "methods", "link", "config", "base_url"}, false, false, false},
+		{&state.SelfserviceMethodsLinkConfigLifespan, nil, []string{"selfservice", "methods", "link", "config", "lifespan"}, false, false, false},
+		{&state.SelfserviceMethodsOIDCConfigBaseRedirectURI, nil, []string{"selfservice", "methods", "oidc", "config", "base_redirect_uri"}, false, false, false},
+		{&state.SelfserviceMethodsPasskeyConfigRPDisplayName, nil, []string{"selfservice", "methods", "passkey", "config", "rp", "display_name"}, false, false, false},
+		{&state.SelfserviceMethodsPasskeyConfigRPID, nil, []string{"selfservice", "methods", "passkey", "config", "rp", "id"}, false, false, false},
+		{&state.SelfserviceMethodsWebAuthnConfigRPIcon, nil, []string{"selfservice", "methods", "webauthn", "config", "rp", "icon"}, false, true, false},
+		{&state.PreviewDefaultReadConsistencyLevel, nil, []string{"preview", "default_read_consistency_level"}, false, false, false},
+		{&state.SelfserviceMethodsCaptchaConfigCFTurnstileSecret, nil, []string{"selfservice", "methods", "captcha", "config", "cf_turnstile", "secret"}, false, true, false},
+		{&state.SelfserviceMethodsCaptchaConfigCFTurnstileSitekey, nil, []string{"selfservice", "methods", "captcha", "config", "cf_turnstile", "sitekey"}, false, false, false},
+		{&state.CourierHTTPRequestConfigAuthType, nil, []string{"courier", "http", "request_config", "auth", "type"}, false, false, false},
+		{&state.CourierHTTPRequestConfigMethod, nil, []string{"courier", "http", "request_config", "method"}, false, false, false},
 	}
 }
 
@@ -582,39 +598,39 @@ func identityMapStringReadEntries(state *ProjectConfigResourceModel) []MapString
 
 func oauth2StringReadEntries(state *ProjectConfigResourceModel) []StringReadEntry {
 	return []StringReadEntry{
-		{&state.OAuth2TTLAccessToken, &state.OAuth2AccessTokenLifespan, []string{"ttl", "access_token"}, false, false},
-		{&state.OAuth2TTLRefreshToken, &state.OAuth2RefreshTokenLifespan, []string{"ttl", "refresh_token"}, false, false},
-		{&state.OAuth2TTLAuthCode, &state.OAuth2AuthCodeLifespan, []string{"ttl", "auth_code"}, false, false},
-		{&state.OAuth2TTLIDToken, &state.OAuth2IDTokenLifespan, []string{"ttl", "id_token"}, false, false},
-		{&state.OAuth2TTLLoginConsentRequest, &state.OAuth2LoginConsentRequestLifespan, []string{"ttl", "login_consent_request"}, false, false},
-		{&state.OAuth2StrategiesAccessToken, &state.OAuth2AccessTokenStrategy, []string{"strategies", "access_token"}, false, false},
-		{&state.OAuth2StrategiesJWTScopeClaim, &state.OAuth2JWTScopeClaim, []string{"strategies", "jwt", "scope_claim"}, false, false},
-		{&state.OAuth2StrategiesScope, &state.OAuth2ScopeStrategy, []string{"strategies", "scope"}, false, false},
-		{&state.OAuth2URLsConsent, &state.OAuth2ConsentURL, []string{"urls", "consent"}, false, false},
-		{&state.OAuth2URLsLogin, &state.OAuth2LoginURL, []string{"urls", "login"}, false, false},
-		{&state.OAuth2URLsLogout, &state.OAuth2LogoutURL, []string{"urls", "logout"}, false, false},
-		{&state.OAuth2URLsError, &state.OAuth2ErrorURL, []string{"urls", "error"}, false, false},
-		{&state.OAuth2URLsSelfIssuer, &state.OAuth2IssuerURL, []string{"urls", "self", "issuer"}, false, false},
-		{&state.OAuth2ServeCookiesSameSiteMode, &state.OAuth2CookiesSameSiteMode, []string{"serve", "cookies", "same_site_mode"}, false, false},
-		{&state.OAuth2GrantJWTMaxTTL, nil, []string{"oauth2", "grant", "jwt", "max_ttl"}, false, false},
-		{&state.OAuth2GrantRefreshTokenRotationGracePeriod, nil, []string{"oauth2", "grant", "refresh_token", "rotation_grace_period"}, false, false},
-		{&state.OAuth2RefreshTokenHook, nil, []string{"oauth2", "refresh_token_hook"}, false, false},
-		{&state.OAuth2TokenHook, nil, []string{"oauth2", "token_hook", "url"}, false, false},
-		{&state.OIDCSubjectIdentifiersPairwiseSalt, nil, []string{"oidc", "subject_identifiers", "pairwise", "salt"}, false, false},
-		{&state.OAuth2UrlsPostLogoutRedirect, nil, []string{"urls", "post_logout_redirect"}, false, false},
-		{&state.OAuth2UrlsRegistration, nil, []string{"urls", "registration"}, false, false},
-		{&state.OAuth2WebfingerOIDCDiscoveryAuthURL, nil, []string{"webfinger", "oidc_discovery", "auth_url"}, false, false},
-		{&state.OAuth2WebfingerOIDCDiscoveryClientRegistrationURL, nil, []string{"webfinger", "oidc_discovery", "client_registration_url"}, false, false},
-		{&state.OAuth2WebfingerOIDCDiscoveryJwksURL, nil, []string{"webfinger", "oidc_discovery", "jwks_url"}, false, false},
-		{&state.OAuth2WebfingerOIDCDiscoveryTokenURL, nil, []string{"webfinger", "oidc_discovery", "token_url"}, false, false},
-		{&state.OAuth2WebfingerOIDCDiscoveryUserinfoURL, nil, []string{"webfinger", "oidc_discovery", "userinfo_url"}, false, false},
-		{&state.OAuth2TokenPrefix, nil, []string{"oauth2", "token_prefix"}, false, false},
-		{&state.OAuth2DeviceAuthorizationTokenPollingInterval, nil, []string{"oauth2", "device_authorization", "token_polling_interval"}, false, false},
-		{&state.OAuth2DeviceAuthorizationUserCodeEntropyPreset, nil, []string{"oauth2", "device_authorization", "user_code", "entropy_preset"}, false, false},
-		{&state.OAuth2TTLDeviceUserCode, nil, []string{"ttl", "device_user_code"}, false, false},
-		{&state.OAuth2UrlsDeviceSuccess, nil, []string{"urls", "device", "success"}, false, false},
-		{&state.OAuth2UrlsDeviceVerification, nil, []string{"urls", "device", "verification"}, false, false},
-		{&state.OAuth2WebfingerOIDCDiscoveryDeviceAuthorizationURL, nil, []string{"webfinger", "oidc_discovery", "device_authorization_url"}, false, false},
+		{&state.OAuth2TTLAccessToken, &state.OAuth2AccessTokenLifespan, []string{"ttl", "access_token"}, false, false, false},
+		{&state.OAuth2TTLRefreshToken, &state.OAuth2RefreshTokenLifespan, []string{"ttl", "refresh_token"}, false, false, false},
+		{&state.OAuth2TTLAuthCode, &state.OAuth2AuthCodeLifespan, []string{"ttl", "auth_code"}, false, false, false},
+		{&state.OAuth2TTLIDToken, &state.OAuth2IDTokenLifespan, []string{"ttl", "id_token"}, false, false, false},
+		{&state.OAuth2TTLLoginConsentRequest, &state.OAuth2LoginConsentRequestLifespan, []string{"ttl", "login_consent_request"}, false, false, false},
+		{&state.OAuth2StrategiesAccessToken, &state.OAuth2AccessTokenStrategy, []string{"strategies", "access_token"}, false, false, false},
+		{&state.OAuth2StrategiesJWTScopeClaim, &state.OAuth2JWTScopeClaim, []string{"strategies", "jwt", "scope_claim"}, false, false, false},
+		{&state.OAuth2StrategiesScope, &state.OAuth2ScopeStrategy, []string{"strategies", "scope"}, false, false, false},
+		{&state.OAuth2URLsConsent, &state.OAuth2ConsentURL, []string{"urls", "consent"}, false, false, false},
+		{&state.OAuth2URLsLogin, &state.OAuth2LoginURL, []string{"urls", "login"}, false, false, false},
+		{&state.OAuth2URLsLogout, &state.OAuth2LogoutURL, []string{"urls", "logout"}, false, false, false},
+		{&state.OAuth2URLsError, &state.OAuth2ErrorURL, []string{"urls", "error"}, false, false, false},
+		{&state.OAuth2URLsSelfIssuer, &state.OAuth2IssuerURL, []string{"urls", "self", "issuer"}, false, false, false},
+		{&state.OAuth2ServeCookiesSameSiteMode, &state.OAuth2CookiesSameSiteMode, []string{"serve", "cookies", "same_site_mode"}, false, false, false},
+		{&state.OAuth2GrantJWTMaxTTL, nil, []string{"oauth2", "grant", "jwt", "max_ttl"}, false, false, false},
+		{&state.OAuth2GrantRefreshTokenRotationGracePeriod, nil, []string{"oauth2", "grant", "refresh_token", "rotation_grace_period"}, false, false, false},
+		{&state.OAuth2RefreshTokenHook, nil, []string{"oauth2", "refresh_token_hook"}, false, false, false},
+		{&state.OAuth2TokenHook, nil, []string{"oauth2", "token_hook", "url"}, false, false, false},
+		{&state.OIDCSubjectIdentifiersPairwiseSalt, nil, []string{"oidc", "subject_identifiers", "pairwise", "salt"}, false, false, false},
+		{&state.OAuth2UrlsPostLogoutRedirect, nil, []string{"urls", "post_logout_redirect"}, false, false, false},
+		{&state.OAuth2UrlsRegistration, nil, []string{"urls", "registration"}, false, false, false},
+		{&state.OAuth2WebfingerOIDCDiscoveryAuthURL, nil, []string{"webfinger", "oidc_discovery", "auth_url"}, false, false, false},
+		{&state.OAuth2WebfingerOIDCDiscoveryClientRegistrationURL, nil, []string{"webfinger", "oidc_discovery", "client_registration_url"}, false, false, false},
+		{&state.OAuth2WebfingerOIDCDiscoveryJwksURL, nil, []string{"webfinger", "oidc_discovery", "jwks_url"}, false, false, false},
+		{&state.OAuth2WebfingerOIDCDiscoveryTokenURL, nil, []string{"webfinger", "oidc_discovery", "token_url"}, false, false, false},
+		{&state.OAuth2WebfingerOIDCDiscoveryUserinfoURL, nil, []string{"webfinger", "oidc_discovery", "userinfo_url"}, false, false, false},
+		{&state.OAuth2TokenPrefix, nil, []string{"oauth2", "token_prefix"}, false, false, false},
+		{&state.OAuth2DeviceAuthorizationTokenPollingInterval, nil, []string{"oauth2", "device_authorization", "token_polling_interval"}, false, false, false},
+		{&state.OAuth2DeviceAuthorizationUserCodeEntropyPreset, nil, []string{"oauth2", "device_authorization", "user_code", "entropy_preset"}, false, false, false},
+		{&state.OAuth2TTLDeviceUserCode, nil, []string{"ttl", "device_user_code"}, false, false, false},
+		{&state.OAuth2UrlsDeviceSuccess, nil, []string{"urls", "device", "success"}, false, false, false},
+		{&state.OAuth2UrlsDeviceVerification, nil, []string{"urls", "device", "verification"}, false, false, false},
+		{&state.OAuth2WebfingerOIDCDiscoveryDeviceAuthorizationURL, nil, []string{"webfinger", "oidc_discovery", "device_authorization_url"}, false, false, false},
 	}
 }
 
@@ -656,7 +672,7 @@ func oauth2ListStringReadEntries(state *ProjectConfigResourceModel) []ListString
 
 func permissionStringReadEntries(state *ProjectConfigResourceModel) []StringReadEntry {
 	return []StringReadEntry{
-		{&state.KetoNamespaceConfiguration, nil, []string{"namespaces", "location"}, false, false},
+		{&state.KetoNamespaceConfiguration, nil, []string{"namespaces", "location"}, false, false, false},
 	}
 }
 

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -978,6 +978,65 @@ func TestAccProjectConfigResource_courierHTTP(t *testing.T) {
 	})
 }
 
+// courierBodyTemplate and courierBodyTemplateUpdated are `base64://` Jsonnet
+// payloads for the flat courier_http_request_config_body attribute. The Ory API
+// stores the decoded payload and reports a storage URL instead, so each step's
+// implicit post-apply plan check is what proves the read path resolves that URL
+// back to the configured value. See issue #315.
+const (
+	courierBodyTemplate        = "base64://ewogICJyZWNpcGllbnQiOiB7eyAucmVjaXBpZW50IH19LAogICJib2R5Ijoge3sgLmJvZHkgfX0KfQ=="
+	courierBodyTemplateUpdated = "base64://ewogICJyZWNpcGllbnQiOiB7eyAucmVjaXBpZW50IH19LAogICJzdWJqZWN0Ijoge3sgLnN1YmplY3QgfX0sCiAgImJvZHkiOiB7eyAuYm9keSB9fQp9"
+)
+
+// TestAccProjectConfigResource_courierHTTPBody covers the flat courier body
+// attribute end to end: create, refresh, update, and import. Before the storage
+// URL fix, the refresh after step 1 wrote
+// `https://storage.googleapis.com/.../<sha512>.jsonnet` into state and the step
+// failed with a non-empty plan.
+func TestAccProjectConfigResource_courierHTTPBody(t *testing.T) {
+	acctest.RunTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/courier_http_body.tf.tmpl", map[string]string{
+					"Body": courierBodyTemplate,
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_project_config.test", "id"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "courier_delivery_strategy", "http"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "courier_http_request_config_url", "https://example.com/mail-api/send"),
+					resource.TestCheckResourceAttr("ory_project_config.test", "courier_http_request_config_body", courierBodyTemplate),
+				),
+			},
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/courier_http_body.tf.tmpl", map[string]string{
+					"Body": courierBodyTemplateUpdated,
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "courier_http_request_config_body", courierBodyTemplateUpdated),
+				),
+			},
+			{
+				ResourceName:      "ory_project_config.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Import starts from empty state, so every optional attribute
+				// comes back null. That is the resource's existing import
+				// behavior and is not what this test covers.
+				ImportStateVerifyIgnore: []string{
+					"courier_delivery_strategy",
+					"courier_http_request_config_url",
+					"courier_http_request_config_body",
+					"smtp_connection_uri",
+					"cors_enabled",
+					"selfservice_methods_password_config_min_password_length",
+				},
+			},
+		},
+	})
+}
+
 func TestAccProjectConfigResource_featureFlags(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccPreCheck(t) },

--- a/internal/resources/projectconfig/schema_gen.go
+++ b/internal/resources/projectconfig/schema_gen.go
@@ -684,7 +684,7 @@ func simpleSchemaAttributes() map[string]schema.Attribute {
 			Optional:    true,
 		},
 		"courier_http_request_config_body": schema.StringAttribute{
-			Description: "Base64-encoded Jsonnet template for the HTTP courier request body.",
+			Description: "Jsonnet template for the HTTP courier request body, as a `base64://<base64-encoded-payload>` value. The API stores the payload in object storage and reports an https URL back, so the read path resolves that URL to the configured value.",
 			Optional:    true,
 		},
 		"courier_http_request_config_url": schema.StringAttribute{

--- a/internal/resources/projectconfig/storage_url_content_test.go
+++ b/internal/resources/projectconfig/storage_url_content_test.go
@@ -1,0 +1,231 @@
+package projectconfig
+
+import (
+	"context"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// jsonnetPayload stands in for a courier request-body template.
+	jsonnetPayload = "{\n  \"recipient\": {{ .recipient }},\n  \"body\": {{ .body }}\n}"
+	// otherPayload is what someone edits the template to in the Ory Console.
+	otherPayload = "{\n  \"changed\": true\n}"
+)
+
+// storageURL builds the URL shape the Ory API reports for a stored payload:
+// the filename is the lowercase hex SHA-512 of the payload.
+func storageURL(payload string) string {
+	sum := sha512.Sum512([]byte(payload))
+	return "https://storage.googleapis.com/bac-gcs-staging/" + hex.EncodeToString(sum[:]) + ".jsonnet"
+}
+
+// base64Value renders a payload the way a user writes it in HCL.
+func base64Value(payload string) string {
+	return base64ContentPrefix + base64.StdEncoding.EncodeToString([]byte(payload))
+}
+
+// stubFetcher replaces storageURLContentFetcher for one test and records how
+// often it ran, so a test can assert the hash fast path avoided the network.
+func stubFetcher(t *testing.T, payload string, err error) *int {
+	t.Helper()
+	calls := 0
+	original := storageURLContentFetcher
+	storageURLContentFetcher = func(_ context.Context, _ string) ([]byte, error) {
+		calls++
+		if err != nil {
+			return nil, err
+		}
+		return []byte(payload), nil
+	}
+	t.Cleanup(func() { storageURLContentFetcher = original })
+	return &calls
+}
+
+func TestDecodeBase64Content(t *testing.T) {
+	padded := base64.StdEncoding.EncodeToString([]byte(jsonnetPayload))
+	unpadded := base64.RawStdEncoding.EncodeToString([]byte(jsonnetPayload))
+
+	tests := []struct {
+		name    string
+		value   string
+		want    string
+		wantOK  bool
+		comment string
+	}{
+		{"padded", base64ContentPrefix + padded, jsonnetPayload, true, "the form the docs and examples use"},
+		{"unpadded", base64ContentPrefix + unpadded, jsonnetPayload, true, "the Ory API accepts this too"},
+		{"empty payload", base64ContentPrefix, "", true, "an empty payload is still the inline form"},
+		{"no prefix", "https://example.com/body.jsonnet", "", false, "a URL is not an inline payload"},
+		{"bad base64", base64ContentPrefix + "not base64!!", "", false, "undecodable, so not usable for a hash compare"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := decodeBase64Content(tt.value)
+			assert.Equal(t, tt.wantOK, ok, tt.comment)
+			if tt.wantOK {
+				assert.Equal(t, tt.want, string(got))
+			}
+		})
+	}
+}
+
+// TestResolveStorageURLContent_KeepsConfiguredValueOnHashMatch is the direct
+// guard for issue #315: the API replaces the configured `base64://` value with a
+// storage URL, and copying that URL into state makes every plan show a change
+// that no apply settles.
+func TestResolveStorageURLContent_KeepsConfiguredValueOnHashMatch(t *testing.T) {
+	configured := base64Value(jsonnetPayload)
+	calls := stubFetcher(t, "", errors.New("the hash fast path must not download anything"))
+
+	got := resolveStorageURLContent(context.Background(), storageURL(jsonnetPayload), configured)
+
+	assert.Equal(t, configured, got, "the configured base64 value must stay in state")
+	assert.Zero(t, *calls, "a matching hash must settle the read without a download")
+}
+
+// The Ory API accepts unpadded base64, so a user who writes it must get the same
+// no-diff behavior as one who writes the padded form.
+func TestResolveStorageURLContent_KeepsUnpaddedConfiguredValue(t *testing.T) {
+	configured := base64ContentPrefix + base64.RawStdEncoding.EncodeToString([]byte(jsonnetPayload))
+	calls := stubFetcher(t, "", errors.New("the hash fast path must not download anything"))
+
+	got := resolveStorageURLContent(context.Background(), storageURL(jsonnetPayload), configured)
+
+	assert.Equal(t, configured, got, "an unpadded base64 value must stay in state")
+	assert.Zero(t, *calls, "a matching hash must settle the read without a download")
+}
+
+// A payload changed outside Terraform must reach state, so the plan shows the
+// drift. The downloaded payload is re-encoded as `base64://` to keep the diff
+// comparable with the configuration.
+func TestResolveStorageURLContent_ReportsOutOfBandChange(t *testing.T) {
+	calls := stubFetcher(t, otherPayload, nil)
+
+	got := resolveStorageURLContent(context.Background(), storageURL(otherPayload), base64Value(jsonnetPayload))
+
+	assert.Equal(t, base64Value(otherPayload), got, "the changed payload must surface as drift")
+	assert.Equal(t, 1, *calls, "a hash mismatch must download the stored payload once")
+}
+
+func TestResolveStorageURLContent_FallsBackToURLWhenDownloadFails(t *testing.T) {
+	apiValue := storageURL(otherPayload)
+	calls := stubFetcher(t, "", errors.New("connection reset"))
+
+	got := resolveStorageURLContent(context.Background(), apiValue, base64Value(jsonnetPayload))
+
+	assert.Equal(t, apiValue, got, "a failed download must still surface drift, not hide it")
+	assert.Equal(t, 1, *calls)
+}
+
+func TestResolveStorageURLContent_PassesThroughNonStorageValues(t *testing.T) {
+	sameURL := storageURL(jsonnetPayload)
+
+	tests := []struct {
+		name     string
+		apiValue string
+		state    string
+		want     string
+		comment  string
+	}{
+		{"cleared out of band", "", base64Value(jsonnetPayload), "", "an empty value must null the attribute so removal shows as drift"},
+		{"identical to state", sameURL, sameURL, sameURL, "nothing to resolve when the API echoes the state value"},
+		{"state holds a URL", storageURL(otherPayload), sameURL, storageURL(otherPayload), "two URLs already compare directly"},
+		{"not a storage URL", "https://example.com/body.jsonnet", base64Value(jsonnetPayload), "https://example.com/body.jsonnet", "no hash to compare, so report the value verbatim"},
+		{"state is empty", sameURL, "", sameURL, "nothing in state to preserve"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := stubFetcher(t, "", errors.New("no download expected on this path"))
+
+			got := resolveStorageURLContent(context.Background(), tt.apiValue, tt.state)
+
+			assert.Equal(t, tt.want, got, tt.comment)
+			assert.Zero(t, *calls, "this path must not download anything")
+		})
+	}
+}
+
+// courierBodyProject nests a courier HTTP request-body value the way the API
+// reports it.
+func courierBodyProject(body string) map[string]interface{} {
+	return map[string]interface{}{
+		"courier": map[string]interface{}{
+			"http": map[string]interface{}{
+				"request_config": map[string]interface{}{
+					"body": body,
+				},
+			},
+		},
+	}
+}
+
+// TestReadSimpleFields_ResolvesCourierBodyStorageURL wires the resolver check
+// through the generated read path, which is what a refresh actually runs.
+func TestReadSimpleFields_ResolvesCourierBodyStorageURL(t *testing.T) {
+	configured := base64Value(jsonnetPayload)
+	calls := stubFetcher(t, "", errors.New("the hash fast path must not download anything"))
+
+	state := &ProjectConfigResourceModel{
+		CourierHTTPRequestConfigBody: types.StringValue(configured),
+	}
+	readSimpleFields(context.Background(), projectWithIdentityConfig(courierBodyProject(storageURL(jsonnetPayload))), state)
+
+	assert.Equal(t, configured, state.CourierHTTPRequestConfigBody.ValueString(),
+		"a refresh must leave the configured courier body in state")
+	assert.Zero(t, *calls)
+}
+
+func TestReadSimpleFields_NullsCourierBodyRemovedOutOfBand(t *testing.T) {
+	state := &ProjectConfigResourceModel{
+		CourierHTTPRequestConfigBody: types.StringValue(base64Value(jsonnetPayload)),
+	}
+	readSimpleFields(context.Background(), projectWithIdentityConfig(map[string]interface{}{
+		"courier": map[string]interface{}{"http": map[string]interface{}{"request_config": map[string]interface{}{}}},
+	}), state)
+
+	assert.True(t, state.CourierHTTPRequestConfigBody.IsNull(),
+		"a courier body removed outside Terraform must null state so the removal shows as drift")
+}
+
+// TestGeneratedReadEntries_StorageURLFlag pins the codegen wiring: exactly the
+// attributes marked `storage_url_content` in mappings.yaml get the resolver.
+func TestGeneratedReadEntries_StorageURLFlag(t *testing.T) {
+	state := &ProjectConfigResourceModel{}
+
+	var storageURLKeys []string
+	for _, e := range identityStringReadEntries(state) {
+		if e.StorageURL {
+			storageURLKeys = append(storageURLKeys, strings.Join(e.Keys, "."))
+		}
+		if e.Field == &state.CourierHTTPRequestConfigBody {
+			assert.True(t, e.StorageURL,
+				"courier_http_request_config_body must resolve storage URLs — see issue #315")
+		}
+	}
+	require.Equal(t, []string{"courier.http.request_config.body"}, storageURLKeys,
+		"unexpected set of storage-URL attributes; update this test when mappings.yaml changes")
+
+	// No other service reports storage-backed content today. A new one showing up
+	// here means the mapping changed and the resolver behavior needs a look.
+	for name, entries := range map[string][]StringReadEntry{
+		"oauth2":             oauth2StringReadEntries(state),
+		"account_experience": account_experienceStringReadEntries(state),
+		"permission":         permissionStringReadEntries(state),
+	} {
+		for _, e := range entries {
+			assert.False(t, e.StorageURL, fmt.Sprintf("%s has an unexpected storage-URL attribute", name))
+		}
+	}
+}

--- a/internal/resources/projectconfig/testdata/courier_http_body.tf.tmpl
+++ b/internal/resources/projectconfig/testdata/courier_http_body.tf.tmpl
@@ -1,0 +1,5 @@
+resource "ory_project_config" "test" {
+  courier_delivery_strategy        = "http"
+  courier_http_request_config_url  = "https://example.com/mail-api/send"
+  courier_http_request_config_body = "[[ .Body ]]"
+}

--- a/templates/resources/project_config.md.tmpl
+++ b/templates/resources/project_config.md.tmpl
@@ -28,6 +28,23 @@ This resource supports drift detection — `terraform plan` will detect changes 
 
 {{ tffile "examples/resources/ory_project_config/resource.tf" }}
 
+## Courier HTTP Request Body
+
+Set `courier_http_request_config_body` to a `base64://` value that carries the Jsonnet template inline. The Ory API rejects a plain Jsonnet string, and it rejects a URL outside its own storage:
+
+```hcl
+resource "ory_project_config" "main" {
+  courier_delivery_strategy       = "http"
+  courier_http_request_config_url = "https://mail.example.com/send"
+
+  courier_http_request_config_body = "base64://${base64encode(file("${path.module}/courier_body.jsonnet"))}"
+}
+```
+
+The API stores the decoded payload and reports an `https://storage.googleapis.com/.../<sha512>.jsonnet` URL instead of the value you set. The provider compares the hash in that URL with your configured payload, so a matching payload produces no change in plan. A payload edited in the Ory Console does not match the hash, so the provider downloads it and plan shows the difference in `base64://` form.
+
+The nested `courier_http_request_config` attribute and each entry in `courier_channels` take the same `base64://` value for their `body` field. For those two, the provider keeps the configured value whenever the API reports a URL, so a payload edited in the Ory Console is not reported as drift.
+
 ## Duration Format
 
 Time-based attributes use Go duration strings. Examples:


### PR DESCRIPTION
## Description

`courier_http_request_config_body` showed a change on every `terraform plan`, even straight after a successful apply.

The Ory API does not echo the configured value back. It uploads the decoded `base64://` payload to object storage and reports `https://storage.googleapis.com/.../<sha512>.jsonnet` instead. The read path copied that URL into state, so plan compared a storage URL in state against the base64 value in the configuration and no apply settled it.

Read now resolves the URL:

- The filename is the lowercase hex SHA-512 of the stored payload, so a hash comparison against the payload in state settles the common case with no network call.
- A hash mismatch means the payload changed outside Terraform. The provider downloads it through `client.FetchSafeHTTPS` and reports it as `base64://`, so plan shows a base64-to-base64 diff.
- An empty API value still nulls the attribute, so a payload removed outside Terraform is still reported as drift.
- A failed download keeps the URL in state, so a transient network error surfaces drift instead of hiding it.

The behavior comes from a new `storage_url_content` codegen flag, so a future attribute the API stores the same way needs one line in `internal/codegen/mappings.yaml`. The generator rejects the flag on a non-string type and rejects combining it with `write_only`.

## Related Issues

Fixes #315

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

**API contract, confirmed with curl against a staging project**

| Value sent | Result |
|---|---|
| `base64://<padded>` | 200, reported as a storage URL whose filename is `sha512(payload)` |
| `base64://<unpadded>` | 200, same payload hash, so both forms are decoded by the resolver |
| `https://example.com/body.jsonnet` | 400 `URL ... is not allowed for courier.http.request_config.body` |
| plain Jsonnet string | 500 `first path segment in URL cannot contain colon` |
| an Ory storage URL | 200, kept verbatim |

**Unit tests** in `internal/resources/projectconfig/storage_url_content_test.go` cover the hash match, the unpadded form, the out-of-band change, the failed download, the pass-through cases, the generated read path, and the codegen wiring. The pass-through and hash-match cases assert no download happens.

**Acceptance test** `TestAccProjectConfigResource_courierHTTPBody` covers create, refresh, update, and import. Each step's implicit post-apply plan check is what the bug used to fail. Verified failing before the fix and passing after:

```
--- FAIL: TestAccProjectConfigResource_courierHTTPBody
    ~ courier_http_request_config_body = "https://storage.googleapis.com/bac-gcs-staging/91fec265....jsonnet" -> "base64://ewogICJyZWNpcGllbnQiOi..."
    Plan: 0 to add, 1 to change, 0 to destroy.
```

```
--- PASS: TestAccProjectConfigResource_courierHTTPBody (5.97s)
--- PASS: TestAccProjectConfigResource_courierHTTP (3.44s)
```

Full suites: `ok internal/resources/projectconfig 137.125s` and `ok internal/resources/emailtemplate 19.821s`.

**Manual terraform CLI run** against a staging project, with the provider built from this branch:

1. apply, then plan reports `No changes`.
2. Change the payload in the configuration, apply, then plan reports `No changes`.
3. Change the payload out of band through the Console API, then plan reports the drift as `base64://eyAiY2hhbmdlZF9pbl9jb25zb2xlIjogdHJ1ZSB9` -> the configured value.
4. Import, apply, then plan reports `No changes`.
5. Destroy, then the project's courier body restored to its pre-test value.

## Screenshots/Output

Before the fix, the reproduction from the issue:

```
~ resource "ory_project_config" "test" {
  ~ courier_http_request_config_body = "https://storage.googleapis.com/bac-gcs-staging/61e3e6de....jsonnet" -> "base64://ewogICJyZXByb18zMTUiOiB0cnVlLC..."
}
Plan: 0 to add, 1 to change, 0 to destroy.
```

After the fix, same configuration and same project:

```
No changes. Your infrastructure matches the configuration.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring flat HTTP courier request bodies with `base64://`-encoded Jsonnet payloads.
  * Project configuration now resolves storage-backed request body URLs while preserving configured content and detecting external changes.
  * Added an example configuration for HTTP delivery with URL and basic authentication.

* **Documentation**
  * Expanded configuration and contribution guidance for courier request bodies, storage URLs, hashing, and drift handling.

* **Tests**
  * Added coverage for payload updates, imports, refreshes, encoding variants, storage changes, and download failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->