### PR TITLE
fix: remove project, workspace, organization, and project config from state when deleted outside Terraform

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -40,6 +40,20 @@ var ErrProjectNotAllowed = errors.New("project not allowed by allowed_project_id
 // IsNotFoundStatus — checks the tag instead.
 var ErrNotFound = errors.New("resource not found")
 
+// organizationRetryBaseDelay is the unit of the exponential backoff between the
+// organization consistency retries in GetOrganization (1x, 2x, 4x, 8x). It is a
+// variable so tests can exercise the retry path without waiting fifteen seconds.
+var organizationRetryBaseDelay = time.Second
+
+// SetOrganizationRetryBaseDelay overrides organizationRetryBaseDelay and returns
+// a function restoring the previous value. Tests use it to keep the retry path
+// covered without paying its production timing.
+func SetOrganizationRetryBaseDelay(d time.Duration) (restore func()) {
+	previous := organizationRetryBaseDelay
+	organizationRetryBaseDelay = d
+	return func() { organizationRetryBaseDelay = previous }
+}
+
 const (
 	// maxRetries is the maximum number of retry attempts for rate-limited requests.
 	maxRetries = 3
@@ -794,6 +808,7 @@ func (c *OryClient) GetProject(ctx context.Context, projectID string) (*ory.Proj
 		return nil, err
 	}
 	project, httpResp, err := c.consoleClient.ProjectAPI.GetProject(ctx, projectID).Execute()
+	err = notFoundIfStatus(httpResp, err)
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
 	}
@@ -1098,6 +1113,7 @@ func (c *OryClient) GetWorkspace(ctx context.Context, workspaceID string) (*ory.
 		return nil, err
 	}
 	workspace, httpResp, err := c.consoleClient.WorkspaceAPI.GetWorkspace(ctx, workspaceID).Execute()
+	err = notFoundIfStatus(httpResp, err)
 	if httpResp != nil {
 		_ = httpResp.Body.Close()
 	}
@@ -1118,7 +1134,11 @@ func (c *OryClient) GetWorkspace(ctx context.Context, workspaceID string) (*ory.
 					return &w, nil
 				}
 			}
-			return nil, fmt.Errorf("workspace %s not found", workspaceID)
+			// The list is authoritative: the workspace is absent, which is the
+			// same answer a 404 gives. Tag it so callers that must distinguish
+			// "gone" from "failed" — see IsNotFoundStatus — get the same signal
+			// on both paths.
+			return nil, fmt.Errorf("%w: workspace %s not found", ErrNotFound, workspaceID)
 		}
 		return nil, err
 	}
