### PR TITLE
fix: remove OAuth2 client, OIDC dynamic client, and trusted JWT issuer from state when deleted outside Terraform

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -33,11 +33,11 @@ var ErrConsoleClientNotConfigured = errors.New("console API client not configure
 // can check with errors.Is.
 var ErrProjectNotAllowed = errors.New("project not allowed by allowed_project_ids")
 
-// ErrNotFound tags an API error whose HTTP response carried 404. The status is
-// the only reliable signal: when the error body does not match the model the SDK
-// expects for an endpoint, the SDK replaces the status text ("404 Not Found")
-// with the JSON decode error, and the body itself no longer parses into the
-// shape extractDebugInfo reads. IsNotFound reports true for a tagged error.
+// ErrNotFound tags an API error whose HTTP response carried 404. The tag exists
+// to be narrow, not to detect more: the substring match in IsNotFound already
+// recognizes these 404s, but it also matches any error text that happens to
+// contain "404". A caller that must not act on a false positive — see
+// IsNotFoundStatus — checks the tag instead.
 var ErrNotFound = errors.New("resource not found")
 
 const (

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -279,11 +279,17 @@ func notFoundIfStatus(resp *http.Response, err error) error {
 // IsNotFound reports whether err is an Ory API 404 (Not Found) — e.g. a project
 // that has been purged. Callers use it to treat a missing resource as already
 // gone rather than a hard failure.
+//
+// The last resort is a substring match, which over-matches: any error text that
+// happens to contain "404" or "Not Found" passes, including a 500 whose request
+// ID contains those digits. That is tolerable where a false positive only makes
+// a teardown path give up early. It is not tolerable where the answer decides
+// whether to drop a live resource from state — use IsNotFoundStatus there.
 func IsNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, ErrNotFound) {
+	if IsNotFoundStatus(err) {
 		return true
 	}
 	if extractDebugInfo(err).StatusCode == 404 {
@@ -291,6 +297,18 @@ func IsNotFound(err error) bool {
 	}
 	errStr := err.Error()
 	return strings.Contains(errStr, "404") || strings.Contains(errStr, "Not Found")
+}
+
+// IsNotFoundStatus reports whether err came from a response that carried HTTP
+// 404, and nothing weaker. Use it for the one decision a false positive would
+// ruin: removing a resource from Terraform state because it looks deleted. A
+// transient 500 must not drop a live resource, and IsNotFound's substring
+// fallback cannot make that promise.
+//
+// Only errors from a getter that calls notFoundIfStatus carry the tag, so a Read
+// that switches to this check needs its getter tagged first.
+func IsNotFoundStatus(err error) bool {
+	return errors.Is(err, ErrNotFound)
 }
 
 // truncateErrorBody trims a raw response body to maxErrorBodyBytes so error

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -33,6 +33,13 @@ var ErrConsoleClientNotConfigured = errors.New("console API client not configure
 // can check with errors.Is.
 var ErrProjectNotAllowed = errors.New("project not allowed by allowed_project_ids")
 
+// ErrNotFound tags an API error whose HTTP response carried 404. The status is
+// the only reliable signal: when the error body does not match the model the SDK
+// expects for an endpoint, the SDK replaces the status text ("404 Not Found")
+// with the JSON decode error, and the body itself no longer parses into the
+// shape extractDebugInfo reads. IsNotFound reports true for a tagged error.
+var ErrNotFound = errors.New("resource not found")
+
 const (
 	// maxRetries is the maximum number of retry attempts for rate-limited requests.
 	maxRetries = 3
@@ -260,12 +267,24 @@ func wrapAPIError(err error, operation string) error {
 	return err
 }
 
+// notFoundIfStatus tags err with ErrNotFound when the response carried HTTP 404,
+// so callers can rely on IsNotFound regardless of the error body's shape.
+func notFoundIfStatus(resp *http.Response, err error) error {
+	if err == nil || resp == nil || resp.StatusCode != http.StatusNotFound {
+		return err
+	}
+	return fmt.Errorf("%w: %w", ErrNotFound, err)
+}
+
 // IsNotFound reports whether err is an Ory API 404 (Not Found) — e.g. a project
 // that has been purged. Callers use it to treat a missing resource as already
 // gone rather than a hard failure.
 func IsNotFound(err error) bool {
 	if err == nil {
 		return false
+	}
+	if errors.Is(err, ErrNotFound) {
+		return true
 	}
 	if extractDebugInfo(err).StatusCode == 404 {
 		return true
@@ -1222,6 +1241,7 @@ func (c *OryClient) GetOAuth2Client(ctx context.Context, clientID string) (*ory.
 		return nil, fmt.Errorf("reading OAuth2 client: %w", err)
 	}
 	oauthClient, httpResp, err := c.projectClient.OAuth2API.GetOAuth2Client(ctx, clientID).Execute()
+	err = notFoundIfStatus(httpResp, err)
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
 	}
@@ -1553,6 +1573,7 @@ func (c *OryClient) GetTrustedOAuth2JwtGrantIssuer(ctx context.Context, id strin
 		return nil, fmt.Errorf("getting trusted JWT grant issuer: %w", err)
 	}
 	issuer, httpResp, err := c.projectClient.OAuth2API.GetTrustedOAuth2JwtGrantIssuer(ctx, id).Execute()
+	err = notFoundIfStatus(httpResp, err)
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
 	}
@@ -1617,6 +1638,7 @@ func (c *OryClient) GetOIDCDynamicClient(ctx context.Context, clientID string) (
 		return nil, fmt.Errorf("getting OIDC dynamic client: %w", err)
 	}
 	result, httpResp, err := c.projectClient.OAuth2API.GetOAuth2Client(ctx, clientID).Execute()
+	err = notFoundIfStatus(httpResp, err)
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -873,3 +873,22 @@ func TestIsNotFound(t *testing.T) {
 	assert.False(t, IsNotFound(errors.New("400 Bad Request")))
 	assert.False(t, IsNotFound(errors.New("500 Internal Server Error")))
 }
+
+// IsNotFound's substring fallback over-matches, which is why the state-removal
+// decision uses IsNotFoundStatus instead. Pin both halves of that split.
+func TestIsNotFoundStatus(t *testing.T) {
+	assert.False(t, IsNotFoundStatus(nil))
+	assert.False(t, IsNotFoundStatus(errors.New("404 Not Found")),
+		"text alone must not count as a 404 status")
+
+	tagged := notFoundIfStatus(&http.Response{StatusCode: http.StatusNotFound}, errors.New("boom"))
+	assert.True(t, IsNotFoundStatus(tagged))
+	assert.True(t, IsNotFound(tagged), "the tag must satisfy the looser check too")
+
+	// A 500 whose body carries the digits "404", for instance in a hex request ID.
+	serverErr := errors.New(`{"error":{"code":500,"status":"Internal Server Error","request":"bfd5c404-7133-9506-8a5f-f7a738b14e04"}}`)
+	assert.False(t, IsNotFoundStatus(notFoundIfStatus(&http.Response{StatusCode: http.StatusInternalServerError}, serverErr)),
+		"a 500 must never be tagged as not-found")
+	assert.True(t, IsNotFound(serverErr),
+		"documents the over-match in IsNotFound that IsNotFoundStatus exists to avoid")
+}

--- a/internal/resources/oauth2client/read_deleted_test.go
+++ b/internal/resources/oauth2client/read_deleted_test.go
@@ -142,3 +142,26 @@ func TestRead_ServerErrorKeepsClient(t *testing.T) {
 	assert.True(t, resp.Diagnostics.HasError(), "a 500 must surface as an error")
 	assert.False(t, resp.State.Raw.IsNull(), "a 500 must not remove the resource from state")
 }
+
+// A 500 whose body merely contains the digits "404" must not be mistaken for a
+// deletion. Request IDs are hex strings, so they carry those digits about once
+// every 150 errors, and IsNotFound's substring fallback matches on them. Dropping
+// a live client from state over a transient outage is worse than the read error
+// this change removes, so the removal path checks the HTTP status alone.
+func TestRead_ServerErrorWith404InRequestIDKeepsClient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":500,"status":"Internal Server Error","request":"bfd5c404-7133-9506-8a5f-f7a738b14e04","message":"boom"}}`))
+	}))
+	defer srv.Close()
+
+	r := clientResourceForServer(t, srv.URL)
+	state := oauth2ClientState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	assert.True(t, resp.Diagnostics.HasError(), "a 500 must surface as an error")
+	assert.False(t, resp.State.Raw.IsNull(), "a 500 must not remove the resource from state")
+}

--- a/internal/resources/oauth2client/read_deleted_test.go
+++ b/internal/resources/oauth2client/read_deleted_test.go
@@ -80,10 +80,10 @@ func TestRead_ClientDeletedOutsideTerraform(t *testing.T) {
 }
 
 // TestRead_ClientDeletedOAuth2ErrorBody covers the other error shape this
-// endpoint can return. The SDK decodes a 404 body into its OAuth2 error model,
-// and only when that fails does it replace the "404 Not Found" status text with
-// the decode error — so neither the message nor the parsed body is a reliable
-// signal on its own. Detection must come from the HTTP status.
+// endpoint can return: the SDK decodes it into its OAuth2 error model, so the
+// error keeps its "404 Not Found" status text, where the Ory-shaped body fails
+// to decode and is recognized by its "code":404 instead. Both shapes must lead
+// to removal, whichever way the 404 is carried.
 func TestRead_ClientDeletedOAuth2ErrorBody(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/resources/oauth2client/read_deleted_test.go
+++ b/internal/resources/oauth2client/read_deleted_test.go
@@ -1,0 +1,144 @@
+package oauth2client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/terraform-provider-ory/internal/client"
+)
+
+// clientResourceForServer builds an OAuth2ClientResource whose project client
+// points at the given test server, so Read can be exercised end-to-end against a
+// fake Ory project API.
+func clientResourceForServer(t *testing.T, srvURL string) *OAuth2ClientResource {
+	t.Helper()
+	c, err := client.NewOryClient(client.OryClientConfig{
+		ProjectAPIKey: "test-key",
+		ProjectSlug:   "test-slug",
+		// The URL template takes the slug; the test server ignores the path.
+		ProjectAPIURL: srvURL + "/%s",
+	})
+	require.NoError(t, err)
+	return &OAuth2ClientResource{client: c}
+}
+
+// oauth2ClientState returns a state object tracking a single OAuth2 client, as
+// it would look after a successful create.
+func oauth2ClientState(t *testing.T, r *OAuth2ClientResource) tfsdk.State {
+	t.Helper()
+	ctx := context.Background()
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	require.False(t, schemaResp.Diagnostics.HasError())
+
+	nullList := types.ListNull(types.StringType)
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	diags := state.Set(ctx, OAuth2ClientResourceModel{
+		ID:                     types.StringValue("client-id"),
+		ClientID:               types.StringValue("client-id"),
+		ClientName:             types.StringValue("test client"),
+		GrantTypes:             nullList,
+		ResponseTypes:          nullList,
+		Audience:               nullList,
+		RedirectURIs:           nullList,
+		PostLogoutRedirectURIs: nullList,
+		AllowedCorsOrigins:     nullList,
+		Contacts:               nullList,
+	})
+	require.False(t, diags.HasError(), "%v", diags)
+	return state
+}
+
+// TestRead_ClientDeletedOutsideTerraform verifies that a client deleted through
+// the Ory Console is dropped from state, so the next plan recreates it instead of
+// failing with a read error that only `terraform state rm` can clear.
+func TestRead_ClientDeletedOutsideTerraform(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":404,"status":"Not Found","request":"req-1","message":"Unable to locate the resource"}}`))
+	}))
+	defer srv.Close()
+
+	r := clientResourceForServer(t, srv.URL)
+	state := oauth2ClientState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "a deleted client must not surface as an error: %v", resp.Diagnostics)
+	assert.True(t, resp.State.Raw.IsNull(), "a deleted client must be removed from state")
+}
+
+// TestRead_ClientDeletedOAuth2ErrorBody covers the other error shape this
+// endpoint can return. The SDK decodes a 404 body into its OAuth2 error model,
+// and only when that fails does it replace the "404 Not Found" status text with
+// the decode error — so neither the message nor the parsed body is a reliable
+// signal on its own. Detection must come from the HTTP status.
+func TestRead_ClientDeletedOAuth2ErrorBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not_found","error_description":"Unable to locate the resource"}`))
+	}))
+	defer srv.Close()
+
+	r := clientResourceForServer(t, srv.URL)
+	state := oauth2ClientState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "a deleted client must not surface as an error: %v", resp.Diagnostics)
+	assert.True(t, resp.State.Raw.IsNull(), "a deleted client must be removed from state")
+}
+
+// TestRead_ClientStillExists is the control: a live client must stay in state,
+// proving the removal path does not fire while the client is alive.
+func TestRead_ClientStillExists(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"client_id":"client-id","client_name":"test client","scope":"openid"}`))
+	}))
+	defer srv.Close()
+
+	r := clientResourceForServer(t, srv.URL)
+	state := oauth2ClientState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	require.False(t, resp.Diagnostics.HasError(), "%v", resp.Diagnostics)
+	assert.False(t, resp.State.Raw.IsNull(), "a live client must stay in state")
+}
+
+// TestRead_ServerErrorKeepsClient verifies a non-404 failure still surfaces as an
+// error and leaves state untouched: a transient outage must not be mistaken for a
+// deletion and silently drop the resource.
+func TestRead_ServerErrorKeepsClient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":500,"status":"Internal Server Error","message":"boom"}}`))
+	}))
+	defer srv.Close()
+
+	r := clientResourceForServer(t, srv.URL)
+	state := oauth2ClientState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	assert.True(t, resp.Diagnostics.HasError(), "a 500 must surface as an error")
+	assert.False(t, resp.State.Raw.IsNull(), "a 500 must not remove the resource from state")
+}

