### PR TITLE
fix(social-provider): expose net_id_token_origin_header

### DIFF
--- a/docs/resources/social_provider.md
+++ b/docs/resources/social_provider.md
@@ -26,6 +26,7 @@ The `provider_type` attribute determines which OAuth2/OIDC integration to use:
 | `discord` | Discord |
 | `facebook` | Facebook |
 | `gitlab` | GitLab |
+| `netid` | NetID (supports FedCM, see below) |
 | `slack` | Slack |
 | `spotify` | Spotify |
 | `twitch` | Twitch |
@@ -147,6 +148,20 @@ resource "ory_social_provider" "google_fedcm" {
   fedcm_config_url = "https://accounts.google.com/gsi/fedcm.json"
 }
 
+# NetID Sign-In with FedCM. NetID needs the origin header Ory sends when it
+# exchanges the FedCM token for an ID token. The value must be one of the
+# `origin_uris` registered on the NetID client.
+resource "ory_social_provider" "netid_fedcm" {
+  provider_id   = "netid"
+  provider_type = "netid"
+  client_id     = var.netid_client_id
+  client_secret = var.netid_client_secret
+  scope         = ["openid", "email"]
+
+  fedcm_config_url           = "https://broker.netid.de/fedcm.json"
+  net_id_token_origin_header = "https://www.example.com"
+}
+
 # Google Sign-In that refreshes identity traits from OIDC claims on every login
 resource "ory_social_provider" "google_sync_on_login" {
   provider_id   = "google-sync"
@@ -252,6 +267,15 @@ variable "google_client_id" {
 }
 
 variable "google_client_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "netid_client_id" {
+  type = string
+}
+
+variable "netid_client_secret" {
   type      = string
   sensitive = true
 }
