### PR TITLE
fix(action): accept auth_method "profile" for settings after-hooks

### DIFF
--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -50,6 +50,16 @@ resource "ory_action" "after_login_saml" {
   method      = "POST"
 }
 
+# Post-settings webhook for profile/trait updates. The profile method exists only
+# on the settings flow.
+resource "ory_action" "after_profile_update" {
+  flow        = "settings"
+  timing      = "after"
+  auth_method = "profile"
+  url         = "https://api.example.com/webhooks/profile-updated"
+  method      = "POST"
+}
+
 # Webhook with write-only (ephemeral) authentication secrets sourced from Vault.
 # The *_wo secrets are never stored in Terraform state or plan (Terraform 1.11+).
 # Bump the matching *_wo_version whenever a secret rotates so Terraform re-sends it.
@@ -144,6 +154,7 @@ The `auth_method` attribute specifies which authentication method triggers the w
 | `password` | Password-based authentication (default) |
 | `oidc` | Social/OIDC authentication (Google, GitHub, etc.) |
 | `code` | One-time code (magic link, OTP) |
+| `profile` | Profile/trait update (settings flow only) |
 | `webauthn` | Hardware security keys |
 | `passkey` | Passkey authentication |
 | `totp` | Time-based one-time password |
@@ -151,6 +162,37 @@ The `auth_method` attribute specifies which authentication method triggers the w
 | `saml` | SAML single sign-on (SSO) |
 
 ~> **Note:** `auth_method` only applies to `timing = "after"` webhooks on the `login`, `registration`, and `settings` flows. The `recovery` and `verification` flows are **not** scoped by authentication method — their after-hooks always run — so `auth_method` is ignored for them and should be omitted. For `timing = "before"` hooks, the webhook runs before any authentication method is invoked.
+
+### Method Availability by Flow
+
+Not every method exists on every flow. Ory accepts a hook written to an
+unsupported flow and method pair with HTTP 200 but discards it, so the provider
+warns during `terraform plan` and the apply then fails verification.
+
+| Method | `login` | `registration` | `settings` |
+|--------|---------|----------------|------------|
+| `password` | yes | yes | yes |
+| `oidc` | yes | yes | yes |
+| `code` | yes | yes | no |
+| `profile` | no | no | yes |
+| `webauthn` | yes | yes | yes |
+| `passkey` | yes | yes | yes |
+| `totp` | yes | no | yes |
+| `lookup_secret` | yes | no | yes |
+| `saml` | yes | yes | yes |
+
+The `profile` method covers the settings flow's profile/trait update step, which
+Ory stores at `selfservice.flows.settings.after.profile.hooks`:
+
+```hcl
+resource "ory_action" "profile_updated" {
+  flow        = "settings"
+  timing      = "after"
+  auth_method = "profile"
+  url         = "https://api.example.com/webhooks/profile-updated"
+  method      = "POST"
+}
+```
 
 ## Webhook Authentication
 
@@ -246,7 +288,7 @@ terraform import ory_action.validate \
 1. **project_id**: Settings → General → Project ID
 2. **flow**: The flow type (login, registration, recovery, settings, verification)
 3. **timing**: "before" or "after"
-4. **auth_method**: for `login`/`registration`/`settings` "after" hooks, one of password, oidc, code, webauthn, passkey, totp, lookup_secret, saml. For `recovery`/`verification` "after" hooks the value is ignored, but the import ID format still requires this segment — use `password` to match the provider default and avoid a post-import diff (keep `auth_method` omitted from the resource configuration itself).
+4. **auth_method**: for `login`/`registration`/`settings` "after" hooks, one of password, oidc, code, profile, webauthn, passkey, totp, lookup_secret, saml (see the availability table above — `profile` is settings-only). For `recovery`/`verification` "after" hooks the value is ignored, but the import ID format still requires this segment — use `password` to match the provider default and avoid a post-import diff (keep `auth_method` omitted from the resource configuration itself).
 5. **method**: The HTTP method (POST, GET, PUT, PATCH, DELETE)
 6. **url**: The exact webhook URL - must match exactly including protocol and trailing slashes
 
@@ -273,7 +315,7 @@ Common issues:
 
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
-- `auth_method` (String) Authentication method that triggers the webhook. In the Ory Console UI, this is the "Method" selector. Valid values: `password` (default), `oidc` (social login), `code` (magic link/OTP), `webauthn`, `passkey`, `totp`, `lookup_secret`, `saml` (SAML single sign-on). Only applies to `timing = "after"` webhooks on the `login`, `registration`, and `settings` flows; it is ignored for the `recovery` and `verification` flows.
+- `auth_method` (String) Authentication method that triggers the webhook. In the Ory Console UI, this is the "Method" selector. Valid values: `password` (default), `oidc` (social login), `code` (magic link/OTP), `profile` (profile/trait update, settings flow only), `webauthn`, `passkey`, `totp`, `lookup_secret`, `saml` (SAML single sign-on). Only applies to `timing = "after"` webhooks on the `login`, `registration`, and `settings` flows; it is ignored for the `recovery` and `verification` flows. Not every method is available on every flow — see the method availability table in the resource description.
 - `body` (String) Jsonnet template for the request body.
 - `can_interrupt` (Boolean) Allow webhook to interrupt/block the flow (default: false).
 - `method` (String) HTTP method (default: POST).

--- a/examples/resources/ory_action/resource.tf
+++ b/examples/resources/ory_action/resource.tf
@@ -32,6 +32,16 @@ resource "ory_action" "after_login_saml" {
   method      = "POST"
 }
 
+# Post-settings webhook for profile/trait updates. The profile method exists only
+# on the settings flow.
+resource "ory_action" "after_profile_update" {
+  flow        = "settings"
+  timing      = "after"
+  auth_method = "profile"
+  url         = "https://api.example.com/webhooks/profile-updated"
+  method      = "POST"
+}
+
 # Webhook with write-only (ephemeral) authentication secrets sourced from Vault.
 # The *_wo secrets are never stored in Terraform state or plan (Terraform 1.11+).
 # Bump the matching *_wo_version whenever a secret rotates so Terraform re-sends it.

--- a/internal/resources/action/hooks_test.go
+++ b/internal/resources/action/hooks_test.go
@@ -50,12 +50,17 @@ func afterConfig(flow string, after map[string]interface{}) map[string]interface
 	}
 }
 