--- a/internal/resources/oauth2client/resource.go
+++ b/internal/resources/oauth2client/resource.go
@@ -707,6 +707,13 @@ func (r *OAuth2ClientResource) Read(ctx context.Context, req resource.ReadReques
 
 	oauthClient, err := r.client.GetOAuth2Client(ctx, state.ClientID.ValueString())
 	if err != nil {
+		if client.IsNotFound(err) {
+			// The client was deleted outside Terraform. Drop it from state so the
+			// next plan recreates it, instead of failing every plan until the
+			// operator runs `terraform state rm`.
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading OAuth2 Client",
 			"Could not read OAuth2 client "+state.ClientID.ValueString()+": "+err.Error(),

--- a/internal/resources/oauth2client/resource.go
+++ b/internal/resources/oauth2client/resource.go
@@ -707,7 +707,7 @@ func (r *OAuth2ClientResource) Read(ctx context.Context, req resource.ReadReques
 
 	oauthClient, err := r.client.GetOAuth2Client(ctx, state.ClientID.ValueString())
 	if err != nil {
-		if client.IsNotFound(err) {
+		if client.IsNotFoundStatus(err) {
 			// The client was deleted outside Terraform. Drop it from state so the
 			// next plan recreates it, instead of failing every plan until the
 			// operator runs `terraform state rm`.

--- a/internal/resources/oidcdynamicclient/read_deleted_test.go
+++ b/internal/resources/oidcdynamicclient/read_deleted_test.go
@@ -115,3 +115,23 @@ func TestRead_DynamicClientServerErrorKeepsResource(t *testing.T) {
 	assert.True(t, resp.Diagnostics.HasError(), "a 500 must surface as an error")
 	assert.False(t, resp.State.Raw.IsNull(), "a 500 must not remove the resource from state")
 }
+
+// Same guard as the OAuth2 client: a 500 whose body happens to contain "404"
+// must not drop a live resource from state.
+func TestRead_DynamicClientServerErrorWith404InRequestIDKeepsResource(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":500,"status":"Internal Server Error","request":"bfd5c404-7133-9506-8a5f-f7a738b14e04","message":"boom"}}`))
+	}))
+	defer srv.Close()
+
+	r := dynamicClientResourceForServer(t, srv.URL)
+	state := dynamicClientState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	assert.True(t, resp.Diagnostics.HasError(), "a 500 must surface as an error")
+	assert.False(t, resp.State.Raw.IsNull(), "a 500 must not remove the resource from state")
+}

--- a/internal/resources/oidcdynamicclient/read_deleted_test.go
+++ b/internal/resources/oidcdynamicclient/read_deleted_test.go
@@ -1,0 +1,117 @@
+package oidcdynamicclient
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/terraform-provider-ory/internal/client"
+)
+
+// dynamicClientResourceForServer builds an OIDCDynamicClientResource whose
+// project client points at the given test server, so Read can be exercised
+// end-to-end against a fake Ory project API.
+func dynamicClientResourceForServer(t *testing.T, srvURL string) *OIDCDynamicClientResource {
+	t.Helper()
+	c, err := client.NewOryClient(client.OryClientConfig{
+		ProjectAPIKey: "test-key",
+		ProjectSlug:   "test-slug",
+		// The URL template takes the slug; the test server ignores the path.
+		ProjectAPIURL: srvURL + "/%s",
+	})
+	require.NoError(t, err)
+	return &OIDCDynamicClientResource{client: c}
+}
+
+// dynamicClientState returns a state object tracking a single dynamic client, as
+// it would look after a successful create.
+func dynamicClientState(t *testing.T, r *OIDCDynamicClientResource) tfsdk.State {
+	t.Helper()
+	ctx := context.Background()
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	require.False(t, schemaResp.Diagnostics.HasError())
+
+	nullList := types.ListNull(types.StringType)
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	diags := state.Set(ctx, OIDCDynamicClientResourceModel{
+		ID:            types.StringValue("client-id"),
+		ClientID:      types.StringValue("client-id"),
+		ClientName:    types.StringValue("test client"),
+		GrantTypes:    nullList,
+		ResponseTypes: nullList,
+		RedirectURIs:  nullList,
+	})
+	require.False(t, diags.HasError(), "%v", diags)
+	return state
+}
+
+// TestRead_DynamicClientDeletedOutsideTerraform verifies that a client deleted
+// through the Ory Console is dropped from state, so the next plan recreates it
+// instead of failing with a read error that only `terraform state rm` can clear.
+func TestRead_DynamicClientDeletedOutsideTerraform(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":404,"status":"Not Found","request":"req-1","message":"Unable to locate the resource"}}`))
+	}))
+	defer srv.Close()
+
+	r := dynamicClientResourceForServer(t, srv.URL)
+	state := dynamicClientState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "a deleted client must not surface as an error: %v", resp.Diagnostics)
+	assert.True(t, resp.State.Raw.IsNull(), "a deleted client must be removed from state")
+}
+
+// TestRead_DynamicClientStillExists is the control: a live client must stay in
+// state, proving the removal path does not fire while the client is alive.
+func TestRead_DynamicClientStillExists(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"client_id":"client-id","client_name":"test client","scope":"openid"}`))
+	}))
+	defer srv.Close()
+
+	r := dynamicClientResourceForServer(t, srv.URL)
+	state := dynamicClientState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	require.False(t, resp.Diagnostics.HasError(), "%v", resp.Diagnostics)
+	assert.False(t, resp.State.Raw.IsNull(), "a live client must stay in state")
+}
+
+// TestRead_DynamicClientServerErrorKeepsResource verifies a non-404 failure still
+// surfaces as an error and leaves state untouched: a transient outage must not be
+// mistaken for a deletion and silently drop the resource.
+func TestRead_DynamicClientServerErrorKeepsResource(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":500,"status":"Internal Server Error","message":"boom"}}`))
+	}))
+	defer srv.Close()
+
+	r := dynamicClientResourceForServer(t, srv.URL)
+	state := dynamicClientState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	assert.True(t, resp.Diagnostics.HasError(), "a 500 must surface as an error")
+	assert.False(t, resp.State.Raw.IsNull(), "a 500 must not remove the resource from state")
+}