@@ -443,6 +467,23 @@ resource "ory_social_provider" "google" {
 
 Leave the attribute unset to disable FedCM for the provider. Removing it from your configuration clears the value server-side.
 
+FedCM is supported for Google and NetID. A NetID provider needs one more attribute: `net_id_token_origin_header`. Ory sends it as the `Origin` header when it exchanges the NetID FedCM token for an ID token, so the value must be one of the `origin_uris` registered on the NetID client. Without it, FedCM sign-in through NetID fails.
+
+```hcl
+resource "ory_social_provider" "netid" {
+  provider_id   = "netid"
+  provider_type = "netid"
+  client_id     = var.netid_client_id
+  client_secret = var.netid_client_secret
+  scope         = ["openid", "email"]
+
+  fedcm_config_url           = "https://broker.netid.de/fedcm.json"
+  net_id_token_origin_header = "https://www.example.com"
+}
+```
+
+Leave `net_id_token_origin_header` unset for every provider other than NetID. Removing it from your configuration clears the value server-side.
+
 ## Update Identity on Login
 
 The `update_identity_on_login` attribute controls whether an identity's traits and metadata are refreshed from the upstream OIDC claims every time the user signs in:
@@ -537,6 +578,7 @@ The `provider_id` is the unique identifier you chose when creating the provider.
 - `issuer_url` (String) OIDC issuer URL (required for generic providers).
 - `label` (String) Human-readable label for the provider, displayed on the login button (e.g., "Sign in with Corporate SSO").
 - `mapper_url` (String) Jsonnet mapper URL for claims mapping. Can be a URL or base64-encoded Jsonnet (base64://...). If not set, a default mapper that extracts email from claims will be used.
+- `net_id_token_origin_header` (String) Origin header Ory sends when it exchanges a NetID FedCM token for an ID token. The value must be one of the `origin_uris` registered on the NetID client, for example "https://www.example.com". Set it together with fedcm_config_url on a NetID provider. Leave it unset for every other provider.
 - `pkce` (String) PKCE (Proof Key for Code Exchange) behavior for the OAuth2 authorization code flow. "auto" (default) enables PKCE when the upstream provider advertises support via OIDC discovery; "force" always sends PKCE (use only with providers known to support it); "never" disables PKCE.
 - `project_id` (String) Project ID. If not set, uses provider's project_id.
 - `scope` (List of String) OAuth2 scopes to request.

--- a/examples/resources/ory_social_provider/resource.tf
+++ b/examples/resources/ory_social_provider/resource.tf
@@ -60,6 +60,20 @@ resource "ory_social_provider" "google_fedcm" {
   fedcm_config_url = "https://accounts.google.com/gsi/fedcm.json"
 }
 
+# NetID Sign-In with FedCM. NetID needs the origin header Ory sends when it
+# exchanges the FedCM token for an ID token. The value must be one of the
+# `origin_uris` registered on the NetID client.
+resource "ory_social_provider" "netid_fedcm" {
+  provider_id   = "netid"
+  provider_type = "netid"
+  client_id     = var.netid_client_id
+  client_secret = var.netid_client_secret
+  scope         = ["openid", "email"]
+
+  fedcm_config_url           = "https://broker.netid.de/fedcm.json"
+  net_id_token_origin_header = "https://www.example.com"
+}
+
 # Google Sign-In that refreshes identity traits from OIDC claims on every login
 resource "ory_social_provider" "google_sync_on_login" {
   provider_id   = "google-sync"
@@ -165,6 +179,15 @@ variable "google_client_id" {
 }
 
 variable "google_client_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "netid_client_id" {
+  type = string
+}
+
+variable "netid_client_secret" {
   type      = string
   sensitive = true
 }

--- a/internal/resources/socialprovider/provider_config_test.go
+++ b/internal/resources/socialprovider/provider_config_test.go
@@ -1,0 +1,91 @@
+package socialprovider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// baseProviderPlan returns the minimum plan every buildProviderConfig test needs.
+func baseProviderPlan() *SocialProviderResourceModel {
+	return &SocialProviderResourceModel{
+		ProviderID:   types.StringValue("netid"),
+		ProviderType: types.StringValue("netid"),
+		ClientID:     types.StringValue("test-client-id"),
+	}
+}
+
+// Create and Update replace the whole provider object, so every attribute the
+// user configured must appear in the payload. A missing net_id_token_origin_header
+// blanks the field server-side on each apply and breaks NetID FedCM sign-in.
+// Regression test for https://github.com/ory/terraform-provider-ory/issues/329
+func TestBuildProviderConfig_NetIDTokenOriginHeader(t *testing.T) {
+	tests := []struct {
+		name        string
+		originValue types.String
+		wantPresent bool
+		wantValue   string
+	}{
+		{
+			name:        "set",
+			originValue: types.StringValue("https://www.example.com"),
+			wantPresent: true,
+			wantValue:   "https://www.example.com",
+		},
+		{
+			name:        "null",
+			originValue: types.StringNull(),
+			wantPresent: false,
+		},
+		{
+			name:        "unknown",
+			originValue: types.StringUnknown(),
+			wantPresent: false,
+		},
+		{
+			name:        "empty string",
+			originValue: types.StringValue(""),
+			wantPresent: false,
+		},
+	}
+
+	r := &SocialProviderResource{}
+	ctx := context.Background()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := baseProviderPlan()
+			plan.NetIDTokenOriginHeader = tt.originValue
+
+			config := r.buildProviderConfig(ctx, plan,
+				plan.ClientID, types.StringValue("test-client-secret"), types.StringNull())
+
+			got, ok := config["net_id_token_origin_header"]
+			if !tt.wantPresent {
+				assert.False(t, ok, "net_id_token_origin_header must be absent from the payload")
+				return
+			}
+			require.True(t, ok, "net_id_token_origin_header must be sent to the API")
+			assert.Equal(t, tt.wantValue, got)
+		})
+	}
+}
+
+// A NetID provider carries both the FedCM config URL and the origin header, so
+// the payload must keep them side by side.
+func TestBuildProviderConfig_NetIDFedcmPair(t *testing.T) {
+	r := &SocialProviderResource{}
+
+	plan := baseProviderPlan()
+	plan.FedcmConfigURL = types.StringValue("https://broker.netid.de/fedcm.json")
+	plan.NetIDTokenOriginHeader = types.StringValue("https://www.example.com")
+
+	config := r.buildProviderConfig(context.Background(), plan,
+		plan.ClientID, types.StringValue("test-client-secret"), types.StringNull())
+
+	assert.Equal(t, "https://broker.netid.de/fedcm.json", config["fedcm_config_url"])
+	assert.Equal(t, "https://www.example.com", config["net_id_token_origin_header"])
+}