@@ -1212,6 +1232,7 @@ func (c *OryClient) GetOrganization(ctx context.Context, projectID, orgID string
 	var lastErr error
 	for attempt := 0; attempt < 5; attempt++ {
 		resp, httpResp, err := c.consoleClient.ProjectAPI.GetOrganization(ctx, projectID, orgID).Execute()
+		err = notFoundIfStatus(httpResp, err)
 		if httpResp != nil {
 			_ = httpResp.Body.Close()
 		}
@@ -1232,7 +1253,7 @@ func (c *OryClient) GetOrganization(ctx context.Context, projectID, orgID string
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
-			case <-time.After(time.Duration(1<<attempt) * time.Second):
+			case <-time.After(time.Duration(1<<attempt) * organizationRetryBaseDelay):
 			}
 		}
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1121,23 +1121,39 @@ func (c *OryClient) GetWorkspace(ctx context.Context, workspaceID string) (*ory.
 		// Check if it's a 403 error - try fallback to list
 		errStr := err.Error()
 		if strings.Contains(errStr, "403") || strings.Contains(errStr, "Forbidden") {
-			// Fall back to listing workspaces and finding by ID
-			listResp, listHttpResp, listErr := c.consoleClient.WorkspaceAPI.ListWorkspaces(ctx).Execute()
-			if listHttpResp != nil {
-				_ = listHttpResp.Body.Close()
-			}
-			if listErr != nil {
-				return nil, err // Return original error
-			}
-			for _, w := range listResp.Workspaces {
-				if w.GetId() == workspaceID {
-					return &w, nil
+			// Fall back to listing workspaces and finding by ID. The listing is
+			// paginated, and every page has to be read before "absent" means
+			// anything: callers treat absence as deletion, so stopping at the
+			// first page would drop a live workspace from Terraform state.
+			var pageToken string
+			for {
+				listReq := c.consoleClient.WorkspaceAPI.ListWorkspaces(ctx)
+				if pageToken != "" {
+					listReq = listReq.PageToken(pageToken)
 				}
+				listResp, listHttpResp, listErr := listReq.Execute()
+				if listHttpResp != nil {
+					_ = listHttpResp.Body.Close()
+				}
+				if listErr != nil {
+					return nil, err // Return original error
+				}
+				for _, w := range listResp.Workspaces {
+					if w.GetId() == workspaceID {
+						return &w, nil
+					}
+				}
+				next := listResp.GetNextPageToken()
+				// A repeated token would loop forever; treat it as the end.
+				if !listResp.GetHasNextPage() || next == "" || next == pageToken {
+					break
+				}
+				pageToken = next
 			}
-			// The list is authoritative: the workspace is absent, which is the
-			// same answer a 404 gives. Tag it so callers that must distinguish
-			// "gone" from "failed" — see IsNotFoundStatus — get the same signal
-			// on both paths.
+			// Every page has been read and the workspace is not in any of them,
+			// which is the same answer a 404 gives. Tag it so callers that must
+			// tell "gone" from "failed" — see IsNotFoundStatus — get the same
+			// signal on both paths.
 			return nil, fmt.Errorf("%w: workspace %s not found", ErrNotFound, workspaceID)
 		}
 		return nil, err

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -40,19 +40,12 @@ var ErrProjectNotAllowed = errors.New("project not allowed by allowed_project_id
 // IsNotFoundStatus — checks the tag instead.
 var ErrNotFound = errors.New("resource not found")
 
-// organizationRetryBaseDelay is the unit of the exponential backoff between the
-// organization consistency retries in GetOrganization (1x, 2x, 4x, 8x). It is a
-// variable so tests can exercise the retry path without waiting fifteen seconds.
-var organizationRetryBaseDelay = time.Second
-
-// SetOrganizationRetryBaseDelay overrides organizationRetryBaseDelay and returns
-// a function restoring the previous value. Tests use it to keep the retry path
-// covered without paying its production timing.
-func SetOrganizationRetryBaseDelay(d time.Duration) (restore func()) {
-	previous := organizationRetryBaseDelay
-	organizationRetryBaseDelay = d
-	return func() { organizationRetryBaseDelay = previous }
-}
+const (
+	// defaultOrganizationRetryBaseDelay is the unit of the exponential backoff
+	// between the organization consistency retries in GetOrganization
+	// (1x, 2x, 4x, 8x), used when the config leaves it unset.
+	defaultOrganizationRetryBaseDelay = time.Second
+)
 
 const (
 	// maxRetries is the maximum number of retry attempts for rate-limited requests.
@@ -414,6 +407,12 @@ type OryClientConfig struct {
 	// project ID not in this list is refused before the request is sent. When
 	// empty, no restriction is applied. See OryClient.checkProjectAllowed.
 	AllowedProjectIDs []string
+
+	// OrganizationRetryBaseDelay is the unit of the exponential backoff between
+	// the organization consistency retries in GetOrganization. Zero means
+	// defaultOrganizationRetryBaseDelay; tests shorten it so the retry path can
+	// be covered without waiting fifteen seconds.
+	OrganizationRetryBaseDelay time.Duration
 }
 
 // Equal reports whether two configs are equivalent. It is used to decide
@@ -428,7 +427,8 @@ func (c OryClientConfig) Equal(other OryClientConfig) bool {
 		c.WorkspaceID != other.WorkspaceID ||
 		c.ConsoleAPIURL != other.ConsoleAPIURL ||
 		c.ProjectAPIURL != other.ProjectAPIURL ||
-		c.UserAgent != other.UserAgent {
+		c.UserAgent != other.UserAgent ||
+		c.OrganizationRetryBaseDelay != other.OrganizationRetryBaseDelay {
 		return false
 	}
 	if len(c.AllowedProjectIDs) != len(other.AllowedProjectIDs) {
@@ -1232,6 +1232,15 @@ func (c *OryClient) CreateOrganization(ctx context.Context, projectID, label str
 	return org, nil
 }
 
+// organizationRetryBaseDelay returns the configured backoff unit for the
+// organization consistency retries, falling back to the production default.
+func (c *OryClient) organizationRetryBaseDelay() time.Duration {
+	if c.config.OrganizationRetryBaseDelay > 0 {
+		return c.config.OrganizationRetryBaseDelay
+	}
+	return defaultOrganizationRetryBaseDelay
+}
+
 // GetOrganization retrieves an organization by ID.
 // Includes retry logic to handle eventual consistency after organization creation.
 func (c *OryClient) GetOrganization(ctx context.Context, projectID, orgID string) (*ory.Organization, error) {
@@ -1269,7 +1278,7 @@ func (c *OryClient) GetOrganization(ctx context.Context, projectID, orgID string
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
-			case <-time.After(time.Duration(1<<attempt) * organizationRetryBaseDelay):
+			case <-time.After(time.Duration(1<<attempt) * c.organizationRetryBaseDelay()):
 			}
 		}
 	}

--- a/internal/client/guardrail_test.go
+++ b/internal/client/guardrail_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -118,6 +119,25 @@ func TestOryClientConfig_Equal(t *testing.T) {
 
 	emptyBoth := OryClientConfig{}
 	assert.True(t, emptyBoth.Equal(OryClientConfig{}))
+
+	// The retry delay decides real timing, so a client configured with one value
+	// must not be reused for another.
+	delayDiff := base
+	delayDiff.AllowedProjectIDs = []string{"a", "b"}
+	delayDiff.OrganizationRetryBaseDelay = time.Millisecond
+	assert.False(t, base.Equal(delayDiff))
+}
+
+// The zero value means "use the production default". A regression that returned
+// zero instead would drop the backoff entirely and hammer the API through all
+// five organization retries, which no other test would notice: the ones that
+// exercise the retry path set the delay explicitly.
+func TestOrganizationRetryBaseDelay_ZeroFallsBackToDefault(t *testing.T) {
+	unset := &OryClient{config: OryClientConfig{}}
+	assert.Equal(t, defaultOrganizationRetryBaseDelay, unset.organizationRetryBaseDelay())
+
+	configured := &OryClient{config: OryClientConfig{OrganizationRetryBaseDelay: time.Millisecond}}
+	assert.Equal(t, time.Millisecond, configured.organizationRetryBaseDelay())
 }
 
 // errorsIsSanity guards against accidental removal of the sentinel wrapping.

--- a/internal/resources/organization/read_deleted_test.go
+++ b/internal/resources/organization/read_deleted_test.go
@@ -1,0 +1,113 @@
+package organization
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/terraform-provider-ory/internal/client"
+)
+
+// organizationResourceForServer builds an OrganizationResource whose console
+// client points at the given test server. The consistency backoff is shortened
+// for the duration of the test: GetOrganization retries a 404 five times, which
+// would otherwise make each case wait fifteen seconds.
+func organizationResourceForServer(t *testing.T, srvURL string) *OrganizationResource {
+	t.Helper()
+	t.Cleanup(client.SetOrganizationRetryBaseDelay(time.Millisecond))
+	c, err := client.NewOryClient(client.OryClientConfig{
+		WorkspaceAPIKey: "ws-test-key",
+		ConsoleAPIURL:   srvURL,
+		ProjectID:       "proj-1",
+	})
+	require.NoError(t, err)
+	return &OrganizationResource{client: c}
+}
+
+// organizationState returns a state object tracking a single organization, as it
+// would look after a successful create.
+func organizationState(t *testing.T, r *OrganizationResource) tfsdk.State {
+	t.Helper()
+	ctx := context.Background()
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	require.False(t, schemaResp.Diagnostics.HasError())
+
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	diags := state.Set(ctx, OrganizationResourceModel{
+		ID:        types.StringValue("org-1"),
+		Label:     types.StringValue("test org"),
+		ProjectID: types.StringValue("proj-1"),
+		Domains:   types.ListNull(types.StringType),
+	})
+	require.False(t, diags.HasError(), "%v", diags)
+	return state
+}
+
+func readOrganization(t *testing.T, srv *httptest.Server) *resource.ReadResponse {
+	t.Helper()
+	r := organizationResourceForServer(t, srv.URL)
+	state := organizationState(t, r)
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+	return resp
+}
+
+// TestRead_OrganizationDeletedOutsideTerraform verifies that an organization
+// deleted through the Ory Console is dropped from state once the consistency
+// retries are exhausted, rather than failing every plan.
+func TestRead_OrganizationDeletedOutsideTerraform(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":404,"status":"Not Found","request":"req-1","message":"organization not found"}}`))
+	}))
+	defer srv.Close()
+
+	resp := readOrganization(t, srv)
+
+	assert.False(t, resp.Diagnostics.HasError(), "a deleted organization must not surface as an error: %v", resp.Diagnostics)
+	assert.True(t, resp.State.Raw.IsNull(), "a deleted organization must be removed from state")
+}
+
+// TestRead_OrganizationStillExists is the control: a live organization stays in
+// state.
+func TestRead_OrganizationStillExists(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"organization":{"id":"org-1","label":"test org","domains":[],"project_id":"proj-1","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}}`))
+	}))
+	defer srv.Close()
+
+	resp := readOrganization(t, srv)
+
+	require.False(t, resp.Diagnostics.HasError(), "%v", resp.Diagnostics)
+	assert.False(t, resp.State.Raw.IsNull(), "a live organization must stay in state")
+}
+
+// TestRead_OrganizationServerErrorKeepsResource pins the direction of the gate:
+// a 500 carrying "404" in its request ID must surface as an error, not read as a
+// deletion. It also proves the 500 is not retried as a consistency lag.
+func TestRead_OrganizationServerErrorKeepsResource(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":500,"status":"Internal Server Error","request":"bfd5c404-7133-9506-8a5f-f7a738b14e04","message":"boom"}}`))
+	}))
+	defer srv.Close()
+
+	resp := readOrganization(t, srv)
+
+	assert.True(t, resp.Diagnostics.HasError(), "a 500 must surface as an error")
+	assert.False(t, resp.State.Raw.IsNull(), "a 500 must not remove the resource from state")
+}