--- a/internal/resources/oidcdynamicclient/resource.go
+++ b/internal/resources/oidcdynamicclient/resource.go
@@ -347,7 +347,7 @@ func (r *OIDCDynamicClientResource) Read(ctx context.Context, req resource.ReadR
 
 	oauthClient, err := projectClient.GetOIDCDynamicClient(ctx, state.ClientID.ValueString())
 	if err != nil {
-		if client.IsNotFound(err) {
+		if client.IsNotFoundStatus(err) {
 			// The client was deleted outside Terraform. Drop it from state so the
 			// next plan recreates it, instead of failing every plan until the
 			// operator runs `terraform state rm`.

--- a/internal/resources/oidcdynamicclient/resource.go
+++ b/internal/resources/oidcdynamicclient/resource.go
@@ -341,11 +341,19 @@ func (r *OIDCDynamicClientResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 
-	// Derive a request-scoped client, using resource-level credentials if provided
-	client := helpers.ResolveProjectClient(r.client, state.ProjectSlug, state.ProjectAPIKey)
+	// Derive a request-scoped client, using resource-level credentials if provided.
+	// Named projectClient (not client) so the client package stays reachable below.
+	projectClient := helpers.ResolveProjectClient(r.client, state.ProjectSlug, state.ProjectAPIKey)
 
-	oauthClient, err := client.GetOIDCDynamicClient(ctx, state.ClientID.ValueString())
+	oauthClient, err := projectClient.GetOIDCDynamicClient(ctx, state.ClientID.ValueString())
 	if err != nil {
+		if client.IsNotFound(err) {
+			// The client was deleted outside Terraform. Drop it from state so the
+			// next plan recreates it, instead of failing every plan until the
+			// operator runs `terraform state rm`.
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading OIDC Dynamic Client",
 			"Could not read OIDC dynamic client "+state.ClientID.ValueString()+": "+err.Error(),

--- a/internal/resources/trustedjwtissuer/read_deleted_test.go
+++ b/internal/resources/trustedjwtissuer/read_deleted_test.go
@@ -1,0 +1,113 @@
+package trustedjwtissuer
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/terraform-provider-ory/internal/client"
+)
+
+// issuerResourceForServer builds a TrustedJwtIssuerResource whose project client
+// points at the given test server, so Read can be exercised end-to-end against a
+// fake Ory project API.
+func issuerResourceForServer(t *testing.T, srvURL string) *TrustedJwtIssuerResource {
+	t.Helper()
+	c, err := client.NewOryClient(client.OryClientConfig{
+		ProjectAPIKey: "test-key",
+		ProjectSlug:   "test-slug",
+		// The URL template takes the slug; the test server ignores the path.
+		ProjectAPIURL: srvURL + "/%s",
+	})
+	require.NoError(t, err)
+	return &TrustedJwtIssuerResource{client: c}
+}
+
+// issuerState returns a state object tracking a single trusted issuer, as it
+// would look after a successful create.
+func issuerState(t *testing.T, r *TrustedJwtIssuerResource) tfsdk.State {
+	t.Helper()
+	ctx := context.Background()
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	require.False(t, schemaResp.Diagnostics.HasError())
+
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	diags := state.Set(ctx, TrustedJwtIssuerResourceModel{
+		ID:     types.StringValue("issuer-id"),
+		Issuer: types.StringValue("https://example.com"),
+		Scope:  types.ListNull(types.StringType),
+	})
+	require.False(t, diags.HasError(), "%v", diags)
+	return state
+}
+
+// TestRead_IssuerDeletedOutsideTerraform verifies that an issuer deleted through
+// the Ory Console is dropped from state, so the next plan recreates it instead of
+// failing with a read error that only `terraform state rm` can clear.
+func TestRead_IssuerDeletedOutsideTerraform(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":404,"status":"Not Found","request":"req-1","message":"Unable to locate the resource"}}`))
+	}))
+	defer srv.Close()
+
+	r := issuerResourceForServer(t, srv.URL)
+	state := issuerState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "a deleted issuer must not surface as an error: %v", resp.Diagnostics)
+	assert.True(t, resp.State.Raw.IsNull(), "a deleted issuer must be removed from state")
+}
+
+// TestRead_IssuerStillExists is the control: a live issuer must stay in state,
+// proving the removal path does not fire while the issuer is alive.
+func TestRead_IssuerStillExists(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"issuer-id","issuer":"https://example.com","subject":"sub","scope":["openid"]}`))
+	}))
+	defer srv.Close()
+
+	r := issuerResourceForServer(t, srv.URL)
+	state := issuerState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	require.False(t, resp.Diagnostics.HasError(), "%v", resp.Diagnostics)
+	assert.False(t, resp.State.Raw.IsNull(), "a live issuer must stay in state")
+}
+
+// TestRead_ServerErrorKeepsResource verifies a non-404 failure still surfaces as
+// an error and leaves state untouched: a transient outage must not be mistaken
+// for a deletion and silently drop the resource.
+func TestRead_ServerErrorKeepsResource(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":500,"status":"Internal Server Error","message":"boom"}}`))
+	}))
+	defer srv.Close()
+
+	r := issuerResourceForServer(t, srv.URL)
+	state := issuerState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	assert.True(t, resp.Diagnostics.HasError(), "a 500 must surface as an error")
+	assert.False(t, resp.State.Raw.IsNull(), "a 500 must not remove the resource from state")
+}