-// TestAuthMethodValidatorAcceptsSAML is the schema-level regression for issue
-// #305: the Ory Console UI offers "saml" as an after-login authentication
-// method, but the auth_method validator rejected it. Every documented method
-// (including saml) must pass validation, while an unknown method must still be
-// rejected so we know the validator is active.
-func TestAuthMethodValidatorAcceptsSAML(t *testing.T) {
+// allAuthMethods is every authentication method the auth_method schema enum
+// accepts. It is also the union of the per-flow sets returned by
+// authMethodsForFlow.
+var allAuthMethods = []string{
+	"password", "oidc", "code", "profile", "webauthn", "passkey", "totp", "lookup_secret", "saml",
+}
+
+// authMethodValidate runs the auth_method schema validators against a value and
+// returns the diagnostics they produce.
+func authMethodValidate(t *testing.T, value string) diag.Diagnostics {
+	t.Helper()
 	ctx := context.Background()
 	r := &ActionResource{}
 	var schemaResp resource.SchemaResponse
@@ -66,26 +71,31 @@ func TestAuthMethodValidatorAcceptsSAML(t *testing.T) {
 	validators := attr.StringValidators()
 	require.NotEmpty(t, validators, "auth_method must have validators")
 
-	validate := func(value string) diag.Diagnostics {
-		var diags diag.Diagnostics
-		for _, v := range validators {
-			resp := &validator.StringResponse{}
-			v.ValidateString(ctx, validator.StringRequest{
-				Path:        path.Root("auth_method"),
-				ConfigValue: types.StringValue(value),
-			}, resp)
-			diags.Append(resp.Diagnostics...)
-		}
-		return diags
+	var diags diag.Diagnostics
+	for _, v := range validators {
+		resp := &validator.StringResponse{}
+		v.ValidateString(ctx, validator.StringRequest{
+			Path:        path.Root("auth_method"),
+			ConfigValue: types.StringValue(value),
+		}, resp)
+		diags.Append(resp.Diagnostics...)
 	}
+	return diags
+}
 
-	for _, method := range []string{"password", "oidc", "code", "webauthn", "passkey", "totp", "lookup_secret", "saml"} {
+// TestAuthMethodValidatorAcceptsDocumentedMethods is the schema-level regression
+// for issues #305 ("saml") and #328 ("profile"): both are methods the Ory API
+// stores hooks under, but the auth_method validator rejected them. Every
+// documented method must pass validation, while an unknown method must still be
+// rejected so we know the validator is active.
+func TestAuthMethodValidatorAcceptsDocumentedMethods(t *testing.T) {
+	for _, method := range allAuthMethods {
 		t.Run(method, func(t *testing.T) {
-			assert.Falsef(t, validate(method).HasError(), "auth_method %q must be accepted", method)
+			assert.Falsef(t, authMethodValidate(t, method).HasError(), "auth_method %q must be accepted", method)
 		})
 	}
 
-	assert.True(t, validate("magic").HasError(), "an unknown auth_method must be rejected")
+	assert.True(t, authMethodValidate(t, "magic").HasError(), "an unknown auth_method must be rejected")
 }
 
 func TestFlowSupportsAuthMethod(t *testing.T) {
@@ -100,6 +110,90 @@ func TestFlowSupportsAuthMethod(t *testing.T) {
 	for flow, want := range cases {
 		assert.Equalf(t, want, flowSupportsAuthMethod(flow), "flowSupportsAuthMethod(%q)", flow)
 	}
+}
+
+// TestAuthMethodsForFlow pins the per-flow method sets to what the live Console
+// API reports as the keys under selfservice.flows.<flow>.after. Writing a hook
+// to a method the flow has no key for is accepted with HTTP 200 and discarded.
+func TestAuthMethodsForFlow(t *testing.T) {
+	assert.ElementsMatch(t,
+		[]string{"password", "oidc", "code", "webauthn", "passkey", "totp", "lookup_secret", "saml"},
+		authMethodsForFlow("login"))
+	assert.ElementsMatch(t,
+		[]string{"password", "oidc", "code", "webauthn", "passkey", "saml"},
+		authMethodsForFlow("registration"))
+	assert.ElementsMatch(t,
+		[]string{"password", "oidc", "profile", "webauthn", "passkey", "totp", "lookup_secret", "saml"},
+		authMethodsForFlow("settings"))
+
+	for _, flow := range []string{"recovery", "verification", "unknown"} {
+		assert.Nilf(t, authMethodsForFlow(flow), "flow %q has no method-scoped after-hooks", flow)
+	}
+}
+
+// TestAuthMethodsForFlowCoversSchemaEnum guards the two tables against drifting
+// apart: every method the schema accepts must be supported by at least one flow,
+// and no per-flow set may name a method the schema rejects. Without this, adding
+// a method to the enum and forgetting authMethodsForFlow would make the provider
+// warn about a method it advertises.
+func TestAuthMethodsForFlowCoversSchemaEnum(t *testing.T) {
+	union := map[string]bool{}
+	for _, flow := range []string{"login", "registration", "settings"} {
+		for _, method := range authMethodsForFlow(flow) {
+			union[method] = true
+			assert.Falsef(t, authMethodValidate(t, method).HasError(),
+				"method %q is offered for flow %q but rejected by the schema enum", method, flow)
+		}
+	}
+	for _, method := range allAuthMethods {
+		assert.Truef(t, union[method], "method %q is in the schema enum but no flow supports it", method)
+	}
+}
+
+// TestFlowSupportsMethod covers the method and flow pairs that differ from the
+// flat enum: profile is settings-only, code is not a settings method, and
+// totp/lookup_secret are not registration methods.
+func TestFlowSupportsMethod(t *testing.T) {
+	cases := []struct {
+		flow, method string
+		want         bool
+	}{
+		{"settings", "profile", true},
+		{"login", "profile", false},
+		{"registration", "profile", false},
+		{"login", "code", true},
+		{"registration", "code", true},
+		{"settings", "code", false},
+		{"login", "totp", true},
+		{"settings", "totp", true},
+		{"registration", "totp", false},
+		{"registration", "lookup_secret", false},
+		{"login", "saml", true},
+		{"recovery", "password", false},
+		{"verification", "password", false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.flow+"/"+tt.method, func(t *testing.T) {
+			assert.Equal(t, tt.want, flowSupportsMethod(tt.flow, tt.method))
+		})
+	}
+}
+
+// TestVerifyFailureDetail verifies the apply-time "hook not found" diagnostic
+// names an unsupported flow and method pair as the likely cause, and stays terse
+// for a supported pair (where the cause is something else).
+func TestVerifyFailureDetail(t *testing.T) {
+	unsupported := verifyFailureDetail("login", "after", "profile", "https://example.com/hook")
+	assert.Contains(t, unsupported, "does not support auth_method \"profile\"")
+	assert.Contains(t, unsupported, "password, oidc, code", "the detail must list the flow's supported methods")
+
+	supported := verifyFailureDetail("settings", "after", "profile", "https://example.com/hook")
+	assert.Contains(t, supported, "Hook not found in PatchProject response")
+	assert.NotContains(t, supported, "does not support auth_method")
+
+	// A flat-hook flow ignores auth_method, so never blame the method.
+	flat := verifyFailureDetail("verification", "after", "password", "https://example.com/hook")
+	assert.NotContains(t, flat, "does not support auth_method")
 }
 
 func TestHookPath(t *testing.T) {
@@ -122,6 +216,12 @@ func TestHookPath(t *testing.T) {
 		{
 			name: "settings after is auth-method scoped", flow: "settings", timing: "after", authMethod: "password",
 			want: "/services/identity/config/selfservice/flows/settings/after/password/hooks",
+		},
+		{
+			// Regression for issue #328: the settings flow stores profile-update
+			// hooks under the "profile" method.
+			name: "settings after profile", flow: "settings", timing: "after", authMethod: "profile",
+			want: "/services/identity/config/selfservice/flows/settings/after/profile/hooks",
 		},
 		{
 			// Regression for issue #241: verification has no auth-method level.
@@ -190,6 +290,33 @@ func TestGetHooksFromProject_AuthScopedFlows(t *testing.T) {
 	})
 	hooks = r.getHooksFromProject(actionTestProject(flatOnly), "login", "after", "password")
 	assert.Empty(t, hooks, "auth-scoped read must not pick up flat after-hooks")
+}
+
+// TestGetHooksFromProject_SettingsProfile is the read-side regression for issue
+// #328. On a real project, settings.after.profile already carries the built-in
+// verify_new_address and organization hooks, so the read must return the whole
+// array and findHookIndex must pick out the web_hook without tripping over the
+// entries that have no config block.
+func TestGetHooksFromProject_SettingsProfile(t *testing.T) {
+	r := &ActionResource{}
+	cfg := afterConfig("settings", map[string]interface{}{
+		"profile": map[string]interface{}{
+			"hooks": []interface{}{
+				map[string]interface{}{"hook": "verify_new_address"},
+				actionTestWebhook("https://example.com/profile-updated"),
+				map[string]interface{}{"hook": "organization"},
+			},
+		},
+	})
+
+	hooks := r.getHooksFromProject(actionTestProject(cfg), "settings", "after", "profile")
+	require.Len(t, hooks, 3)
+
+	index := r.findHookIndex(hooks, "https://example.com/profile-updated", "POST")
+	require.Equal(t, 1, index)
+
+	// The password method on the same flow must not see the profile hooks.
+	assert.Empty(t, r.getHooksFromProject(actionTestProject(cfg), "settings", "after", "password"))
 }
 
 // TestGetHooksFromProject_BeforeTiming verifies before-hooks are read flat for all flows.

--- a/internal/resources/action/resource.go
+++ b/internal/resources/action/resource.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -130,6 +131,7 @@ The ` + "`auth_method`" + ` attribute specifies which authentication method trig
 | ` + "`password`" + ` | Password-based authentication (default) | "Password" |
 | ` + "`oidc`" + ` | Social/OIDC authentication (Google, GitHub, etc.) | "Social Sign-In" |
 | ` + "`code`" + ` | One-time code (magic link, OTP) | "Code" |
+| ` + "`profile`" + ` | Profile/trait update (settings flow only) | "Profile" |
 | ` + "`webauthn`" + ` | Hardware security keys | "WebAuthn" |
 | ` + "`passkey`" + ` | Passkey authentication | "Passkey" |
 | ` + "`totp`" + ` | Time-based one-time password | "TOTP" |
@@ -137,6 +139,35 @@ The ` + "`auth_method`" + ` attribute specifies which authentication method trig
 | ` + "`saml`" + ` | SAML single sign-on (SSO) | "SAML" |
 
 **Note:** ` + "`auth_method`" + ` only applies to ` + "`timing = \"after\"`" + ` webhooks on the ` + "`login`" + `, ` + "`registration`" + `, and ` + "`settings`" + ` flows. The ` + "`recovery`" + ` and ` + "`verification`" + ` flows are not scoped by authentication method, so ` + "`auth_method`" + ` is ignored for them and should be omitted. For ` + "`timing = \"before\"`" + ` hooks, the webhook runs before any authentication method.
+
+### Method Availability by Flow
+
+Not every method exists on every flow. The Ory API accepts a hook written to an
+unsupported flow and method pair with HTTP 200 but discards it, so the provider
+warns at plan time and the apply then fails verification.
+
+| Method | ` + "`login`" + ` | ` + "`registration`" + ` | ` + "`settings`" + ` |
+|--------|---------|----------------|------------|
+| ` + "`password`" + ` | yes | yes | yes |
+| ` + "`oidc`" + ` | yes | yes | yes |
+| ` + "`code`" + ` | yes | yes | no |
+| ` + "`profile`" + ` | no | no | yes |
+| ` + "`webauthn`" + ` | yes | yes | yes |
+| ` + "`passkey`" + ` | yes | yes | yes |
+| ` + "`totp`" + ` | yes | no | yes |
+| ` + "`lookup_secret`" + ` | yes | no | yes |
+| ` + "`saml`" + ` | yes | yes | yes |
+
+` + "```hcl" + `
+# Post-profile-update webhook on the settings flow
+resource "ory_action" "profile_updated" {
+  flow        = "settings"
+  timing      = "after"
+  auth_method = "profile"
+  url         = "https://api.example.com/webhooks/profile-updated"
+  method      = "POST"
+}
+` + "```" + `
 
 ## Webhook Authentication
 
@@ -252,13 +283,13 @@ func (r *ActionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"auth_method": schema.StringAttribute{
-				Description:         "Authentication method to hook into (password, oidc, code, webauthn, passkey, totp, lookup_secret, saml). Defaults to 'password'. Only applies to 'after' timing on the login, registration, and settings flows; ignored for the recovery and verification flows.",
-				MarkdownDescription: "Authentication method that triggers the webhook. In the Ory Console UI, this is the \"Method\" selector. Valid values: `password` (default), `oidc` (social login), `code` (magic link/OTP), `webauthn`, `passkey`, `totp`, `lookup_secret`, `saml` (SAML single sign-on). Only applies to `timing = \"after\"` webhooks on the `login`, `registration`, and `settings` flows; it is ignored for the `recovery` and `verification` flows.",
+				Description:         "Authentication method to hook into (password, oidc, code, profile, webauthn, passkey, totp, lookup_secret, saml). Defaults to 'password'. Only applies to 'after' timing on the login, registration, and settings flows; ignored for the recovery and verification flows. Not every method is available on every flow: 'profile' is settings-only, 'code' is login/registration-only, and 'totp'/'lookup_secret' are login/settings-only.",
+				MarkdownDescription: "Authentication method that triggers the webhook. In the Ory Console UI, this is the \"Method\" selector. Valid values: `password` (default), `oidc` (social login), `code` (magic link/OTP), `profile` (profile/trait update, settings flow only), `webauthn`, `passkey`, `totp`, `lookup_secret`, `saml` (SAML single sign-on). Only applies to `timing = \"after\"` webhooks on the `login`, `registration`, and `settings` flows; it is ignored for the `recovery` and `verification` flows. Not every method is available on every flow — see the method availability table in the resource description.",
 				Optional:            true,
 				Computed:            true,
 				Default:             stringdefault.StaticString("password"),
 				Validators: []validator.String{
-					stringvalidator.OneOf("password", "oidc", "code", "webauthn", "passkey", "totp", "lookup_secret", "saml"),
+					stringvalidator.OneOf("password", "oidc", "code", "profile", "webauthn", "passkey", "totp", "lookup_secret", "saml"),
 				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -443,9 +474,9 @@ func (r *ActionResource) ValidateConfig(ctx context.Context, req resource.Valida
 	if !config.AuthMethod.IsNull() && !config.AuthMethod.IsUnknown() &&
 		!config.Flow.IsNull() && !config.Flow.IsUnknown() {
 		flow := config.Flow.ValueString()
+		timingKnown := !config.Timing.IsNull() && !config.Timing.IsUnknown()
 		ignoredByFlow := !flowSupportsAuthMethod(flow)
-		ignoredByTiming := !config.Timing.IsNull() && !config.Timing.IsUnknown() &&
-			config.Timing.ValueString() != timingAfter
+		ignoredByTiming := timingKnown && config.Timing.ValueString() != timingAfter
 		if ignoredByFlow || ignoredByTiming {
 			detail := fmt.Sprintf("The %q flow does not scope its hooks by authentication method, so "+
 				"auth_method is ignored. You can safely remove auth_method from this resource.", flow)
@@ -457,6 +488,17 @@ func (r *ActionResource) ValidateConfig(ctx context.Context, req resource.Valida
 				path.Root("auth_method"),
 				"auth_method has no effect for this configuration",
 				detail,
+			)
+		} else if authMethod := config.AuthMethod.ValueString(); timingKnown && !flowSupportsMethod(flow, authMethod) {
+			// The method passes the schema enum but this flow has no key for it, so
+			// the API accepts the patch with HTTP 200 and drops the hook. Warn rather
+			// than error so a config the provider misjudges (for example because a
+			// later Ory release adds a method key) can still be planned; the apply
+			// verification catches it either way.
+			resp.Diagnostics.AddAttributeWarning(
+				path.Root("auth_method"),
+				"auth_method is not available on this flow",
+				unsupportedMethodDetail(flow, authMethod),
 			)
 		}
 	}
@@ -667,6 +709,33 @@ func (r *ActionResource) findHookIndex(hooks []map[string]interface{}, url, meth
 	return -1
 }
 
+// authMethodsForFlow returns the authentication methods a flow's "after" hooks
+// can be scoped by, in the order the Ory Console UI lists them. A flow with no
+// method-scoped after-hooks (recovery, verification) returns nil.
+//
+// The sets are the method keys under
+// services.identity.config.selfservice.flows.<flow>.after in a live project
+// config, which is also how the Console UI builds its "Method" picker. Verified
+// against the Console API on 2026-08-13: "profile" exists only for settings,
+// "code" only for login and registration, and "totp"/"lookup_secret" only for
+// login and settings.
+//
+// Writing a hook to a method a flow does not support returns HTTP 200 but the
+// API drops the key, so nothing is stored. See
+// https://github.com/ory/terraform-provider-ory/issues/328
+func authMethodsForFlow(flow string) []string {
+	switch flow {
+	case "login":
+		return []string{"password", "oidc", "code", "webauthn", "passkey", "totp", "lookup_secret", "saml"}
+	case "registration":
+		return []string{"password", "oidc", "code", "webauthn", "passkey", "saml"}
+	case "settings":
+		return []string{"password", "oidc", "profile", "webauthn", "passkey", "totp", "lookup_secret", "saml"}
+	default:
+		return nil
+	}
+}
+
 // flowSupportsAuthMethod reports whether a flow's "after" hooks are scoped by
 // authentication method (e.g. .../after/password/hooks). Only the login,
 // registration, and settings flows have method-scoped after-hooks in the Ory
@@ -675,12 +744,32 @@ func (r *ActionResource) findHookIndex(hooks []map[string]interface{}, url, meth
 // to .../after/<auth_method>/hooks for them returns 200 but silently drops the
 // hook. See https://github.com/ory/terraform-provider-ory/issues/241
 func flowSupportsAuthMethod(flow string) bool {
-	switch flow {
-	case "login", "registration", "settings":
-		return true
-	default:
-		return false
+	return authMethodsForFlow(flow) != nil
+}
+
+// flowSupportsMethod reports whether the given flow's after-hooks accept the
+// given authentication method.
+func flowSupportsMethod(flow, authMethod string) bool {
+	return slices.Contains(authMethodsForFlow(flow), authMethod)
+}
+
+// unsupportedMethodDetail explains that a flow has no key for an authentication
+// method and lists the methods it does accept.
+func unsupportedMethodDetail(flow, authMethod string) string {
+	return fmt.Sprintf("The %q flow does not support auth_method %q. Supported methods for this flow: %s. "+
+		"Ory accepts a hook written to an unsupported method with HTTP 200 but discards it, so the hook is "+
+		"never stored.", flow, authMethod, strings.Join(authMethodsForFlow(flow), ", "))
+}
+
+// verifyFailureDetail describes a hook that is absent from the PatchProject
+// response. An unsupported flow and method pair is the most likely cause, so
+// name it instead of leaving the user with a bare "not found".
+func verifyFailureDetail(flow, timing, authMethod, url string) string {
+	detail := fmt.Sprintf("Hook not found in PatchProject response for %s/%s/%s with URL %s", flow, timing, authMethod, url)
+	if timing == timingAfter && flowSupportsAuthMethod(flow) && !flowSupportsMethod(flow, authMethod) {
+		detail += "\n\n" + unsupportedMethodDetail(flow, authMethod)
 	}
+	return detail
 }
 
 func (r *ActionResource) hookPath(flow, timing, authMethod string) string {
@@ -813,7 +902,7 @@ func (r *ActionResource) Create(ctx context.Context, req resource.CreateRequest,
 	hooks = r.getHooksFromProject(&project, flow, timing, authMethod)
 	if r.findHookIndex(hooks, url, httpMethod) < 0 {
 		resp.Diagnostics.AddError("Error Verifying Action",
-			fmt.Sprintf("Hook not found in PatchProject response for %s/%s/%s with URL %s", flow, timing, authMethod, url))
+			verifyFailureDetail(flow, timing, authMethod, url))
 		return
 	}
 
@@ -1102,7 +1191,7 @@ func (r *ActionResource) Update(ctx context.Context, req resource.UpdateRequest,
 	updatedHooks := r.getHooksFromProject(&project, flow, timing, authMethod)
 	if r.findHookIndex(updatedHooks, newURL, newMethod) < 0 {
 		resp.Diagnostics.AddError("Error Verifying Action Update",
-			fmt.Sprintf("Hook not found in PatchProject response for %s/%s/%s with URL %s", flow, timing, authMethod, newURL))
+			verifyFailureDetail(flow, timing, authMethod, newURL))
 		return
 	}
 

--- a/internal/resources/action/resource_test.go
+++ b/internal/resources/action/resource_test.go
@@ -5,6 +5,7 @@ package action_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -272,6 +273,69 @@ func TestAccActionResource_samlLogin(t *testing.T) {
 					resource.TestCheckResourceAttr("ory_action.test", "timing", "after"),
 					resource.TestCheckResourceAttr("ory_action.test", "auth_method", "saml"),
 					resource.TestCheckResourceAttr("ory_action.test", "method", "POST"),
+				),
+			},
+			// Import using the 6-part format: project_id:flow:timing:auth_method:method:url
+			{
+				ResourceName:      "ory_action.test",
+				ImportState:       true,
+				ImportStateIdFunc: actionImportStateIDFunc,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccActionResource_settingsProfile is the regression test for issue #328:
+// the Ory API stores settings:after:profile hooks under the "profile"
+// authentication method, but the provider's auth_method validator rejected
+// "profile", making those webhooks unmanageable. This exercises create, read,
+// update, import, and delete of a webhook bound to the profile method on the
+// settings flow (stored at .../settings/after/profile/hooks, alongside the
+// built-in verify_new_address and organization hooks configured there).
+// project_id is set explicitly so the update step is an in-place Update. When it
+// is left to the provider default it plans as unknown, and because it requires
+// replacement, every change becomes a destroy and create.
+func TestAccActionResource_settingsProfile(t *testing.T) {
+	projectID := os.Getenv("ORY_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("ORY_PROJECT_ID must be set to exercise the in-place update step")
+	}
+
+	webhookURL := testutil.ExampleWebhookURL + "/profile-after-settings"
+	hookPath := "/services/identity/config/selfservice/flows/settings/after/profile/hooks"
+	configData := map[string]string{
+		"ProjectID":  projectID,
+		"WebhookURL": testutil.ExampleWebhookURL,
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.AccPreCheck(t)
+			cleanupDanglingWebhook(t, hookPath, webhookURL)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create and Read
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/settings_profile.tf.tmpl", configData),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_action.test", "id"),
+					resource.TestCheckResourceAttr("ory_action.test", "flow", "settings"),
+					resource.TestCheckResourceAttr("ory_action.test", "timing", "after"),
+					resource.TestCheckResourceAttr("ory_action.test", "auth_method", "profile"),
+					resource.TestCheckResourceAttr("ory_action.test", "method", "POST"),
+					resource.TestCheckResourceAttr("ory_action.test", "url", webhookURL),
+				),
+			},
+			// Update: the url and auth_method are unchanged, so the hook is patched
+			// at its existing index under the profile method.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/settings_profile_updated.tf.tmpl", configData),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_action.test", "auth_method", "profile"),
+					resource.TestCheckResourceAttr("ory_action.test", "response_parse", "true"),
+					resource.TestCheckResourceAttr("ory_action.test", "can_interrupt", "true"),
 				),
 			},
 			// Import using the 6-part format: project_id:flow:timing:auth_method:method:url

--- a/internal/resources/action/resource_test.go
+++ b/internal/resources/action/resource_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -138,50 +139,22 @@ func TestAccActionResource_writeOnlyAPIKey(t *testing.T) {
 func cleanupDanglingWebhook(t *testing.T, hookPath, webhookURL string) {
 	t.Helper()
 
+	hooksSlice, err := readRemoteHooks(t, hookPath)
+	if err != nil {
+		t.Logf("Warning: could not read hooks for cleanup: %v", err)
+		return
+	}
+	if len(hooksSlice) == 0 {
+		return
+	}
+
 	c, err := acctest.GetOryClient()
 	if err != nil {
 		t.Logf("Warning: could not create client for cleanup: %v", err)
 		return
 	}
-
 	project := acctest.GetTestProject(t)
 	ctx := context.Background()
-
-	p, err := c.GetProject(ctx, project.ID)
-	if err != nil {
-		t.Logf("Warning: could not get project for cleanup: %v", err)
-		return
-	}
-
-	configMap := p.Services.Identity.Config
-	if configMap == nil {
-		return
-	}
-
-	// Derive navigation segments from hookPath.
-	// e.g. "/services/identity/config/selfservice/flows/registration/after/password/hooks"
-	// → strip prefix "/services/identity/config/" and suffix "/hooks"
-	// → segments: ["selfservice", "flows", "registration", "after", "password"]
-	trimmed := strings.TrimPrefix(hookPath, "/services/identity/config/")
-	trimmed = strings.TrimSuffix(trimmed, "/hooks")
-	segments := strings.Split(trimmed, "/")
-
-	var current interface{} = configMap
-	for _, seg := range segments {
-		m, ok := current.(map[string]interface{})
-		if !ok {
-			return
-		}
-		current = m[seg]
-		if current == nil {
-			return
-		}
-	}
-
-	hooksSlice, ok := current.(map[string]interface{})["hooks"].([]interface{})
-	if !ok || len(hooksSlice) == 0 {
-		return
-	}
 
 	// Build a new hooks list without the dangling test webhook.
 	filtered := make([]interface{}, 0, len(hooksSlice))
@@ -212,6 +185,112 @@ func cleanupDanglingWebhook(t *testing.T, hookPath, webhookURL string) {
 	if err != nil {
 		t.Logf("Warning: failed to clean up dangling webhook: %v", err)
 	}
+}
+
+// readRemoteHooks returns the hooks array the test project stores at hookPath.
+// hookPath must be a full JSON Patch path ending in "/hooks". A path that does
+// not exist yields an empty slice and no error, which is how the API reports a
+// flow and method pair with no hooks configured.
+func readRemoteHooks(t *testing.T, hookPath string) ([]interface{}, error) {
+	t.Helper()
+
+	c, err := acctest.GetOryClient()
+	if err != nil {
+		return nil, fmt.Errorf("could not create client: %w", err)
+	}
+
+	project := acctest.GetTestProject(t)
+	p, err := c.GetProject(context.Background(), project.ID)
+	if err != nil {
+		return nil, fmt.Errorf("could not get project: %w", err)
+	}
+
+	var current interface{} = p.Services.Identity.Config
+	if current == nil {
+		return nil, nil
+	}
+
+	// Derive navigation segments from hookPath.
+	// e.g. "/services/identity/config/selfservice/flows/registration/after/password/hooks"
+	// → strip prefix "/services/identity/config/" and suffix "/hooks"
+	// → segments: ["selfservice", "flows", "registration", "after", "password"]
+	trimmed := strings.TrimPrefix(hookPath, "/services/identity/config/")
+	trimmed = strings.TrimSuffix(trimmed, "/hooks")
+
+	for _, seg := range strings.Split(trimmed, "/") {
+		m, ok := current.(map[string]interface{})
+		if !ok {
+			return nil, nil
+		}
+		current = m[seg]
+		if current == nil {
+			return nil, nil
+		}
+	}
+
+	m, ok := current.(map[string]interface{})
+	if !ok {
+		return nil, nil
+	}
+	hooks, _ := m["hooks"].([]interface{})
+	return hooks, nil
+}
+
+// checkWebhookDestroyed reports whether the webhook is gone from hookPath while
+// the hooks Ory manages itself at that path are still there. Deleting an action
+// is a read-modify-write of a shared array, so a delete that took the built-in
+// hooks with it would pass a state-only check.
+//
+// GetProject is eventually consistent, so the read is retried for a bounded
+// window before the check is treated as a failure.
+func checkWebhookDestroyed(t *testing.T, hookPath, webhookURL string, keepHooks []string) resource.TestCheckFunc {
+	const (
+		attempts = 15
+		interval = 2 * time.Second
+	)
+
+	return func(*terraform.State) error {
+		var lastErr error
+		for i := 0; i < attempts; i++ {
+			if i > 0 {
+				time.Sleep(interval)
+			}
+			lastErr = webhookAbsentFrom(t, hookPath, webhookURL, keepHooks)
+			if lastErr == nil {
+				return nil
+			}
+		}
+		return lastErr
+	}
+}
+
+// webhookAbsentFrom performs a single check of the post-destroy expectation.
+func webhookAbsentFrom(t *testing.T, hookPath, webhookURL string, keepHooks []string) error {
+	hooks, err := readRemoteHooks(t, hookPath)
+	if err != nil {
+		return err
+	}
+
+	remaining := make(map[string]bool, len(hooks))
+	for _, h := range hooks {
+		hm, _ := h.(map[string]interface{})
+		name, _ := hm["hook"].(string)
+		remaining[name] = true
+		if name != "web_hook" {
+			continue
+		}
+		cfg, _ := hm["config"].(map[string]interface{})
+		if url, _ := cfg["url"].(string); url == webhookURL {
+			return fmt.Errorf("webhook %s is still configured at %s after destroy", webhookURL, hookPath)
+		}
+	}
+
+	for _, name := range keepHooks {
+		if !remaining[name] {
+			return fmt.Errorf("destroy removed the %q hook from %s, which it does not own", name, hookPath)
+		}
+	}
+	return nil
 }
 
 func TestAccActionResource_basic(t *testing.T) {
@@ -315,6 +394,10 @@ func TestAccActionResource_settingsProfile(t *testing.T) {
 			cleanupDanglingWebhook(t, hookPath, webhookURL)
 		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		// Ory manages verify_new_address and organization at this path, so the
+		// delete must remove only the webhook.
+		CheckDestroy: checkWebhookDestroyed(t, hookPath, webhookURL,
+			[]string{"verify_new_address", "organization"}),
 		Steps: []resource.TestStep{
 			// Create and Read
 			{

--- a/internal/resources/action/testdata/settings_profile.tf.tmpl
+++ b/internal/resources/action/testdata/settings_profile.tf.tmpl
@@ -1,0 +1,8 @@
+resource "ory_action" "test" {
+  project_id  = "[[ .ProjectID ]]"
+  flow        = "settings"
+  timing      = "after"
+  auth_method = "profile"
+  url         = "[[ .WebhookURL ]]/profile-after-settings"
+  method      = "POST"
+}

--- a/internal/resources/action/testdata/settings_profile_updated.tf.tmpl
+++ b/internal/resources/action/testdata/settings_profile_updated.tf.tmpl
@@ -1,0 +1,11 @@
+resource "ory_action" "test" {
+  project_id  = "[[ .ProjectID ]]"
+  flow        = "settings"
+  timing      = "after"
+  auth_method = "profile"
+  url         = "[[ .WebhookURL ]]/profile-after-settings"
+  method      = "POST"
+
+  response_parse = true
+  can_interrupt  = true
+}

--- a/internal/resources/action/validate_config_test.go
+++ b/internal/resources/action/validate_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // buildActionTestConfig creates a ValidateConfigRequest from an ActionResourceModel.
@@ -135,6 +136,80 @@ func TestValidateConfig_AuthMethodOnAuthScopedFlow_NoWarn(t *testing.T) {
 			assert.Empty(t, resp.Diagnostics.Warnings(), "did not expect a warning for auth_method on %s flow: %v", flow, resp.Diagnostics.Warnings())
 		})
 	}
+}
+
+// TestValidateConfig_ProfileOnSettings_NoWarn is the plan-time regression for
+// issue #328: auth_method = "profile" is valid on the settings flow and must
+// neither error nor warn.
+func TestValidateConfig_ProfileOnSettings_NoWarn(t *testing.T) {
+	r := &ActionResource{}
+	ctx := context.Background()
+
+	req := buildActionTestConfig(t, ActionResourceModel{
+		Flow:       types.StringValue("settings"),
+		Timing:     types.StringValue("after"),
+		AuthMethod: types.StringValue("profile"),
+		URL:        types.StringValue("https://example.com/webhook"),
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "auth_method \"profile\" on settings must not error: %v", resp.Diagnostics.Errors())
+	assert.Empty(t, resp.Diagnostics.Warnings(), "auth_method \"profile\" on settings must not warn: %v", resp.Diagnostics.Warnings())
+}
+
+// TestValidateConfig_MethodNotOnFlow_Warns verifies that a method the schema
+// accepts but the chosen flow has no key for warns at plan time. Ory accepts such
+// a write with HTTP 200 and discards the hook, so without the warning the first
+// signal is an opaque verification failure during apply.
+func TestValidateConfig_MethodNotOnFlow_Warns(t *testing.T) {
+	cases := []struct{ flow, method string }{
+		{"login", "profile"},
+		{"registration", "profile"},
+		{"settings", "code"},
+		{"registration", "totp"},
+		{"registration", "lookup_secret"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.flow+"/"+tt.method, func(t *testing.T) {
+			r := &ActionResource{}
+			ctx := context.Background()
+
+			req := buildActionTestConfig(t, ActionResourceModel{
+				Flow:       types.StringValue(tt.flow),
+				Timing:     types.StringValue("after"),
+				AuthMethod: types.StringValue(tt.method),
+				URL:        types.StringValue("https://example.com/webhook"),
+			})
+			var resp resource.ValidateConfigResponse
+			r.ValidateConfig(ctx, req, &resp)
+
+			assert.False(t, resp.Diagnostics.HasError(),
+				"an unsupported method must warn, not error: %v", resp.Diagnostics.Errors())
+			require.NotEmpty(t, resp.Diagnostics.Warnings(),
+				"expected a warning for auth_method %q on the %q flow", tt.method, tt.flow)
+			assert.Contains(t, resp.Diagnostics.Warnings()[0].Detail(), "does not support auth_method")
+		})
+	}
+}
+
+// TestValidateConfig_MethodNotOnFlow_UnknownTiming_NoWarn verifies the
+// unsupported-method warning is suppressed while timing is unknown, since
+// auth_method is ignored outright for "before" hooks.
+func TestValidateConfig_MethodNotOnFlow_UnknownTiming_NoWarn(t *testing.T) {
+	r := &ActionResource{}
+	ctx := context.Background()
+
+	req := buildActionTestConfig(t, ActionResourceModel{
+		Flow:       types.StringValue("login"),
+		Timing:     types.StringUnknown(),
+		AuthMethod: types.StringValue("profile"),
+		URL:        types.StringValue("https://example.com/webhook"),
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.Empty(t, resp.Diagnostics.Warnings(), "did not expect a warning while timing is unknown: %v", resp.Diagnostics.Warnings())
 }
 
 // TestValidateConfig_AuthMethodOnBeforeTiming_Warns verifies that auth_method set

--- a/templates/resources/action.md.tmpl
+++ b/templates/resources/action.md.tmpl
@@ -26,6 +26,7 @@ The `auth_method` attribute specifies which authentication method triggers the w
 | `password` | Password-based authentication (default) |
 | `oidc` | Social/OIDC authentication (Google, GitHub, etc.) |
 | `code` | One-time code (magic link, OTP) |
+| `profile` | Profile/trait update (settings flow only) |
 | `webauthn` | Hardware security keys |
 | `passkey` | Passkey authentication |
 | `totp` | Time-based one-time password |
@@ -33,6 +34,37 @@ The `auth_method` attribute specifies which authentication method triggers the w
 | `saml` | SAML single sign-on (SSO) |
 
 ~> **Note:** `auth_method` only applies to `timing = "after"` webhooks on the `login`, `registration`, and `settings` flows. The `recovery` and `verification` flows are **not** scoped by authentication method — their after-hooks always run — so `auth_method` is ignored for them and should be omitted. For `timing = "before"` hooks, the webhook runs before any authentication method is invoked.
+
+### Method Availability by Flow
+
+Not every method exists on every flow. Ory accepts a hook written to an
+unsupported flow and method pair with HTTP 200 but discards it, so the provider
+warns during `terraform plan` and the apply then fails verification.
+
+| Method | `login` | `registration` | `settings` |
+|--------|---------|----------------|------------|
+| `password` | yes | yes | yes |
+| `oidc` | yes | yes | yes |
+| `code` | yes | yes | no |
+| `profile` | no | no | yes |
+| `webauthn` | yes | yes | yes |
+| `passkey` | yes | yes | yes |
+| `totp` | yes | no | yes |
+| `lookup_secret` | yes | no | yes |
+| `saml` | yes | yes | yes |
+
+The `profile` method covers the settings flow's profile/trait update step, which
+Ory stores at `selfservice.flows.settings.after.profile.hooks`:
+
+```hcl
+resource "ory_action" "profile_updated" {
+  flow        = "settings"
+  timing      = "after"
+  auth_method = "profile"
+  url         = "https://api.example.com/webhooks/profile-updated"
+  method      = "POST"
+}
+```
 
 ## Webhook Authentication
 
@@ -128,7 +160,7 @@ terraform import ory_action.validate \
 1. **project_id**: Settings → General → Project ID
 2. **flow**: The flow type (login, registration, recovery, settings, verification)
 3. **timing**: "before" or "after"
-4. **auth_method**: for `login`/`registration`/`settings` "after" hooks, one of password, oidc, code, webauthn, passkey, totp, lookup_secret, saml. For `recovery`/`verification` "after" hooks the value is ignored, but the import ID format still requires this segment — use `password` to match the provider default and avoid a post-import diff (keep `auth_method` omitted from the resource configuration itself).
+4. **auth_method**: for `login`/`registration`/`settings` "after" hooks, one of password, oidc, code, profile, webauthn, passkey, totp, lookup_secret, saml (see the availability table above — `profile` is settings-only). For `recovery`/`verification` "after" hooks the value is ignored, but the import ID format still requires this segment — use `password` to match the provider default and avoid a post-import diff (keep `auth_method` omitted from the resource configuration itself).
 5. **method**: The HTTP method (POST, GET, PUT, PATCH, DELETE)
 6. **url**: The exact webhook URL - must match exactly including protocol and trailing slashes
 


### PR DESCRIPTION
## Description

`ory_action` rejected `auth_method = "profile"`, so `settings:after:profile`
webhooks could not be declared in HCL or drift-detected. The Ory API stores those
hooks under the `profile` method, which was missing from the provider's
`auth_method` enum.

This adds `profile` to the enum and, because `profile` is the first method that
exists on only one flow, adds a per-flow method table so the provider does not
offer a method the chosen flow cannot store. Ory accepts a hook written to an
unsupported flow and method pair with HTTP 200 and then discards it, so an
unsupported pair now warns during `terraform plan`, and the apply-time
verification failure names the cause instead of reporting a bare "hook not
found".

Verified against the live Console API:

- `settings.after.profile` accepts and persists a `web_hook`, preserving the
  built-in `verify_new_address` and `organization` hooks already stored there.
- `login.after.profile` returns HTTP 200 and the key is dropped, confirming the
  per-flow table.
- Per-flow method keys read from a live project match the Console UI's "Method"
  picker: login has 8 methods, registration 6 (no `totp` or `lookup_secret`),
  settings 8 (`profile` instead of `code`).

## Related Issues

Fixes #328

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

**Unit tests** (new and updated in `internal/resources/action/`):

- `TestAuthMethodValidatorAcceptsDocumentedMethods` generalizes the previous
  SAML-only enum test to every documented method, covering `profile`.
- `TestAuthMethodsForFlow` pins the per-flow sets to the live API's config keys.
- `TestAuthMethodsForFlowCoversSchemaEnum` guards the enum and the per-flow table
  against drifting apart in either direction.
- `TestFlowSupportsMethod` covers the pairs that differ from the flat enum.
- `TestHookPath` gains the `settings/after/profile` path.
- `TestGetHooksFromProject_SettingsProfile` reads a profile hooks array that also
  holds the built-in non-webhook hooks.
- `TestVerifyFailureDetail`, `TestValidateConfig_ProfileOnSettings_NoWarn`,
  `TestValidateConfig_MethodNotOnFlow_Warns`, and
  `TestValidateConfig_MethodNotOnFlow_UnknownTiming_NoWarn` cover the new
  diagnostics.

**Acceptance test:** `TestAccActionResource_settingsProfile` covers create, read,
in-place update, import, and delete against `.../settings/after/profile/hooks`.
It sets `project_id` explicitly so the update step is a real in-place `Update`
rather than a replacement.

```
TF_ACC=1 go test -tags acceptance -run TestAccActionResource_settingsProfile ./internal/resources/action/...
--- PASS: TestAccActionResource_settingsProfile (6.81s)

TF_ACC=1 go test -tags acceptance ./internal/resources/action/...
ok    github.com/ory/terraform-provider-ory/internal/resources/action  101.605s
```

**Manual testing** with the Terraform CLI against the staging Console API, using
the exact configuration from the issue (including `body`):

- `apply` creates the hook; the API preserves `verify_new_address` and
  `organization` and reports the Jsonnet `body` as a storage URL, which the
  existing read path already resolves, so the follow-up `plan` is empty.
- Changing `response_parse` and `can_interrupt` updates in place.
- `terraform import` with
  `<project>:settings:after:profile:POST:<url>` succeeds and the post-import
  `plan` reports no changes.
- `destroy` removes only the webhook, leaving the two built-in hooks.
- `auth_method = "profile"` on the `login` flow warns at plan time and fails the
  apply with an error naming the unsupported pair.
- The test project was restored to its original configuration afterwards.

## Screenshots/Output

Before, with the configuration from the issue:

```
Error: Invalid Attribute Value Match

  with ory_action.profile_hook,
  on main.tf line 14, in resource "ory_action" "profile_hook":
  14:   auth_method = "profile"

Attribute auth_method value must be one of: ["password" "oidc" "code"
"webauthn" "passkey" "totp" "lookup_secret" "saml"], got: "profile"
```

After:

```
ory_action.profile_hook: Creation complete after 4s [id=...:settings:after:profile:https://example.com/webhook/tf-328-profile]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

The new plan-time warning for an unsupported pair:

```
Warning: auth_method is not available on this flow

  with ory_action.wrong_flow,
  on main.tf line 13, in resource "ory_action" "wrong_flow":
  13:   auth_method = "profile"

The "login" flow does not support auth_method "profile". Supported methods for
this flow: password, oidc, code, webauthn, passkey, totp, lookup_secret, saml.
Ory accepts a hook written to an unsupported method with HTTP 200 but discards
it, so the hook is never stored.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for profile-authenticated webhooks on the settings flow.
  * Added an example for invoking a POST webhook after profile updates.
  * Added validation and warnings for authentication methods unavailable in specific flows.

* **Documentation**
  * Documented supported authentication methods and their flow availability.
  * Updated configuration and import guidance for the profile method.

* **Bug Fixes**
  * Improved diagnostics for unsupported flow and authentication-method combinations.
  * Expanded coverage for settings profile hooks and mixed built-in and webhook actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->