--- a/internal/resources/organization/read_deleted_test.go
+++ b/internal/resources/organization/read_deleted_test.go
@@ -22,11 +22,11 @@ import (
 // would otherwise make each case wait fifteen seconds.
 func organizationResourceForServer(t *testing.T, srvURL string) *OrganizationResource {
 	t.Helper()
-	t.Cleanup(client.SetOrganizationRetryBaseDelay(time.Millisecond))
 	c, err := client.NewOryClient(client.OryClientConfig{
-		WorkspaceAPIKey: "ws-test-key",
-		ConsoleAPIURL:   srvURL,
-		ProjectID:       "proj-1",
+		WorkspaceAPIKey:            "ws-test-key",
+		ConsoleAPIURL:              srvURL,
+		ProjectID:                  "proj-1",
+		OrganizationRetryBaseDelay: time.Millisecond,
 	})
 	require.NoError(t, err)
 	return &OrganizationResource{client: c}

--- a/internal/resources/organization/resource.go
+++ b/internal/resources/organization/resource.go
@@ -219,6 +219,14 @@ func (r *OrganizationResource) Read(ctx context.Context, req resource.ReadReques
 
 	org, err := r.client.GetOrganization(ctx, projectID, state.ID.ValueString())
 	if err != nil {
+		if client.IsNotFoundStatus(err) {
+			// The organization was deleted outside Terraform, and the consistency
+			// retries in GetOrganization did not turn it up. Drop it from state so
+			// the next plan recreates it, instead of failing every plan until the
+			// operator runs `terraform state rm`.
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading Organization",
 			"Could not read organization ID "+state.ID.ValueString()+": "+err.Error(),

--- a/internal/resources/project/read_deleted_test.go
+++ b/internal/resources/project/read_deleted_test.go
@@ -1,0 +1,109 @@
+package project
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/terraform-provider-ory/internal/client"
+)
+
+// projectResourceForServer builds a ProjectResource whose console client points
+// at the given test server, so Read can be exercised end-to-end against a fake
+// Ory Console.
+func projectResourceForServer(t *testing.T, srvURL string) *ProjectResource {
+	t.Helper()
+	c, err := client.NewOryClient(client.OryClientConfig{
+		WorkspaceAPIKey: "ws-test-key",
+		ConsoleAPIURL:   srvURL,
+	})
+	require.NoError(t, err)
+	return &ProjectResource{client: c}
+}
+
+// projectState returns a state object tracking a single project, as it would
+// look after a successful create.
+func projectState(t *testing.T, r *ProjectResource) tfsdk.State {
+	t.Helper()
+	ctx := context.Background()
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	require.False(t, schemaResp.Diagnostics.HasError())
+
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	diags := state.Set(ctx, ProjectResourceModel{
+		ID:   types.StringValue("proj-1"),
+		Name: types.StringValue("test project"),
+	})
+	require.False(t, diags.HasError(), "%v", diags)
+	return state
+}
+
+// TestRead_ProjectPurgedOutsideTerraform verifies that a project purged through
+// the Ory Console is dropped from state, so the next plan recreates it instead of
+// failing every plan until the operator runs `terraform state rm`.
+func TestRead_ProjectPurgedOutsideTerraform(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":404,"status":"Not Found","request":"req-1","message":"project not found"}}`))
+	}))
+	defer srv.Close()
+
+	r := projectResourceForServer(t, srv.URL)
+	state := projectState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "a purged project must not surface as an error: %v", resp.Diagnostics)
+	assert.True(t, resp.State.Raw.IsNull(), "a purged project must be removed from state")
+}
+
+// TestRead_ProjectStillExists is the control: a live project must stay in state.
+func TestRead_ProjectStillExists(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"proj-1","name":"test project","slug":"s","environment":"prod","home_region":"eu-central","revision_id":"r","organizations":[],"state":"running","services":{}}`))
+	}))
+	defer srv.Close()
+
+	r := projectResourceForServer(t, srv.URL)
+	state := projectState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	require.False(t, resp.Diagnostics.HasError(), "%v", resp.Diagnostics)
+	assert.False(t, resp.State.Raw.IsNull(), "a live project must stay in state")
+}
+
+// TestRead_ProjectServerErrorKeepsResource pins the direction of the removal
+// gate: a 500 whose request ID happens to carry the digits "404" must surface as
+// an error and leave state intact, never be mistaken for a purge.
+func TestRead_ProjectServerErrorKeepsResource(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":500,"status":"Internal Server Error","request":"bfd5c404-7133-9506-8a5f-f7a738b14e04","message":"boom"}}`))
+	}))
+	defer srv.Close()
+
+	r := projectResourceForServer(t, srv.URL)
+	state := projectState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	assert.True(t, resp.Diagnostics.HasError(), "a 500 must surface as an error")
+	assert.False(t, resp.State.Raw.IsNull(), "a 500 must not remove the resource from state")
+}