--- a/internal/resources/socialprovider/resource.go
+++ b/internal/resources/socialprovider/resource.go
@@ -88,6 +88,7 @@ type SocialProviderResourceModel struct {
 	Aal2AmrValues              types.List   `tfsdk:"aal2_amr_values"`
 	Pkce                       types.String `tfsdk:"pkce"`
 	FedcmConfigURL             types.String `tfsdk:"fedcm_config_url"`
+	NetIDTokenOriginHeader     types.String `tfsdk:"net_id_token_origin_header"`
 	UpdateIdentityOnLogin      types.String `tfsdk:"update_identity_on_login"`
 }
 
@@ -283,6 +284,10 @@ func (r *SocialProviderResource) Schema(ctx context.Context, req resource.Schema
 				Description: "URL of the provider's FedCM (Federated Credential Management) configuration file. When set, Ory can use the browser's FedCM API for sign-in with this provider instead of a full-page redirect. For example, Google's FedCM configuration is served at \"https://accounts.google.com/gsi/fedcm.json\". Leave unset to disable FedCM for this provider.",
 				Optional:    true,
 			},
+			"net_id_token_origin_header": schema.StringAttribute{
+				Description: "Origin header Ory sends when it exchanges a NetID FedCM token for an ID token. The value must be one of the `origin_uris` registered on the NetID client, for example \"https://www.example.com\". Set it together with fedcm_config_url on a NetID provider. Leave it unset for every other provider.",
+				Optional:    true,
+			},
 			"update_identity_on_login": schema.StringAttribute{
 				Description: "Controls whether the identity's traits and metadata are refreshed from the upstream OIDC claims on every login. \"never\" (the API default) keeps the identity as-is after the initial sign-up. \"automatic\" re-runs the Jsonnet claims mapper on each login and updates the identity accordingly. Leave unset to use the Ory default (\"never\").",
 				Optional:    true,
@@ -398,6 +403,9 @@ func (r *SocialProviderResource) ValidateConfig(ctx context.Context, req resourc
 	}
 	if !config.FedcmConfigURL.IsNull() && !config.FedcmConfigURL.IsUnknown() && config.FedcmConfigURL.ValueString() == "" {
 		resp.Diagnostics.AddAttributeError(path.Root("fedcm_config_url"), "Invalid Attribute Value", "fedcm_config_url must not be an empty string.")
+	}
+	if !config.NetIDTokenOriginHeader.IsNull() && !config.NetIDTokenOriginHeader.IsUnknown() && config.NetIDTokenOriginHeader.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(path.Root("net_id_token_origin_header"), "Invalid Attribute Value", "net_id_token_origin_header must not be an empty string.")
 	}
 
 	if providerType == "apple" {
@@ -532,6 +540,14 @@ func (r *SocialProviderResource) buildProviderConfig(ctx context.Context, plan *
 	// the full-object replace performed by Update clears it server-side.
 	if !plan.FedcmConfigURL.IsNull() && !plan.FedcmConfigURL.IsUnknown() && plan.FedcmConfigURL.ValueString() != "" {
 		config["fedcm_config_url"] = plan.FedcmConfigURL.ValueString()
+	}
+
+	// net_id_token_origin_header gets the same handling as fedcm_config_url.
+	// Create and Update replace the whole provider object, so a value missing
+	// here is wiped server-side on the next apply.
+	// See: https://github.com/ory/terraform-provider-ory/issues/329
+	if !plan.NetIDTokenOriginHeader.IsNull() && !plan.NetIDTokenOriginHeader.IsUnknown() && plan.NetIDTokenOriginHeader.ValueString() != "" {
+		config["net_id_token_origin_header"] = plan.NetIDTokenOriginHeader.ValueString()
 	}
 
 	// Apple-specific fields — skip empty strings to avoid sending blank credentials
@@ -1000,6 +1016,14 @@ func (r *SocialProviderResource) Read(ctx context.Context, req resource.ReadRequ
 		state.FedcmConfigURL = types.StringValue(fedcmURL)
 	} else {
 		state.FedcmConfigURL = types.StringNull()
+	}
+
+	// Read net_id_token_origin_header from the API (returned on read), clearing
+	// stale state when the API omits it.
+	if originHeader, ok := provider["net_id_token_origin_header"].(string); ok && originHeader != "" {
+		state.NetIDTokenOriginHeader = types.StringValue(originHeader)
+	} else {
+		state.NetIDTokenOriginHeader = types.StringNull()
 	}
 
 	// Read Apple-specific fields, clearing stale state when not returned by the API

--- a/internal/resources/socialprovider/resource_test.go
+++ b/internal/resources/socialprovider/resource_test.go
@@ -630,6 +630,75 @@ func TestAccSocialProviderResource_fedcmConfigURL(t *testing.T) {
 	})
 }
 