--- a/internal/resources/trustedjwtissuer/read_deleted_test.go
+++ b/internal/resources/trustedjwtissuer/read_deleted_test.go
@@ -111,3 +111,23 @@ func TestRead_ServerErrorKeepsResource(t *testing.T) {
 	assert.True(t, resp.Diagnostics.HasError(), "a 500 must surface as an error")
 	assert.False(t, resp.State.Raw.IsNull(), "a 500 must not remove the resource from state")
 }
+
+// Same guard as the OAuth2 client: a 500 whose body happens to contain "404"
+// must not drop a live issuer from state.
+func TestRead_ServerErrorWith404InRequestIDKeepsResource(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":500,"status":"Internal Server Error","request":"bfd5c404-7133-9506-8a5f-f7a738b14e04","message":"boom"}}`))
+	}))
+	defer srv.Close()
+
+	r := issuerResourceForServer(t, srv.URL)
+	state := issuerState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	assert.True(t, resp.Diagnostics.HasError(), "a 500 must surface as an error")
+	assert.False(t, resp.State.Raw.IsNull(), "a 500 must not remove the resource from state")
+}

--- a/internal/resources/trustedjwtissuer/resource.go
+++ b/internal/resources/trustedjwtissuer/resource.go
@@ -269,7 +269,7 @@ func (r *TrustedJwtIssuerResource) Read(ctx context.Context, req resource.ReadRe
 
 	issuer, err := r.client.GetTrustedOAuth2JwtGrantIssuer(ctx, state.ID.ValueString())
 	if err != nil {
-		if client.IsNotFound(err) {
+		if client.IsNotFoundStatus(err) {
 			// The issuer was deleted outside Terraform. Drop it from state so the
 			// next plan recreates it, instead of failing every plan until the
 			// operator runs `terraform state rm`.

--- a/internal/resources/trustedjwtissuer/resource.go
+++ b/internal/resources/trustedjwtissuer/resource.go
@@ -269,6 +269,13 @@ func (r *TrustedJwtIssuerResource) Read(ctx context.Context, req resource.ReadRe
 
 	issuer, err := r.client.GetTrustedOAuth2JwtGrantIssuer(ctx, state.ID.ValueString())
 	if err != nil {
+		if client.IsNotFound(err) {
+			// The issuer was deleted outside Terraform. Drop it from state so the
+			// next plan recreates it, instead of failing every plan until the
+			// operator runs `terraform state rm`.
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading Trusted JWT Grant Issuer",
 			"Could not read trusted JWT grant issuer "+state.ID.ValueString()+": "+err.Error(),


### PR DESCRIPTION
## Problem

`Read` on `ory_oauth2_client`, `ory_oidc_dynamic_client`, and `ory_trusted_oauth2_jwt_grant_issuer` turns every API failure into a diagnostic error, including the 404 for a resource that was deleted in the Ory Console:

```
Error: Error Reading OAuth2 Client
Could not read OAuth2 client <id>: reading OAuth2 client: HTTP 404 ...
```

Terraform then fails on **every** subsequent plan — the configuration cannot converge until the operator runs `terraform state rm`. The expected behavior is to drop the resource from state so the next plan recreates it.

Most resources in this provider already do that (`jwk`, `relationship`, `identity`, `saml_provider`, `email_template`, …); these three did not.

## Why the removal decision needs its own check

`client.IsNotFound` already detects these 404s: its last resort is a substring match on the error text, and that catches both error body shapes these endpoints return. Detection is not the problem.

The problem is the opposite one. That substring match answers yes too often — any error text containing "404" or "Not Found" passes, and request IDs are hex, so a 500 carrying `bfd5c404-...` reads as a deletion. Removing a live resource from state is the one decision a false positive ruins: the read error at least stops the plan with a reason, while a silent removal makes the next apply try to recreate an OAuth2 client that still exists.

So the two questions are split:

- `ErrNotFound` + `notFoundIfStatus(httpResp, err)` tag errors whose response carried HTTP 404. The three getters tag theirs.
- `IsNotFoundStatus` honours that tag and nothing weaker. The three `Read` implementations gate removal on it.
- `IsNotFound` keeps its looser behaviour for `action.getHooks`, where a false positive only makes a teardown path give up early, and where `GetProject` is not tagged.

## Tests

Unit tests only — no credentials needed, following the pattern in `internal/resources/action/hooks_deleted_project_test.go`. Against an `httptest` server, per resource:

| Case | Expected |
|---|---|
| 404, Ory-style error body | removed from state, no error |
| 404, OAuth2-style error body (`oauth2client`) | removed from state, no error |
| 200, live resource | stays in state |
| 500 | error surfaced, stays in state |
| 500 whose request ID contains "404" | error surfaced, **stays** in state |

The last case is the regression test for the over-match: it fails when removal is gated on `IsNotFound` and passes when gated on `IsNotFoundStatus`. `TestIsNotFoundStatus` pins the split at the client level.

Verified locally: the removal tests fail when staged on `main` and pass here, the control tests pass on both, `go test ./...` and `make lint` (0 issues) are green.

## Not included

`project`, `workspace`, `organization`, and `project_config` also lack out-of-band-deletion handling in `Read`, but their semantics need separate thought (the client retries organization 404s five times for eventual consistency, and `project_config` is a singleton), so they are left out of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resources deleted outside Terraform are now removed from state automatically for OAuth2 clients, OIDC dynamic clients, and trusted JWT issuers.
  * Genuine not-found responses are distinguished from unrelated server errors that happen to contain “404”.
  * Other API errors continue to produce diagnostics and preserve resource state.

* **Tests**
  * Added coverage for deleted resources, successful reads, server errors, and ambiguous error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->