--- a/internal/resources/project/read_deleted_test.go
+++ b/internal/resources/project/read_deleted_test.go
@@ -107,3 +107,45 @@ func TestRead_ProjectServerErrorKeepsResource(t *testing.T) {
 	assert.True(t, resp.Diagnostics.HasError(), "a 500 must surface as an error")
 	assert.False(t, resp.State.Raw.IsNull(), "a 500 must not remove the resource from state")
 }
+
+// TestRead_ProjectSoftDeletedOutsideTerraform covers what deleting a project in
+// the console actually does. It is a soft delete: GetProject keeps answering 200
+// and only the state field changes, so the 404 path above never fires and plan
+// used to report no changes at all for a project that is gone.
+func TestRead_ProjectSoftDeletedOutsideTerraform(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"proj-1","name":"test project","slug":"test-slug","state":"deleted","environment":"prod","home_region":"eu-central","revision_id":"r","organizations":[],"services":{}}`))
+	}))
+	defer srv.Close()
+
+	r := projectResourceForServer(t, srv.URL)
+	state := projectState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "a deleted project must not surface as an error: %v", resp.Diagnostics)
+	assert.True(t, resp.State.Raw.IsNull(), "a deleted project must be removed from state")
+}
+
+// The control for the state check: a halted project is not gone, so it must stay
+// in state rather than being recreated.
+func TestRead_ProjectHaltedStaysInState(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"proj-1","name":"test project","slug":"test-slug","state":"halted","environment":"prod","home_region":"eu-central","revision_id":"r","organizations":[],"services":{}}`))
+	}))
+	defer srv.Close()
+
+	r := projectResourceForServer(t, srv.URL)
+	state := projectState(t, r)
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	require.False(t, resp.Diagnostics.HasError(), "%v", resp.Diagnostics)
+	assert.False(t, resp.State.Raw.IsNull(), "a halted project must stay in state")
+}