+// TestAccSocialProviderResource_netIDTokenOriginHeader exercises
+// net_id_token_origin_header across create, update (changed origin), removal,
+// and import. Create and Update replace the whole provider object, so an
+// attribute missing from the schema is blanked server-side on every apply. The
+// PlanOnly step after each apply is the regression guard for that: it fails if
+// the API drops the value.
+// Regression test for https://github.com/ory/terraform-provider-ory/issues/329.
+func TestAccSocialProviderResource_netIDTokenOriginHeader(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.AccPreCheck(t)
+			acctest.RequireSocialProviderTests(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create with net_id_token_origin_header set
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_net_id_origin_header.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_social_provider.test", "id"),
+					resource.TestCheckResourceAttr("ory_social_provider.test", "provider_id", "test-netid-origin"),
+					resource.TestCheckResourceAttr("ory_social_provider.test", "provider_type", "netid"),
+					resource.TestCheckResourceAttr("ory_social_provider.test", "fedcm_config_url", "https://broker.netid.de/fedcm.json"),
+					resource.TestCheckResourceAttr("ory_social_provider.test", "net_id_token_origin_header", "https://www.example.com"),
+				),
+			},
+			// Verify no perpetual diff — the API must echo the value back unchanged
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/with_net_id_origin_header.tf.tmpl", nil),
+				PlanOnly: true,
+			},
+			// Update the origin header
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_net_id_origin_header_updated.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_social_provider.test", "net_id_token_origin_header", "https://news.example.com"),
+				),
+			},
+			// Verify no perpetual diff after update
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/with_net_id_origin_header_updated.tf.tmpl", nil),
+				PlanOnly: true,
+			},
+			// Remove net_id_token_origin_header from config — should clear it server-side
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_net_id_origin_header_removed.tf.tmpl", nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("ory_social_provider.test", "net_id_token_origin_header"),
+					// The sibling FedCM attribute must survive the removal.
+					resource.TestCheckResourceAttr("ory_social_provider.test", "fedcm_config_url", "https://broker.netid.de/fedcm.json"),
+				),
+			},
+			// Verify no diff after removal
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/with_net_id_origin_header_removed.tf.tmpl", nil),
+				PlanOnly: true,
+			},
+			// ImportState
+			{
+				ResourceName:            "ory_social_provider.test",
+				ImportState:             true,
+				ImportStateId:           "test-netid-origin",
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"client_secret"},
+			},
+		},
+	})
+}
+
 // TestAccSocialProviderResource_aal2Values exercises aal2_acr_values and
 // aal2_amr_values across create, update (changed list contents), removal, and
 // import. Values are opaque strings stored on the provider config — the API

--- a/internal/resources/socialprovider/testdata/with_net_id_origin_header.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/with_net_id_origin_header.tf.tmpl
@@ -1,0 +1,9 @@
+resource "ory_social_provider" "test" {
+  provider_id                = "test-netid-origin"
+  provider_type              = "netid"
+  client_id                  = "test-netid-client-id"
+  client_secret              = "test-netid-client-secret"
+  scope                      = ["openid", "email"]
+  fedcm_config_url           = "https://broker.netid.de/fedcm.json"
+  net_id_token_origin_header = "https://www.example.com"
+}

--- a/internal/resources/socialprovider/testdata/with_net_id_origin_header_removed.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/with_net_id_origin_header_removed.tf.tmpl
@@ -1,0 +1,9 @@
+resource "ory_social_provider" "test" {
+  provider_id      = "test-netid-origin"
+  provider_type    = "netid"
+  client_id        = "test-netid-client-id"
+  client_secret    = "test-netid-client-secret"
+  scope            = ["openid", "email"]
+  fedcm_config_url = "https://broker.netid.de/fedcm.json"
+  # net_id_token_origin_header intentionally omitted to test removal
+}