--- a/internal/resources/project/resource.go
+++ b/internal/resources/project/resource.go
@@ -16,6 +16,11 @@ import (
 	"github.com/ory/terraform-provider-ory/internal/client"
 )
 
+// projectStateDeleted is the state Ory reports for a project that has been
+// deleted. The delete is soft: the project keeps answering GetProject with 200
+// and this state, rather than starting to 404.
+const projectStateDeleted = "deleted"
+
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
 	_ resource.Resource                = &ProjectResource{}
@@ -263,6 +268,16 @@ func (r *ProjectResource) Read(ctx context.Context, req resource.ReadRequest, re
 			"Error Reading Project",
 			"Could not read project ID "+state.ID.ValueString()+": "+err.Error(),
 		)
+		return
+	}
+
+	// Deleting a project through the console is a soft delete: GetProject keeps
+	// answering 200 and only the state field changes, so the 404 above never
+	// fires for the case operators actually hit. Without this check a plan
+	// reports no changes at all for a project that is gone from the console.
+	// ActionResource.getHooksFromProject treats the same state the same way.
+	if project.GetState() == projectStateDeleted {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resources/project/resource.go
+++ b/internal/resources/project/resource.go
@@ -211,6 +211,11 @@ func (r *ProjectResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	project, httpResp, err := r.client.CreateProject(ctx, plan.Name.ValueString(), plan.Environment.ValueString(), plan.HomeRegion.ValueString())
+	// CreateProject hands back the response so the 402 below can read its status;
+	// closing it here is what keeps the connection from leaking on every create.
+	if httpResp != nil {
+		defer func() { _ = httpResp.Body.Close() }()
+	}
 	if err != nil {
 		if httpResp != nil && httpResp.StatusCode == 402 {
 			resp.Diagnostics.AddError(
@@ -247,6 +252,13 @@ func (r *ProjectResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	project, err := r.client.GetProject(ctx, state.ID.ValueString())
 	if err != nil {
+		if client.IsNotFoundStatus(err) {
+			// The project was purged outside Terraform. Drop it from state so the
+			// next plan recreates it, instead of failing every plan until the
+			// operator runs `terraform state rm`.
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading Project",
 			"Could not read project ID "+state.ID.ValueString()+": "+err.Error(),

--- a/internal/resources/projectconfig/read_deleted_test.go
+++ b/internal/resources/projectconfig/read_deleted_test.go
@@ -1,0 +1,117 @@
+package projectconfig
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/terraform-provider-ory/internal/client"
+)
+
+// projectConfigResourceForServer builds a ProjectConfigResource whose console
+// client points at the given test server, so Read can be exercised end-to-end
+// against a fake Ory Console.
+func projectConfigResourceForServer(t *testing.T, srvURL string) *ProjectConfigResource {
+	t.Helper()
+	c, err := client.NewOryClient(client.OryClientConfig{
+		WorkspaceAPIKey: "ws-test-key",
+		ConsoleAPIURL:   srvURL,
+	})
+	require.NoError(t, err)
+	return &ProjectConfigResource{client: c}
+}
+
+// projectConfigState returns a state object holding only the two identifying
+// attributes. The schema is generated and carries hundreds of attributes, so the
+// object is built null and the two that Read needs are filled in.
+func projectConfigState(t *testing.T, s schema.Schema) tfsdk.State {
+	t.Helper()
+	ctx := context.Background()
+
+	objType, ok := s.Type().TerraformType(ctx).(tftypes.Object)
+	require.True(t, ok)
+
+	values := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		values[name] = tftypes.NewValue(attrType, nil)
+	}
+
+	state := tfsdk.State{Schema: s, Raw: tftypes.NewValue(objType, values)}
+	require.False(t, state.SetAttribute(ctx, path.Root("id"), types.StringValue("proj-1")).HasError())
+	require.False(t, state.SetAttribute(ctx, path.Root("project_id"), types.StringValue("proj-1")).HasError())
+	return state
+}
+
+func readProjectConfig(t *testing.T, srv *httptest.Server) *resource.ReadResponse {
+	t.Helper()
+	ctx := context.Background()
+
+	r := projectConfigResourceForServer(t, srv.URL)
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	require.False(t, schemaResp.Diagnostics.HasError())
+
+	state := projectConfigState(t, schemaResp.Schema)
+	resp := &resource.ReadResponse{State: state}
+	r.Read(ctx, resource.ReadRequest{State: state}, resp)
+	return resp
+}
+
+// TestRead_ProjectConfigProjectPurged verifies that the config resource leaves
+// state when the project it configures is gone. The config is not an object of
+// its own: it lives inside the project, so a purged project takes it with it.
+func TestRead_ProjectConfigProjectPurged(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":404,"status":"Not Found","request":"req-1","message":"project not found"}}`))
+	}))
+	defer srv.Close()
+
+	resp := readProjectConfig(t, srv)
+
+	assert.False(t, resp.Diagnostics.HasError(), "a purged project must not surface as an error: %v", resp.Diagnostics)
+	assert.True(t, resp.State.Raw.IsNull(), "a purged project must take its config out of state")
+}
+
+// TestRead_ProjectConfigProjectAlive is the control: a live project keeps its
+// config in state.
+func TestRead_ProjectConfigProjectAlive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"proj-1","name":"n","slug":"s","environment":"prod","home_region":"eu-central","revision_id":"r","organizations":[],"state":"running","services":{}}`))
+	}))
+	defer srv.Close()
+
+	resp := readProjectConfig(t, srv)
+
+	require.False(t, resp.Diagnostics.HasError(), "%v", resp.Diagnostics)
+	assert.False(t, resp.State.Raw.IsNull(), "a live project must keep its config in state")
+}
+
+// TestRead_ProjectConfigServerErrorKeepsResource pins the direction of the gate:
+// a 500 carrying "404" in its request ID must surface as an error, not a purge.
+func TestRead_ProjectConfigServerErrorKeepsResource(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":500,"status":"Internal Server Error","request":"bfd5c404-7133-9506-8a5f-f7a738b14e04","message":"boom"}}`))
+	}))
+	defer srv.Close()
+
+	resp := readProjectConfig(t, srv)
+
+	assert.True(t, resp.Diagnostics.HasError(), "a 500 must surface as an error")
+	assert.False(t, resp.State.Raw.IsNull(), "a 500 must not remove the resource from state")
+}

--- a/internal/resources/projectconfig/read_deleted_test.go
+++ b/internal/resources/projectconfig/read_deleted_test.go
@@ -115,3 +115,21 @@ func TestRead_ProjectConfigServerErrorKeepsResource(t *testing.T) {
 	assert.True(t, resp.Diagnostics.HasError(), "a 500 must surface as an error")
 	assert.False(t, resp.State.Raw.IsNull(), "a 500 must not remove the resource from state")
 }
+
+// TestRead_ProjectConfigProjectSoftDeleted covers what deleting a project in the
+// console actually does. It is a soft delete: GetProject keeps answering 200 and
+// only the state field changes, so the 404 path never fires and plan used to
+// report no changes for the config of a project that is gone.
+func TestRead_ProjectConfigProjectSoftDeleted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"proj-1","name":"n","slug":"s","environment":"prod","home_region":"eu-central","revision_id":"r","organizations":[],"state":"deleted","services":{}}`))
+	}))
+	defer srv.Close()
+
+	resp := readProjectConfig(t, srv)
+
+	assert.False(t, resp.Diagnostics.HasError(), "a deleted project must not surface as an error: %v", resp.Diagnostics)
+	assert.True(t, resp.State.Raw.IsNull(), "a deleted project must take its config out of state")
+}

--- a/internal/resources/projectconfig/resource.go
+++ b/internal/resources/projectconfig/resource.go
@@ -1450,6 +1450,11 @@ func hookEntries(plan *ProjectConfigResourceModel) []hookEntry {
 // when the notify_previous_addresses hook carries no config.
 const notifyPreviousAddressesDefaultRecipients = "removed"
 
+// projectStateDeleted is the state Ory reports for a project that has been
+// deleted. The delete is soft: the project keeps answering GetProject with 200
+// and this state, rather than starting to 404.
+const projectStateDeleted = "deleted"
+
 // notifyPreviousAddressesConfig builds the config object for the
 // notify_previous_addresses hook entry, or nil when no scope is configured.
 func notifyPreviousAddressesConfig(plan *ProjectConfigResourceModel) map[string]interface{} {
@@ -1783,6 +1788,15 @@ func (r *ProjectConfigResource) Read(ctx context.Context, req resource.ReadReque
 				"Could not read project "+projectID+": "+err.Error())
 			return
 		}
+	}
+
+	// Deleting a project through the console is a soft delete: GetProject keeps
+	// answering 200 and only the state field changes, so the 404 above never
+	// fires for the case operators actually hit. A deleted project's config is
+	// gone with it, so drop the resource rather than reporting no changes.
+	if project.GetState() == projectStateDeleted {
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
 	r.readProjectConfig(ctx, project, &state)

--- a/internal/resources/projectconfig/resource.go
+++ b/internal/resources/projectconfig/resource.go
@@ -1772,6 +1772,13 @@ func (r *ProjectConfigResource) Read(ctx context.Context, req resource.ReadReque
 		var err error
 		project, err = r.client.GetProject(ctx, projectID)
 		if err != nil {
+			if client.IsNotFoundStatus(err) {
+				// The config is not an object of its own: it lives inside the
+				// project. A purged project takes its config with it, so drop the
+				// resource from state rather than failing every plan.
+				resp.State.RemoveResource(ctx)
+				return
+			}
 			resp.Diagnostics.AddError("Error Reading Project Config",
 				"Could not read project "+projectID+": "+err.Error())
 			return

--- a/internal/resources/workspace/read_deleted_test.go
+++ b/internal/resources/workspace/read_deleted_test.go
@@ -1,0 +1,128 @@
+package workspace
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/terraform-provider-ory/internal/client"
+)
+
+// workspaceResourceForServer builds a WorkspaceResource whose console client
+// points at the given test server, so Read can be exercised end-to-end against a
+// fake Ory Console.
+func workspaceResourceForServer(t *testing.T, srvURL string) *WorkspaceResource {
+	t.Helper()
+	c, err := client.NewOryClient(client.OryClientConfig{
+		WorkspaceAPIKey: "ws-test-key",
+		ConsoleAPIURL:   srvURL,
+	})
+	require.NoError(t, err)
+	return &WorkspaceResource{client: c}
+}
+
+// workspaceState returns a state object tracking a single workspace, as it would
+// look after a successful create.
+func workspaceState(t *testing.T, r *WorkspaceResource) tfsdk.State {
+	t.Helper()
+	ctx := context.Background()
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	require.False(t, schemaResp.Diagnostics.HasError())
+
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	diags := state.Set(ctx, WorkspaceResourceModel{
+		ID:   types.StringValue("ws-1"),
+		Name: types.StringValue("test workspace"),
+	})
+	require.False(t, diags.HasError(), "%v", diags)
+	return state
+}
+
+func readWorkspace(t *testing.T, srv *httptest.Server) *resource.ReadResponse {
+	t.Helper()
+	r := workspaceResourceForServer(t, srv.URL)
+	state := workspaceState(t, r)
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+	return resp
+}
+
+// TestRead_WorkspaceDeletedOutsideTerraform covers the direct path: GetWorkspace
+// answers 404, so the workspace is gone and must leave state.
+func TestRead_WorkspaceDeletedOutsideTerraform(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":404,"status":"Not Found","request":"req-1","message":"workspace not found"}}`))
+	}))
+	defer srv.Close()
+
+	resp := readWorkspace(t, srv)
+
+	assert.False(t, resp.Diagnostics.HasError(), "a deleted workspace must not surface as an error: %v", resp.Diagnostics)
+	assert.True(t, resp.State.Raw.IsNull(), "a deleted workspace must be removed from state")
+}
+
+// TestRead_WorkspaceDeletedViaListFallback covers the other path into "gone".
+// Some API keys may list workspaces but not GET one, so GetWorkspace falls back
+// to ListWorkspaces on a 403. A workspace missing from that list is just as
+// absent as a 404, and must leave state rather than fail every plan.
+func TestRead_WorkspaceDeletedViaListFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(req.URL.Path, "/workspaces/") {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":{"code":403,"status":"Forbidden","message":"no access"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"workspaces":[{"id":"other-ws","name":"other","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z","subscription_id":null}],"has_next_page":false,"next_page_token":""}`))
+	}))
+	defer srv.Close()
+
+	resp := readWorkspace(t, srv)
+
+	assert.False(t, resp.Diagnostics.HasError(), "a workspace absent from the list must not surface as an error: %v", resp.Diagnostics)
+	assert.True(t, resp.State.Raw.IsNull(), "a workspace absent from the list must be removed from state")
+}
+
+// TestRead_WorkspaceStillExists is the control: a live workspace stays in state.
+func TestRead_WorkspaceStillExists(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"ws-1","name":"test workspace","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-02T00:00:00Z","subscription_id":null}`))
+	}))
+	defer srv.Close()
+
+	resp := readWorkspace(t, srv)
+
+	require.False(t, resp.Diagnostics.HasError(), "%v", resp.Diagnostics)
+	assert.False(t, resp.State.Raw.IsNull(), "a live workspace must stay in state")
+}
+
+// TestRead_WorkspaceServerErrorKeepsResource pins the direction of the gate: a
+// 500 carrying "404" in its request ID must surface as an error, not a deletion.
+func TestRead_WorkspaceServerErrorKeepsResource(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":500,"status":"Internal Server Error","request":"bfd5c404-7133-9506-8a5f-f7a738b14e04","message":"boom"}}`))
+	}))
+	defer srv.Close()
+
+	resp := readWorkspace(t, srv)
+
+	assert.True(t, resp.Diagnostics.HasError(), "a 500 must surface as an error")
+	assert.False(t, resp.State.Raw.IsNull(), "a 500 must not remove the resource from state")
+}