--- a/internal/resources/socialprovider/testdata/with_net_id_origin_header_updated.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/with_net_id_origin_header_updated.tf.tmpl
@@ -1,0 +1,9 @@
+resource "ory_social_provider" "test" {
+  provider_id                = "test-netid-origin"
+  provider_type              = "netid"
+  client_id                  = "test-netid-client-id"
+  client_secret              = "test-netid-client-secret"
+  scope                      = ["openid", "email"]
+  fedcm_config_url           = "https://broker.netid.de/fedcm.json"
+  net_id_token_origin_header = "https://news.example.com"
+}

--- a/internal/resources/socialprovider/validate_config_test.go
+++ b/internal/resources/socialprovider/validate_config_test.go
@@ -52,6 +52,7 @@ func buildTestConfig(t *testing.T, model SocialProviderResourceModel) resource.V
 		"aal2_amr_values":               tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
 		"pkce":                          tfStringValue(model.Pkce),
 		"fedcm_config_url":              tfStringValue(model.FedcmConfigURL),
+		"net_id_token_origin_header":    tfStringValue(model.NetIDTokenOriginHeader),
 		"update_identity_on_login":      tfStringValue(model.UpdateIdentityOnLogin),
 	}
 
@@ -87,6 +88,7 @@ func buildTestConfig(t *testing.T, model SocialProviderResourceModel) resource.V
 			"aal2_amr_values":               tftypes.List{ElementType: tftypes.String},
 			"pkce":                          tftypes.String,
 			"fedcm_config_url":              tftypes.String,
+			"net_id_token_origin_header":    tftypes.String,
 			"update_identity_on_login":      tftypes.String,
 		},
 	}
@@ -219,6 +221,40 @@ func TestValidateConfig_EmptyFedcmConfigURL_Fails(t *testing.T) {
 	r.ValidateConfig(ctx, req, &resp)
 
 	assert.True(t, resp.Diagnostics.HasError(), "expected error for empty fedcm_config_url")
+}
+
+func TestValidateConfig_EmptyNetIDTokenOriginHeader_Fails(t *testing.T) {
+	r := &SocialProviderResource{}
+	ctx := context.Background()
+
+	req := buildTestConfig(t, SocialProviderResourceModel{
+		ProviderID:             types.StringValue("netid"),
+		ProviderType:           types.StringValue("netid"),
+		ClientID:               types.StringValue("my-client-id"),
+		ClientSecret:           types.StringValue("my-secret"),
+		NetIDTokenOriginHeader: types.StringValue(""), // empty string must fail
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.True(t, resp.Diagnostics.HasError(), "expected error for empty net_id_token_origin_header")
+}
+
+func TestValidateConfig_NetIDTokenOriginHeader_Passes(t *testing.T) {
+	r := &SocialProviderResource{}
+	ctx := context.Background()
+
+	req := buildTestConfig(t, SocialProviderResourceModel{
+		ProviderID:             types.StringValue("netid"),
+		ProviderType:           types.StringValue("netid"),
+		ClientID:               types.StringValue("my-client-id"),
+		ClientSecret:           types.StringValue("my-secret"),
+		NetIDTokenOriginHeader: types.StringValue("https://www.example.com"),
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for a valid net_id_token_origin_header: %v", resp.Diagnostics.Errors())
 }
 
 func TestValidateConfig_WriteOnlyClientSecret_Passes(t *testing.T) {

--- a/templates/resources/social_provider.md.tmpl
+++ b/templates/resources/social_provider.md.tmpl
@@ -26,6 +26,7 @@ The `provider_type` attribute determines which OAuth2/OIDC integration to use:
 | `discord` | Discord |
 | `facebook` | Facebook |
 | `gitlab` | GitLab |
+| `netid` | NetID (supports FedCM, see below) |
 | `slack` | Slack |
 | `spotify` | Spotify |
 | `twitch` | Twitch |
@@ -210,6 +211,23 @@ resource "ory_social_provider" "google" {
 ```
 
 Leave the attribute unset to disable FedCM for the provider. Removing it from your configuration clears the value server-side.
+
+FedCM is supported for Google and NetID. A NetID provider needs one more attribute: `net_id_token_origin_header`. Ory sends it as the `Origin` header when it exchanges the NetID FedCM token for an ID token, so the value must be one of the `origin_uris` registered on the NetID client. Without it, FedCM sign-in through NetID fails.
+
+```hcl
+resource "ory_social_provider" "netid" {
+  provider_id   = "netid"
+  provider_type = "netid"
+  client_id     = var.netid_client_id
+  client_secret = var.netid_client_secret
+  scope         = ["openid", "email"]
+
+  fedcm_config_url           = "https://broker.netid.de/fedcm.json"
+  net_id_token_origin_header = "https://www.example.com"
+}
+```
+
+Leave `net_id_token_origin_header` unset for every provider other than NetID. Removing it from your configuration clears the value server-side.
 
 ## Update Identity on Login
 


### PR DESCRIPTION
## Description

`ory_social_provider` replaces the whole provider object on every create and update. Any attribute the schema does not know about is therefore dropped from the PATCH payload and blanked server-side. `net_id_token_origin_header` was missing from the schema, so every `terraform apply` cleared it and broke NetID FedCM sign-in.

This adds `net_id_token_origin_header` as an optional string attribute, wired through the schema, the create and update payload, the read path, and config validation. The handling matches `fedcm_config_url`: the value is sent only when set to a non-empty string, read back from the API, and cleared server-side when removed from configuration.

```hcl
resource "ory_social_provider" "netid" {
  provider_id   = "netid"
  provider_type = "netid"
  client_id     = var.netid_client_id
  client_secret = var.netid_client_secret
  scope         = ["openid", "email"]

  fedcm_config_url           = "https://broker.netid.de/fedcm.json"
  net_id_token_origin_header = "https://www.example.com"
}
```

The `netid` provider type is also added to the provider-type table in the resource documentation.

## Related Issues

Fixes #329

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

**Live API verification, before any code changes.** A raw `PATCH /projects/{id}` that created a `netid` provider carrying `net_id_token_origin_header` returned HTTP 200, and a fresh `GET` echoed the value back unchanged. Replaying the payload the pre-fix provider sent, the same provider object without that key, cleared the field server-side. This reproduces the reported blanking at the API level.

**Unit tests** in `internal/resources/socialprovider/`:

- `TestBuildProviderConfig_NetIDTokenOriginHeader` asserts the value reaches the payload when set, and is omitted when null, unknown, or an empty string.
- `TestBuildProviderConfig_NetIDFedcmPair` asserts the attribute coexists with `fedcm_config_url` on the same provider object.
- `TestValidateConfig_EmptyNetIDTokenOriginHeader_Fails` and `TestValidateConfig_NetIDTokenOriginHeader_Passes` cover config validation.

**Acceptance test** `TestAccSocialProviderResource_netIDTokenOriginHeader` covers create, update to a different origin, removal, and import, with a `PlanOnly` step after each apply so a dropped value fails the test. The removal step also asserts the sibling `fedcm_config_url` survives.

```
--- PASS: TestAccSocialProviderResource_netIDTokenOriginHeader (8.35s)
```

The full social provider acceptance suite passes:

```
ok  github.com/ory/terraform-provider-ory/internal/resources/socialprovider  146.091s
```

**Manual testing** with the Terraform CLI against a live project, using the locally built provider: apply, re-apply, update, import, remove the attribute, and destroy. Test resources were removed afterwards and the project restored to its prior state.

## Screenshots/Output

The regression, confirmed end to end. The value survives a second apply, which is exactly what failed before:

```
$ terraform apply -auto-approve      # second apply, no config change
No changes. Your infrastructure matches the configuration.

$ curl ... | jq -r '... | .net_id_token_origin_header'
https://www.example.com
```

Import populates the attribute:

```
$ terraform import ory_social_provider.netid tf-manual-netid
$ terraform show -json | jq -c '...'
{"provider_type":"netid","fedcm_config_url":"https://broker.netid.de/fedcm.json","net_id_token_origin_header":"https://news.example.com"}
```

Removing the attribute clears it server-side and leaves a clean plan:

```
$ terraform plan
No changes. Your infrastructure matches the configuration.
```

Pre-commit checks:

```
make format      0 issues
make test-short  all packages ok
make sec         govulncheck: 0 affecting vulnerabilities, gosec: 0 issues, gitleaks: no leaks found
```