--- a/internal/resources/workspace/read_deleted_test.go
+++ b/internal/resources/workspace/read_deleted_test.go
@@ -96,6 +96,34 @@ func TestRead_WorkspaceDeletedViaListFallback(t *testing.T) {
 	assert.True(t, resp.State.Raw.IsNull(), "a workspace absent from the list must be removed from state")
 }
 
+// TestRead_WorkspaceOnLaterListPageIsKept guards the dangerous half of the list
+// fallback. The listing is paginated, and absence from it is read as deletion, so
+// a workspace that merely sits on a later page must still be found. Reading only
+// the first page would drop a live workspace from state and make the next apply
+// create a duplicate.
+func TestRead_WorkspaceOnLaterListPageIsKept(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(req.URL.Path, "/workspaces/") {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":{"code":403,"status":"Forbidden","message":"no access"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if req.URL.Query().Get("page_token") == "page-2" {
+			_, _ = w.Write([]byte(`{"workspaces":[{"id":"ws-1","name":"test workspace","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-02T00:00:00Z","subscription_id":null}],"has_next_page":false,"next_page_token":""}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"workspaces":[{"id":"other-ws","name":"other","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z","subscription_id":null}],"has_next_page":true,"next_page_token":"page-2"}`))
+	}))
+	defer srv.Close()
+
+	resp := readWorkspace(t, srv)
+
+	require.False(t, resp.Diagnostics.HasError(), "%v", resp.Diagnostics)
+	assert.False(t, resp.State.Raw.IsNull(), "a workspace on a later page is live and must stay in state")
+}
+
 // TestRead_WorkspaceStillExists is the control: a live workspace stays in state.
 func TestRead_WorkspaceStillExists(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/resources/workspace/resource.go
+++ b/internal/resources/workspace/resource.go
@@ -142,6 +142,14 @@ func (r *WorkspaceResource) Read(ctx context.Context, req resource.ReadRequest, 
 
 	workspace, err := r.client.GetWorkspace(ctx, state.ID.ValueString())
 	if err != nil {
+		if client.IsNotFoundStatus(err) {
+			// The workspace is gone — either a 404, or absent from the list the
+			// client falls back to when a key may list but not GET. Drop it from
+			// state so the next plan recreates it, instead of failing every plan
+			// until the operator runs `terraform state rm`.
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading Workspace",
 			"Could not read workspace ID "+state.ID.ValueString()+": "+err.Error(),


### PR DESCRIPTION
Follow-up to #318, covering the four resources it listed as out of scope.

## Problem

`Read` on `ory_project`, `ory_workspace`, `ory_organization`, and `ory_project_config` turns every API failure into a diagnostic error, including the 404 for a resource deleted through the Ory Console:

```
Error: Error Reading Project
Could not read project ID <id>: 404 Not Found
```

Every subsequent plan fails the same way. The configuration cannot converge until the operator runs `terraform state rm`, where the expected behaviour is to drop the resource from state and plan a recreate.

## Approach

Same split #318 settled on. The getters tag a 404 with `ErrNotFound`, and each `Read` gates removal on `IsNotFoundStatus`, never on `IsNotFound` — a 500 whose request ID happens to contain "404" must not drop a live resource.

Two paths needed more than a status check:

- **`GetWorkspace`** falls back to `ListWorkspaces` when a key may list but not GET a workspace. A workspace absent from that list is as gone as a 404, so that branch carries the same tag instead of returning an untagged `fmt.Errorf`.
- **`GetOrganization`** retries a 404 five times for eventual consistency. The retries stay and the tag rides the final error, so a deleted organization leaves state once they are exhausted. Its base delay moved into a variable (`SetOrganizationRetryBaseDelay`) so the retry path stays covered without a fifteen-second unit test.

`ory_project_config` is not an object of its own — it lives inside the project — so a purged project takes its config out of state with it.

## Tests

Unit tests only, no credentials, against an `httptest` server:

| Resource | Cases |
|---|---|
| `project` | 404 purge / live / 500 |
| `workspace` | 404 / absent from list fallback / live / 500 |
| `organization` | 404 after retries / live / 500 |
| `project_config` | project purged / project alive / 500 |

Every 500 fixture carries `"request":"bfd5c404-..."` — the case that made #318 fail review. Each one asserts the error surfaces and the resource **stays** in state.

Verified by reverting the four `Read` changes with the client tagging left in place: the five removal tests fail, the controls pass. `go test ./...` and `make lint` are green.

## One thing that is not part of the fix

`ProjectResource.Create` never closed the response `CreateProject` hands back — a connection leaked on every project create. The client edit changes what `bodyclose` can see, so it now reports it and CI would fail without the one-line close. Flagging it since it is unrelated to state removal.

## Known limitation: the workspace list fallback

`GetWorkspace` falls back to `ListWorkspaces`, and absence from that listing is treated as deletion. The listing only shows what the configured key can see, so a workspace that exists but is invisible to the key looks identical to one that was deleted: 403 on the direct read, then absent from the list.

So **a key scoped to the wrong workspace will drop a live workspace from state**, and the next apply creates a duplicate. A workspace is a billable top-level container, so that is worth knowing before upgrading.

`b7179dd` is what makes this defensible rather than reckless: the fallback now reads every page, so absence is authoritative for everything the key can see. It cannot cover what the key cannot see at all.

The project path deliberately does not do this. A project that answers 403 stays an unrecoverable error instead of being treated as gone, which is the trade #318 settled on. A purged project therefore still needs `terraform state rm`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resources removed outside Terraform are automatically cleared from state for organizations, projects, project configurations, and workspaces.
  * Soft-deleted projects and project configurations are removed from state.
  * Genuine server errors continue to produce diagnostics while preserving resource state.
  * Workspace lookups now handle paginated results and missing workspaces more reliably.

* **Improvements**
  * Organization retry delays can be configured, with a one-second default when unspecified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
