### PR TITLE
fix: retry Ory API rate limits instead of failing the apply

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -172,7 +172,9 @@ The provider retries a rejected request instead of failing the apply. It follows
 
 No configuration is needed. A large apply works at the default parallelism, and `terraform apply -parallelism=1` is no longer a workaround.
 
-Set `max_retries` to change how many times a rejected request is retried. The default is 6, which spends up to 61 seconds waiting and so outlasts a full 60-second rate-limit window. The maximum is 20. Set it to `0` to turn the retry off and let the `429` reach Terraform.
+A `429` still reaches Terraform when the retries run out or when `max_retries` is `0`. The error then names the operation and the number of retries it used.
+
+Set `max_retries` to change how many times a rejected request is retried. The default is 6. Its waits of 1, 2, 4, 8, 16 and 30 seconds come to 61 seconds, so the retry outlasts a full 60-second rate-limit window. That total is a floor: the jitter and a longer window reported by the server both raise it. The maximum is 20. Set it to `0` to turn the retry off.
 
 ```hcl
 provider "ory" {
@@ -201,7 +203,7 @@ When importing existing resources, ensure you have the appropriate credentials c
 
 - `allowed_project_ids` (List of String) Optional safety guardrail. When set, the provider refuses any project-configuration operation (`ory_project_config`, `ory_action`, `ory_email_template`, `ory_social_provider`, `ory_saml_provider`, `ory_identity_schema`, `ory_custom_domain`, `ory_event_stream`, `ory_organization`, `ory_project_api_key`, and `ory_project` create/delete) that targets a project ID not in this list. This bounds the blast radius of a workspace API key so a mis-pointed `project_id` (such as production) cannot be read or changed. When unset, no restriction is applied. Can also be set via the `ORY_ALLOWED_PROJECT_IDS` environment variable as a comma-separated list.
 - `console_api_url` (String) Override the console API URL (default: `https://api.console.ory.sh`). Mainly for testing.
-- `max_retries` (Number) How many times a request that the Ory API rejects with `429 Too Many Requests` is retried before the error reaches Terraform (default: `6`, maximum: `20`). The provider backs off exponentially, capped at 30 seconds, waits longer when the `x-ratelimit-reset` header reports a longer window, and adds random jitter so parallel workers do not retry together. Raise it for a very large apply; set it to `0` to disable the retry. Can also be set via the `ORY_MAX_RETRIES` environment variable.
+- `max_retries` (Number) How many times a request that the Ory API rejects with `429 Too Many Requests` is retried before the error reaches Terraform (default: `6`, maximum: `20`). The provider backs off exponentially, capped at 30 seconds, waits longer when the `x-ratelimit-reset` header reports a longer window, and adds random jitter so parallel workers do not retry together. At the default the waits come to 61 seconds, which is a floor: the jitter and a longer reported window both raise it. The `429` still reaches Terraform once the retries run out, or when this is set to `0`. Raise it for a very large apply. Can also be set via the `ORY_MAX_RETRIES` environment variable.
 - `project_api_key` (String, Sensitive) Ory Project API Key (`ory_pat_...`). Used for identity and OAuth2 operations. Can also be set via `ORY_PROJECT_API_KEY` environment variable.
 - `project_api_url` (String) Override the project API URL template (default: `https://%s.projects.oryapis.com`).
 - `project_id` (String) Ory Project ID. Can also be set via `ORY_PROJECT_ID` environment variable.

--- a/docs/index.md
+++ b/docs/index.md
@@ -159,6 +159,37 @@ export ORY_ALLOWED_PROJECT_IDS="3fa274fe-910d-4766-b1a4-0c0dd3b41429,7bc1e0c2-..
 
 When `allowed_project_ids` is unset, no restriction is applied.
 
+## Rate limits and retries
+
+The Ory API answers `429 Too Many Requests` when a caller exceeds the request budget for a route. Terraform runs resource operations in parallel, ten at a time by default, so a bulk apply of many `ory_oauth2_client` or `ory_identity` resources can reach that budget.
+
+The provider retries a rejected request instead of failing the apply. It follows [Ory's guidance for 429 responses](https://www.ory.com/docs/guides/rate-limits-new#how-to-handle-429-responses):
+
+1. Back off exponentially, capped at 30 seconds.
+2. Wait longer when the `x-ratelimit-reset` response header reports a longer window.
+3. Add random jitter to every wait, so parallel workers do not retry together.
+4. Pause before the budget runs out, based on the `x-ratelimit-remaining` header.
+
+No configuration is needed. A large apply works at the default parallelism, and `terraform apply -parallelism=1` is no longer a workaround.
+
+Set `max_retries` to change how many times a rejected request is retried. The default is 6, which spends up to 61 seconds waiting and so outlasts a full 60-second rate-limit window. The maximum is 20. Set it to `0` to turn the retry off and let the `429` reach Terraform.
+
+```hcl
+provider "ory" {
+  workspace_api_key = var.ory_workspace_api_key
+  project_id        = var.ory_project_id
+  max_retries       = 8 # for a very large apply
+}
+```
+
+The value can also be supplied as an `ORY_MAX_RETRIES` environment variable:
+
+```bash
+export ORY_MAX_RETRIES=8
+```
+
+To see each wait, run Terraform with `TF_LOG=DEBUG` and look for `Ory API rate limit reached`.
+
 ## Import Requirements
 
 When importing existing resources, ensure you have the appropriate credentials configured **before** running `terraform import`.
@@ -170,6 +201,7 @@ When importing existing resources, ensure you have the appropriate credentials c
 
 - `allowed_project_ids` (List of String) Optional safety guardrail. When set, the provider refuses any project-configuration operation (`ory_project_config`, `ory_action`, `ory_email_template`, `ory_social_provider`, `ory_saml_provider`, `ory_identity_schema`, `ory_custom_domain`, `ory_event_stream`, `ory_organization`, `ory_project_api_key`, and `ory_project` create/delete) that targets a project ID not in this list. This bounds the blast radius of a workspace API key so a mis-pointed `project_id` (such as production) cannot be read or changed. When unset, no restriction is applied. Can also be set via the `ORY_ALLOWED_PROJECT_IDS` environment variable as a comma-separated list.
 - `console_api_url` (String) Override the console API URL (default: `https://api.console.ory.sh`). Mainly for testing.
+- `max_retries` (Number) How many times a request that the Ory API rejects with `429 Too Many Requests` is retried before the error reaches Terraform (default: `6`, maximum: `20`). The provider backs off exponentially, capped at 30 seconds, waits longer when the `x-ratelimit-reset` header reports a longer window, and adds random jitter so parallel workers do not retry together. Raise it for a very large apply; set it to `0` to disable the retry. Can also be set via the `ORY_MAX_RETRIES` environment variable.
 - `project_api_key` (String, Sensitive) Ory Project API Key (`ory_pat_...`). Used for identity and OAuth2 operations. Can also be set via `ORY_PROJECT_API_KEY` environment variable.
 - `project_api_url` (String) Override the project API URL template (default: `https://%s.projects.oryapis.com`).
 - `project_id` (String) Ory Project ID. Can also be set via `ORY_PROJECT_ID` environment variable.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -48,10 +48,6 @@ const (
 )
 
 const (
-	// maxRetries is the maximum number of retry attempts for rate-limited requests.
-	maxRetries = 3
-	// initialBackoff is the initial backoff duration before first retry.
-	initialBackoff = 1 * time.Second
 	// maxErrorBodyBytes is the maximum length of a raw response body included in
 	// a wrapped API error before it is truncated.
 	maxErrorBodyBytes = 2048
@@ -359,38 +355,6 @@ func IsTransientError(err error) bool {
 	return isRetryableError(err) || isRateLimitError(err)
 }
 
-// retryWithBackoff executes a function with exponential backoff on rate limit errors.
-func retryWithBackoff[T any](ctx context.Context, operation string, fn func() (T, error)) (T, error) {
-	var result T
-	var err error
-	backoff := initialBackoff
-
-	for attempt := 0; attempt <= maxRetries; attempt++ {
-		result, err = fn()
-		if err == nil {
-			return result, nil
-		}
-
-		if !isRateLimitError(err) {
-			return result, err
-		}
-
-		if attempt == maxRetries {
-			return result, fmt.Errorf("%s: rate limit exceeded after %d retries: %w", operation, maxRetries, err)
-		}
-
-		// Wait before retrying
-		select {
-		case <-ctx.Done():
-			return result, ctx.Err()
-		case <-time.After(backoff):
-			backoff *= 2 // Exponential backoff
-		}
-	}
-
-	return result, err
-}
-
 // OryClientConfig holds configuration for the Ory API client.
 type OryClientConfig struct {
 	WorkspaceAPIKey string
@@ -413,6 +377,24 @@ type OryClientConfig struct {
 	// defaultOrganizationRetryBaseDelay; tests shorten it so the retry path can
 	// be covered without waiting fifteen seconds.
 	OrganizationRetryBaseDelay time.Duration
+
+	// MaxRetries is how many more times a request that the Ory API rejected
+	// with HTTP 429 is sent before the error reaches the caller. A nil pointer
+	// means DefaultMaxRetries, and a pointer to 0 turns the retry off. The
+	// field is a pointer because those two cases differ. See rateLimitTransport.
+	MaxRetries *int
+}
+
+// maxRetries returns the configured 429 retry count, or DefaultMaxRetries when
+// the config leaves it unset.
+func (c OryClientConfig) maxRetries() int {
+	if c.MaxRetries == nil {
+		return DefaultMaxRetries
+	}
+	if *c.MaxRetries < 0 {
+		return 0
+	}
+	return *c.MaxRetries
 }
 
 // Equal reports whether two configs are equivalent. It is used to decide
@@ -428,7 +410,8 @@ func (c OryClientConfig) Equal(other OryClientConfig) bool {
 		c.ConsoleAPIURL != other.ConsoleAPIURL ||
 		c.ProjectAPIURL != other.ProjectAPIURL ||
 		c.UserAgent != other.UserAgent ||
-		c.OrganizationRetryBaseDelay != other.OrganizationRetryBaseDelay {
+		c.OrganizationRetryBaseDelay != other.OrganizationRetryBaseDelay ||
+		c.maxRetries() != other.maxRetries() {
 		return false
 	}
 	if len(c.AllowedProjectIDs) != len(other.AllowedProjectIDs) {
@@ -452,6 +435,13 @@ type OryClient struct {
 	// allowedProjects is the set of project IDs console operations may target,
 	// derived from config.AllowedProjectIDs. When empty, no restriction applies.
 	allowedProjects map[string]struct{}
+
+	// httpClient sends every request to the Ory API, both through the SDK and
+	// through the raw console calls the SDK does not cover. Its transport
+	// retries an HTTP 429, so a bulk apply survives the rate limit. It is nil on
+	// a zero-valued OryClient, and rawHTTPClient falls back to the package
+	// default in that case.
+	httpClient *http.Client
 
 	// Console API client (for organizations, projects, workspaces)
 	consoleClient *ory.APIClient
@@ -492,7 +482,11 @@ func (c *OryClient) patchProjectMutex(projectID string) *sync.Mutex {
 
 // NewOryClient creates a new Ory API client.
 func NewOryClient(cfg OryClientConfig) (*OryClient, error) {
-	client := &OryClient{config: cfg, allowedProjects: buildProjectSet(cfg.AllowedProjectIDs)}
+	client := &OryClient{
+		config:          cfg,
+		allowedProjects: buildProjectSet(cfg.AllowedProjectIDs),
+		httpClient:      newOryHTTPClient(cfg.maxRetries()),
+	}
 
 	// Initialize console client if workspace API key is provided
 	if cfg.WorkspaceAPIKey != "" {
@@ -506,6 +500,7 @@ func NewOryClient(cfg OryClientConfig) (*OryClient, error) {
 		}
 
 		consoleCfg := ory.NewConfiguration()
+		consoleCfg.HTTPClient = client.httpClient
 		consoleCfg.UserAgent = cfg.UserAgent
 		consoleCfg.Host = parsedURL.Host
 		consoleCfg.Scheme = parsedURL.Scheme
@@ -575,6 +570,7 @@ func NewOryClient(cfg OryClientConfig) (*OryClient, error) {
 		}
 
 		projectCfg := ory.NewConfiguration()
+		projectCfg.HTTPClient = client.httpClient
 		projectCfg.UserAgent = cfg.UserAgent
 		projectCfg.Host = parsedURL.Host
 		projectCfg.Scheme = parsedURL.Scheme
@@ -665,6 +661,7 @@ func (c *OryClient) WithProjectCredentials(slug, apiKey string) *OryClient {
 	return &OryClient{
 		config:          newConfig,
 		allowedProjects: c.allowedProjects,
+		httpClient:      c.httpClient,
 		consoleClient:   c.consoleClient,
 		// projectClient is nil — ensureProjectClient will lazily initialize it
 		// projectClientMu and cachedProjects are zero-valued (valid)
@@ -745,6 +742,7 @@ func (c *OryClient) ensureProjectClient() error {
 	}
 
 	projectCfg := ory.NewConfiguration()
+	projectCfg.HTTPClient = c.rawHTTPClient()
 	projectCfg.UserAgent = c.config.UserAgent
 	projectCfg.Host = parsedURL.Host
 	projectCfg.Scheme = parsedURL.Scheme
@@ -755,6 +753,17 @@ func (c *OryClient) ensureProjectClient() error {
 	c.projectClient = ory.NewAPIClient(projectCfg)
 
 	return nil
+}
+
+// rawHTTPClient returns the HTTP client that sends requests to the Ory API. A
+// client built by NewOryClient always has one. A zero-valued OryClient, which
+// only tests construct, falls back to the package default so its requests still
+// retry an HTTP 429.
+func (c *OryClient) rawHTTPClient() *http.Client {
+	if c.httpClient != nil {
+		return c.httpClient
+	}
+	return consoleHTTPClient
 }
 
 // requireConsoleClient returns an error wrapping ErrConsoleClientNotConfigured
@@ -879,40 +888,40 @@ func (c *OryClient) GetCachedProject(projectID string) *ory.Project {
 }
 
 // doConsoleRawRequest issues a request against a console API endpoint that is
-// missing from the generated client-go SDK, with the standard auth headers
-// and 429-aware retry. A non-nil payload is sent as JSON. The caller owns the
-// response body.
+// missing from the generated client-go SDK, with the standard auth headers. A
+// non-nil payload is sent as JSON. The caller owns the response body.
+//
+// The client's transport retries an HTTP 429, so this method only reports the
+// one that survives every retry. bytes.Reader gives the request a GetBody, so
+// the transport can replay the payload on each attempt.
 func (c *OryClient) doConsoleRawRequest(ctx context.Context, operation, method, endpoint string, payload []byte) (*http.Response, error) {
-	return retryWithBackoff(ctx, operation, func() (*http.Response, error) {
-		// Build the request inside the retry closure so each attempt gets a
-		// fresh, unconsumed request body.
-		var body io.Reader
-		if payload != nil {
-			body = bytes.NewReader(payload)
-		}
-		req, reqErr := http.NewRequestWithContext(ctx, method, endpoint, body)
-		if reqErr != nil {
-			return nil, reqErr
-		}
-		req.Header.Set("Authorization", "Bearer "+c.config.WorkspaceAPIKey)
-		if payload != nil {
-			req.Header.Set("Content-Type", "application/json")
-		}
-		req.Header.Set("Accept", "application/json")
-		if c.config.UserAgent != "" {
-			req.Header.Set("User-Agent", c.config.UserAgent)
-		}
-		r, doErr := consoleHTTPClient.Do(req)
-		if doErr != nil {
-			return nil, doErr
-		}
-		if r.StatusCode == http.StatusTooManyRequests {
-			respBody, _ := io.ReadAll(r.Body)
-			_ = r.Body.Close()
-			return nil, fmt.Errorf("429 Too Many Requests: %s", strings.TrimSpace(string(respBody)))
-		}
-		return r, nil
-	})
+	var body io.Reader
+	if payload != nil {
+		body = bytes.NewReader(payload)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.config.WorkspaceAPIKey)
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	if c.config.UserAgent != "" {
+		req.Header.Set("User-Agent", c.config.UserAgent)
+	}
+	resp, err := c.rawHTTPClient().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		respBody, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("%s: 429 Too Many Requests after %d retries: %s",
+			operation, c.config.maxRetries(), strings.TrimSpace(string(respBody)))
+	}
+	return resp, nil
 }
 
 // normalizedProjectResponse is the subset of the console API's normalized
@@ -1359,60 +1368,52 @@ func (c *OryClient) DeleteOrganization(ctx context.Context, projectID, orgID str
 // Identity Operations (Project API)
 // =============================================================================
 
-// CreateIdentity creates a new identity with retry on rate limit.
+// CreateIdentity creates a new identity. The client's transport retries an
+// HTTP 429, so a rate limit only reaches the caller once every retry is spent.
 func (c *OryClient) CreateIdentity(ctx context.Context, body ory.CreateIdentityBody) (*ory.Identity, error) {
 	if err := c.ensureProjectClient(); err != nil {
 		return nil, fmt.Errorf("creating identity: %w", err)
 	}
-	return retryWithBackoff(ctx, "creating identity", func() (*ory.Identity, error) {
-		identity, httpResp, err := c.projectClient.IdentityAPI.CreateIdentity(ctx).CreateIdentityBody(body).Execute()
-		if httpResp != nil {
-			_ = httpResp.Body.Close()
-		}
-		return identity, err
-	})
+	identity, httpResp, err := c.projectClient.IdentityAPI.CreateIdentity(ctx).CreateIdentityBody(body).Execute()
+	if httpResp != nil {
+		_ = httpResp.Body.Close()
+	}
+	return identity, err
 }
 
-// GetIdentity retrieves an identity by ID with retry on rate limit.
+// GetIdentity retrieves an identity by ID.
 func (c *OryClient) GetIdentity(ctx context.Context, identityID string) (*ory.Identity, error) {
 	if err := c.ensureProjectClient(); err != nil {
 		return nil, fmt.Errorf("getting identity: %w", err)
 	}
-	return retryWithBackoff(ctx, "getting identity", func() (*ory.Identity, error) {
-		identity, httpResp, err := c.projectClient.IdentityAPI.GetIdentity(ctx, identityID).Execute()
-		if httpResp != nil {
-			_ = httpResp.Body.Close()
-		}
-		return identity, err
-	})
+	identity, httpResp, err := c.projectClient.IdentityAPI.GetIdentity(ctx, identityID).Execute()
+	if httpResp != nil {
+		_ = httpResp.Body.Close()
+	}
+	return identity, err
 }
 
-// UpdateIdentity updates an identity with retry on rate limit.
+// UpdateIdentity updates an identity.
 func (c *OryClient) UpdateIdentity(ctx context.Context, identityID string, body ory.UpdateIdentityBody) (*ory.Identity, error) {
 	if err := c.ensureProjectClient(); err != nil {
 		return nil, fmt.Errorf("updating identity: %w", err)
 	}
-	return retryWithBackoff(ctx, "updating identity", func() (*ory.Identity, error) {
-		identity, httpResp, err := c.projectClient.IdentityAPI.UpdateIdentity(ctx, identityID).UpdateIdentityBody(body).Execute()
-		if httpResp != nil {
-			_ = httpResp.Body.Close()
-		}
-		return identity, err
-	})
+	identity, httpResp, err := c.projectClient.IdentityAPI.UpdateIdentity(ctx, identityID).UpdateIdentityBody(body).Execute()
+	if httpResp != nil {
+		_ = httpResp.Body.Close()
+	}
+	return identity, err
 }
 
-// DeleteIdentity deletes an identity with retry on rate limit.
+// DeleteIdentity deletes an identity.
 func (c *OryClient) DeleteIdentity(ctx context.Context, identityID string) error {
 	if err := c.ensureProjectClient(); err != nil {
 		return fmt.Errorf("deleting identity: %w", err)
 	}
-	_, err := retryWithBackoff(ctx, "deleting identity", func() (struct{}, error) {
-		httpResp, err := c.projectClient.IdentityAPI.DeleteIdentity(ctx, identityID).Execute()
-		if httpResp != nil {
-			_ = httpResp.Body.Close()
-		}
-		return struct{}{}, err
-	})
+	httpResp, err := c.projectClient.IdentityAPI.DeleteIdentity(ctx, identityID).Execute()
+	if httpResp != nil {
+		_ = httpResp.Body.Close()
+	}
 	return err
 }
 
@@ -1503,7 +1504,18 @@ func (c *OryClient) ListProjectAPIKeys(ctx context.Context, projectID string) ([
 	return keys, err
 }
 
-// DeleteProjectAPIKey deletes an API key with retry logic for transient errors.
+const (
+	// serverErrorRetries is how many more times DeleteProjectAPIKey sends a
+	// request that the console API failed with a 5xx.
+	serverErrorRetries = 3
+	// serverErrorBackoff is the first wait between those attempts. It doubles
+	// on each further attempt.
+	serverErrorBackoff = 1 * time.Second
+)
+
+// DeleteProjectAPIKey deletes an API key, and retries a server error. A rate
+// limit needs no handling here: the client's transport already retries an
+// HTTP 429, so one that reaches this code has spent every retry.
 func (c *OryClient) DeleteProjectAPIKey(ctx context.Context, projectID, keyID string) error {
 	if err := c.requireConsoleClient("deleting project API key"); err != nil {
 		return err
@@ -1512,9 +1524,9 @@ func (c *OryClient) DeleteProjectAPIKey(ctx context.Context, projectID, keyID st
 		return err
 	}
 	var lastErr error
-	backoff := initialBackoff
+	backoff := serverErrorBackoff
 
-	for attempt := 0; attempt <= maxRetries; attempt++ {
+	for attempt := 0; attempt <= serverErrorRetries; attempt++ {
 		httpResp, err := c.consoleClient.ProjectAPI.DeleteProjectApiKey(ctx, projectID, keyID).Execute()
 		if httpResp != nil {
 			_ = httpResp.Body.Close()
@@ -1526,12 +1538,12 @@ func (c *OryClient) DeleteProjectAPIKey(ctx context.Context, projectID, keyID st
 
 		lastErr = err
 
-		// Only retry on rate limit or 5xx errors
-		if !isRateLimitError(err) && !isRetryableError(err) {
+		// Only retry on 5xx errors
+		if !isRetryableError(err) {
 			return err
 		}
 
-		if attempt == maxRetries {
+		if attempt == serverErrorRetries {
 			break
 		}
 
@@ -1544,7 +1556,7 @@ func (c *OryClient) DeleteProjectAPIKey(ctx context.Context, projectID, keyID st
 		}
 	}
 
-	return fmt.Errorf("deleting API key: failed after %d retries: %w", maxRetries, lastErr)
+	return fmt.Errorf("deleting API key: failed after %d retries: %w", serverErrorRetries, lastErr)
 }
 
 // =============================================================================
@@ -2008,11 +2020,13 @@ func (c *OryClient) ListIdentitySchemasViaProject(ctx context.Context, projectID
 	return extractSchemasFromProjectConfig(ctx, project)
 }
 
-// consoleHTTPClient is used for direct calls to the console API (the workspace
-// identity-schemas endpoint) that the SDK does not yet expose. It carries an
-// explicit timeout so a stalled upstream cannot block reads indefinitely, and
-// is a variable so tests can override it.
-var consoleHTTPClient = &http.Client{Timeout: 30 * time.Second}
+// consoleHTTPClient is the fallback for direct calls to the console API (the
+// workspace identity-schemas endpoint) that the SDK does not yet expose. A
+// client built by NewOryClient carries its own, so this one only serves a
+// zero-valued OryClient. Its transport retries an HTTP 429 and guards a stalled
+// upstream with a per-attempt response-header timeout. It is a variable so
+// tests can override it.
+var consoleHTTPClient = newOryHTTPClient(DefaultMaxRetries)
 
 // managedIdentitySchema mirrors the response of the backoffice
 // GET /identity-schemas endpoint. It is defined locally so the method does not
@@ -2050,18 +2064,9 @@ func (c *OryClient) ListWorkspaceIdentitySchemas(ctx context.Context) ([]ory.Ide
 		req.Header.Set("User-Agent", c.config.UserAgent)
 	}
 
-	resp, err := retryWithBackoff(ctx, "listing workspace identity schemas", func() (*http.Response, error) {
-		r, doErr := consoleHTTPClient.Do(req)
-		if doErr != nil {
-			return nil, doErr
-		}
-		if r.StatusCode == http.StatusTooManyRequests {
-			body, _ := io.ReadAll(r.Body)
-			_ = r.Body.Close()
-			return nil, fmt.Errorf("429 Too Many Requests: %s", strings.TrimSpace(string(body)))
-		}
-		return r, nil
-	})
+	// The client's transport retries an HTTP 429, so a rate limit only reaches
+	// the caller once every retry is spent.
+	resp, err := c.rawHTTPClient().Do(req)
 	if err != nil {
 		return nil, wrapAPIError(err, "listing workspace identity schemas")
 	}

--- a/internal/client/ratelimit.go
+++ b/internal/client/ratelimit.go
@@ -1,0 +1,384 @@
+package client
+
+import (
+	"context"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Rate-limit handling.
+//
+// The Ory API rejects a request with HTTP 429 when the caller exceeds the
+// request budget for a route. Terraform runs resource operations in parallel,
+// ten at a time by default, so a bulk apply reaches that budget quickly. Before
+// this transport existed, the provider surfaced the 429 as a hard error and
+// aborted the apply with the resources half-written.
+//
+// rateLimitTransport absorbs the 429 inside the HTTP client, so every SDK call
+// and every raw console call retries without a change at the call site. The
+// wait follows Ory's guidance at
+// https://www.ory.com/docs/guides/rate-limits-new#how-to-handle-429-responses:
+//
+//  1. Back off exponentially, capped at 30 s.
+//  2. Wait longer when the x-ratelimit-reset header reports a longer window.
+//  3. Add random jitter, so parallel workers do not retry in lockstep.
+//  4. Slow down before the budget runs out, based on x-ratelimit-remaining.
+//
+// The exponential step is the floor, not the fallback, because the Ory API
+// reports x-ratelimit-reset: 0 on the sub-second buckets it rejects most often.
+// A wait taken from that header alone lasts a few hundred milliseconds, spends
+// every retry inside one window, and fails the apply anyway.
+
+const (
+	// DefaultMaxRetries is how many more times the transport sends a request
+	// that the API rejected with HTTP 429. Ory meters each route with a
+	// one-second burst bucket and a sixty-second sustained bucket, so six
+	// retries are the smallest number whose waits (1 s, 2 s, 4 s, 8 s, 16 s and
+	// 30 s, 61 s in total) outlast a full sustained window.
+	DefaultMaxRetries = 6
+
+	// MaxRetriesUpperBound is the largest value the provider accepts for
+	// max_retries. It stops a typo from stalling an apply for hours.
+	MaxRetriesUpperBound = 20
+)
+
+const (
+	// rateLimitBaseDelay is the first step of the exponential backoff. It
+	// applies when the response carries no usable rate-limit header.
+	rateLimitBaseDelay = 1 * time.Second
+	// rateLimitMaxDelay caps a single wait, as Ory's 429 guidance requires.
+	rateLimitMaxDelay = 30 * time.Second
+	// rateLimitJitterShare is the fraction of the wait added as random jitter.
+	// The jitter is additive, so a wait never ends before the window the server
+	// reported.
+	rateLimitJitterShare = 0.5
+	// rateLimitThrottleAt is the x-ratelimit-remaining value at or below which
+	// the transport pauses after a successful response. The pause costs the same
+	// as a retry but does not spend a request, and Ory blocks a client that
+	// keeps exceeding its limit.
+	rateLimitThrottleAt = 1
+	// rateLimitThrottleMaxDelay caps a proactive pause. A pause protects the
+	// next request; it must not stall the apply the way a real 429 wait can.
+	rateLimitThrottleMaxDelay = 2 * time.Second
+	// rateLimitDrainLimit is how much of a rejected response body the transport
+	// reads before it closes the body, so the connection returns to the pool.
+	// Ory sends an empty body with a 429, so the limit only bounds an
+	// unexpected large one.
+	rateLimitDrainLimit = 4 << 10
+	// backoffShiftLimit bounds the exponential shift, so the delay cannot
+	// overflow before the cap applies.
+	backoffShiftLimit = 20
+)
+
+// Rate-limit response headers. Ory documents all three at
+// https://www.ory.com/docs/guides/rate-limits-new. A response carries one set
+// per limit bucket, for example a per-route bucket and a global bucket, so the
+// transport reads every value of a header and not only the first.
+const (
+	headerRateLimitRemaining = "X-Ratelimit-Remaining"
+	headerRateLimitReset     = "X-Ratelimit-Reset"
+	// headerRetryAfter is the standard fallback. Ory does not send it today, so
+	// the transport prefers it only because it is unambiguous when present.
+	headerRetryAfter = "Retry-After"
+)
+
+// rateLimitTransport retries a request that the Ory API rejects with HTTP 429.
+// It wraps a base RoundTripper and adds no connection pool of its own, so many
+// transports can share one pool.
+type rateLimitTransport struct {
+	// base sends the request. A nil base means http.DefaultTransport.
+	base http.RoundTripper
+	// maxRetries is how many more times a rejected request is sent. Zero
+	// disables the retry and leaves the proactive throttle in place.
+	maxRetries int
+	// sleep waits for d or until ctx is done. Tests replace it so a case runs
+	// without a real wait.
+	sleep func(ctx context.Context, d time.Duration) error
+	// randFloat returns a number in [0, 1) for the jitter. Tests replace it to
+	// make a wait deterministic.
+	randFloat func() float64
+}
+
+// newRateLimitTransport returns a transport that retries a 429 up to maxRetries
+// times on top of base. A nil base means http.DefaultTransport, which keeps the
+// shared connection pool the Ory SDK uses by default.
+func newRateLimitTransport(base http.RoundTripper, maxRetries int) *rateLimitTransport {
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	return &rateLimitTransport{base: base, maxRetries: maxRetries}
+}
+
+// newOryHTTPClient returns the HTTP client the provider uses for every call to
+// the Ory API. The client carries no overall timeout, because that budget would
+// also cover the waits between retries and cut a legitimate backoff short. The
+// per-attempt guard lives on the transport instead.
+func newOryHTTPClient(maxRetries int) *http.Client {
+	return &http.Client{Transport: newRateLimitTransport(oryBaseTransport(), maxRetries)}
+}
+
+// oryBaseTransport returns the transport that sends a request to the Ory API.
+// It clones the standard transport, so the connection pool, the proxy settings,
+// and the dial timeouts stay as the Go runtime configures them, and adds a
+// per-attempt response-header timeout. That timeout is the stall guard: an
+// overall http.Client.Timeout cannot serve that role here, because it also
+// covers the waits between retries.
+func oryBaseTransport() http.RoundTripper {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return http.DefaultTransport
+	}
+	cloned := transport.Clone()
+	cloned.ResponseHeaderTimeout = 30 * time.Second
+	return cloned
+}
+
+// RoundTrip sends the request and retries it while the API answers HTTP 429.
+// It returns the last response when the retries run out, so the caller still
+// sees the API's own error.
+func (t *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	// Every attempt sends a copy that carries its own body, so the body the
+	// caller handed over is never read and never closed by the base transport.
+	// Close it here, as the RoundTripper contract requires.
+	if req.Body != nil && req.GetBody != nil {
+		defer func() { _ = req.Body.Close() }()
+	}
+
+	for attempt := 0; ; attempt++ {
+		// A RoundTripper must not change the request it is given, and a retry
+		// needs an unread body, so every attempt sends its own copy.
+		attemptReq, err := cloneRequest(req)
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := base.RoundTrip(attemptReq)
+		if err != nil {
+			return resp, err
+		}
+
+		if resp.StatusCode != http.StatusTooManyRequests ||
+			attempt >= t.maxRetries ||
+			!canReplayBody(req) {
+			t.throttleBeforeNext(req.Context(), resp)
+			return resp, nil
+		}
+
+		wait := t.waitFor(resp.Header, attempt)
+		tflog.Debug(req.Context(), "Ory API rate limit reached; retrying after backoff", map[string]interface{}{
+			"method":      req.Method,
+			"request_url": req.URL.Redacted(),
+			"attempt":     attempt + 1,
+			"max_retries": t.maxRetries,
+			"wait_ms":     wait.Milliseconds(),
+		})
+		drainAndClose(resp.Body)
+
+		if err := t.wait(req.Context(), wait); err != nil {
+			return nil, err
+		}
+	}
+}
+
+// cloneRequest copies req and gives the copy an unread body. A request whose
+// body cannot be replayed keeps the original body, and canReplayBody stops the
+// retry before that copy is sent twice.
+func cloneRequest(req *http.Request) (*http.Request, error) {
+	clone := req.Clone(req.Context())
+	if req.Body == nil || req.GetBody == nil {
+		return clone, nil
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return nil, err
+	}
+	clone.Body = body
+	return clone, nil
+}
+
+// canReplayBody reports whether a second attempt can send the same body. A
+// request built by the Ory SDK or by doConsoleRawRequest always can, because
+// net/http fills in GetBody for the buffer types both use. A request that
+// cannot replay its body is returned to the caller with its 429 intact, because
+// a retry would send an empty body and change the meaning of the call.
+func canReplayBody(req *http.Request) bool {
+	return req.Body == nil || req.GetBody != nil
+}
+
+// waitFor returns how long to wait before the next attempt. The exponential
+// step sets the floor, the window the server reports raises it when that window
+// is longer, the cap trims the result, and the jitter spreads parallel workers.
+func (t *rateLimitTransport) waitFor(header http.Header, attempt int) time.Duration {
+	delay := backoffDelay(attempt)
+	if reported, ok := reportedDelay(header); ok && reported > delay {
+		delay = reported
+	}
+	if delay > rateLimitMaxDelay {
+		delay = rateLimitMaxDelay
+	}
+	return delay + t.jitter(delay)
+}
+
+// reportedDelay returns the wait the server asked for, from Retry-After when it
+// is present and from x-ratelimit-reset otherwise.
+func reportedDelay(header http.Header) (time.Duration, bool) {
+	if delay, ok := retryAfterDelay(header); ok {
+		return delay, true
+	}
+	return resetDelay(header)
+}
+
+// throttleBeforeNext pauses when the response shows the request budget is spent,
+// so the next call from the same Terraform worker starts in a fresh window
+// instead of being rejected. Ory recommends this over waiting for the 429,
+// because a client that keeps exceeding its limit can lose API access.
+func (t *rateLimitTransport) throttleBeforeNext(ctx context.Context, resp *http.Response) {
+	if resp.StatusCode == http.StatusTooManyRequests {
+		// The retry loop already waited for this response, or the retries ran
+		// out. Either way, a further pause helps nobody.
+		return
+	}
+	remaining, ok := lowestRemaining(resp.Header)
+	if !ok || remaining > rateLimitThrottleAt {
+		return
+	}
+	delay, ok := reportedDelay(resp.Header)
+	if !ok || delay < rateLimitBaseDelay {
+		// The Ory API reports a reset of 0 on a sub-second bucket, which asks
+		// for a wait too short to let the window turn over.
+		delay = rateLimitBaseDelay
+	}
+	if delay > rateLimitThrottleMaxDelay {
+		delay = rateLimitThrottleMaxDelay
+	}
+	pause := delay + t.jitter(delay)
+	tflog.Debug(ctx, "Ory API request budget nearly spent; pausing before the next request", map[string]interface{}{
+		"remaining": remaining,
+		"wait_ms":   pause.Milliseconds(),
+	})
+	// A canceled context ends the pause. The response is already in hand, so
+	// the caller still gets it and decides what the cancellation means.
+	_ = t.wait(ctx, pause)
+}
+
+// backoffDelay returns the exponential step for an attempt, starting at
+// rateLimitBaseDelay and doubling each time.
+func backoffDelay(attempt int) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+	if attempt > backoffShiftLimit {
+		return rateLimitMaxDelay
+	}
+	return rateLimitBaseDelay << uint(attempt)
+}
+
+// jitter returns a random share of d, up to rateLimitJitterShare of it.
+func (t *rateLimitTransport) jitter(d time.Duration) time.Duration {
+	random := t.randFloat
+	if random == nil {
+		// #nosec G404 -- the jitter only spreads retries apart in time and
+		// carries no security meaning, so the fast pseudo-random source fits.
+		random = rand.Float64
+	}
+	return time.Duration(random() * rateLimitJitterShare * float64(d))
+}
+
+// wait blocks for d, or returns the context error when the caller cancels first.
+func (t *rateLimitTransport) wait(ctx context.Context, d time.Duration) error {
+	if t.sleep != nil {
+		return t.sleep(ctx, d)
+	}
+	if d <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// retryAfterDelay reads a Retry-After header, in seconds or as an HTTP date.
+func retryAfterDelay(header http.Header) (time.Duration, bool) {
+	value := header.Get(headerRetryAfter)
+	if value == "" {
+		return 0, false
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds < 0 {
+			return 0, false
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+	when, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+	delay := time.Until(when)
+	if delay < 0 {
+		delay = 0
+	}
+	return delay, true
+}
+
+// resetDelay reads x-ratelimit-reset, the number of seconds until the limit
+// window resets. A response carries one value per limit bucket, so the longest
+// window wins: a shorter wait would run into the bucket that is still full.
+func resetDelay(header http.Header) (time.Duration, bool) {
+	longest := time.Duration(0)
+	found := false
+	for _, value := range header.Values(headerRateLimitReset) {
+		seconds, err := strconv.Atoi(value)
+		if err != nil || seconds < 0 {
+			continue
+		}
+		found = true
+		if delay := time.Duration(seconds) * time.Second; delay > longest {
+			longest = delay
+		}
+	}
+	return longest, found
+}
+
+// lowestRemaining reads x-ratelimit-remaining and returns the smallest value.
+// A response carries one value per limit bucket, and the bucket closest to
+// empty is the one that rejects the next request.
+func lowestRemaining(header http.Header) (int, bool) {
+	lowest := 0
+	found := false
+	for _, value := range header.Values(headerRateLimitRemaining) {
+		remaining, err := strconv.Atoi(value)
+		if err != nil || remaining < 0 {
+			continue
+		}
+		if !found || remaining < lowest {
+			lowest = remaining
+		}
+		found = true
+	}
+	return lowest, found
+}
+
+// drainAndClose reads and closes a rejected response body, so the underlying
+// connection goes back to the pool instead of being dropped.
+func drainAndClose(body io.ReadCloser) {
+	if body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(body, rateLimitDrainLimit))
+	_ = body.Close()
+}

--- a/internal/client/ratelimit.go
+++ b/internal/client/ratelimit.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"math/rand/v2"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -37,9 +38,10 @@ import (
 const (
 	// DefaultMaxRetries is how many more times the transport sends a request
 	// that the API rejected with HTTP 429. Ory meters each route with a
-	// one-second burst bucket and a sixty-second sustained bucket, so six
-	// retries are the smallest number whose waits (1 s, 2 s, 4 s, 8 s, 16 s and
-	// 30 s, 61 s in total) outlast a full sustained window.
+	// one-second burst bucket and a sixty-second sustained bucket. Six retries
+	// wait 1 s, 2 s, 4 s, 8 s, 16 s and 30 s, which is 61 s in total and so
+	// outlasts a full sustained window. That total is a floor. The jitter and a
+	// longer window reported by the server both raise it.
 	DefaultMaxRetries = 6
 
 	// MaxRetriesUpperBound is the largest value the provider accepts for
@@ -176,11 +178,11 @@ func (t *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error
 
 		wait := t.waitFor(resp.Header, attempt)
 		tflog.Debug(req.Context(), "Ory API rate limit reached; retrying after backoff", map[string]interface{}{
-			"method":      req.Method,
-			"request_url": req.URL.Redacted(),
-			"attempt":     attempt + 1,
-			"max_retries": t.maxRetries,
-			"wait_ms":     wait.Milliseconds(),
+			"method":        req.Method,
+			"request_route": requestRoute(req.URL),
+			"attempt":       attempt + 1,
+			"max_retries":   t.maxRetries,
+			"wait_ms":       wait.Milliseconds(),
 		})
 		drainAndClose(resp.Body)
 
@@ -188,6 +190,18 @@ func (t *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error
 			return nil, err
 		}
 	}
+}
+
+// requestRoute returns the scheme, the host and the path of a URL, without the
+// query string. The Ory API takes identifiers and filter values as query
+// parameters, such as the email address in credentials_identifier, and a retry
+// diagnostic has no use for them. url.URL.Redacted hides only the userinfo, so
+// it does not keep those values out of the Terraform debug log.
+func requestRoute(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	return u.Scheme + "://" + u.Host + u.EscapedPath()
 }
 
 // cloneRequest copies req and gives the copy an unread body. A request whose

--- a/internal/client/ratelimit_test.go
+++ b/internal/client/ratelimit_test.go
@@ -1,0 +1,682 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/terraform-provider-ory/internal/testutil"
+)
+
+// recordingSleeper stands in for the real wait so a test runs instantly. It
+// records every duration the transport asked for.
+type recordingSleeper struct {
+	mu     sync.Mutex
+	waits  []time.Duration
+	err    error
+	errAt  int
+	called int
+}
+
+func (s *recordingSleeper) sleep(_ context.Context, d time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.called++
+	s.waits = append(s.waits, d)
+	if s.err != nil && s.called >= s.errAt {
+		return s.err
+	}
+	return nil
+}
+
+func (s *recordingSleeper) recorded() []time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]time.Duration, len(s.waits))
+	copy(out, s.waits)
+	return out
+}
+
+// newTestTransport builds a transport with no jitter and no real wait, so a
+// test can assert on exact durations.
+func newTestTransport(base http.RoundTripper, maxRetries int, sleeper *recordingSleeper) *rateLimitTransport {
+	t := newRateLimitTransport(base, maxRetries)
+	t.sleep = sleeper.sleep
+	t.randFloat = func() float64 { return 0 }
+	return t
+}
+
+// rateLimitServer answers with 429 for the first rejectCount requests and then
+// with 200. It records every request it saw.
+type rateLimitServer struct {
+	rejectCount int32
+	seen        int32
+	bodies      []string
+	headers     http.Header
+	mu          sync.Mutex
+}
+
+func (s *rateLimitServer) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		s.mu.Lock()
+		s.bodies = append(s.bodies, string(body))
+		s.mu.Unlock()
+
+		for key, values := range s.headers {
+			for _, value := range values {
+				w.Header().Add(key, value)
+			}
+		}
+		if atomic.AddInt32(&s.seen, 1) <= atomic.LoadInt32(&s.rejectCount) {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}
+}
+
+func (s *rateLimitServer) sentBodies() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.bodies))
+	copy(out, s.bodies)
+	return out
+}
+
+func TestRateLimitTransport_RetriesUntilSuccess(t *testing.T) {
+	backend := &rateLimitServer{rejectCount: 2}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	sleeper := &recordingSleeper{}
+	client := &http.Client{Transport: newTestTransport(srv.Client().Transport, 5, sleeper)}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&backend.seen), "two rejections plus the accepted attempt")
+	assert.Len(t, sleeper.recorded(), 2, "one wait per rejection")
+}
+
+func TestRateLimitTransport_ReturnsLastResponseWhenRetriesRunOut(t *testing.T) {
+	backend := &rateLimitServer{rejectCount: 100}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	sleeper := &recordingSleeper{}
+	client := &http.Client{Transport: newTestTransport(srv.Client().Transport, 2, sleeper)}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err, "an exhausted retry returns the API response, not a transport error")
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&backend.seen), "the first attempt plus two retries")
+}
+
+func TestRateLimitTransport_ZeroRetriesSendsOneRequest(t *testing.T) {
+	backend := &rateLimitServer{rejectCount: 100}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	sleeper := &recordingSleeper{}
+	client := &http.Client{Transport: newTestTransport(srv.Client().Transport, 0, sleeper)}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&backend.seen))
+	assert.Empty(t, sleeper.recorded())
+}
+
+func TestRateLimitTransport_ReplaysRequestBody(t *testing.T) {
+	backend := &rateLimitServer{rejectCount: 2}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	sleeper := &recordingSleeper{}
+	client := &http.Client{Transport: newTestTransport(srv.Client().Transport, 5, sleeper)}
+
+	const payload = `{"client_name":"tf-bulk"}`
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL, strings.NewReader(payload))
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, []string{payload, payload, payload}, backend.sentBodies(),
+		"every attempt must carry the full body, not an empty one")
+}
+
+func TestRateLimitTransport_DoesNotRetryWhenBodyCannotReplay(t *testing.T) {
+	backend := &rateLimitServer{rejectCount: 100}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	sleeper := &recordingSleeper{}
+	client := &http.Client{Transport: newTestTransport(srv.Client().Transport, 5, sleeper)}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL, nil)
+	require.NoError(t, err)
+	// A reader net/http cannot rewind leaves GetBody nil, so a retry would send
+	// an empty body and change the meaning of the call.
+	req.Body = io.NopCloser(strings.NewReader(`{"a":1}`))
+	req.GetBody = nil
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&backend.seen), "the request is sent once")
+	assert.Empty(t, sleeper.recorded())
+}
+
+func TestRateLimitTransport_LeavesOriginalRequestUnchanged(t *testing.T) {
+	backend := &rateLimitServer{rejectCount: 1}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	sleeper := &recordingSleeper{}
+	client := &http.Client{Transport: newTestTransport(srv.Client().Transport, 5, sleeper)}
+
+	const payload = `{"a":1}`
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL, strings.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("X-Test", "kept")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.MethodPost, req.Method)
+	assert.Equal(t, "kept", req.Header.Get("X-Test"))
+	// Every attempt sends its own copy, so the caller's body stays unread and
+	// the request can be sent again.
+	body, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	assert.Equal(t, payload, string(body), "RoundTrip must not consume the caller's body")
+}
+
+func TestRateLimitTransport_HonoursResetHeader(t *testing.T) {
+	backend := &rateLimitServer{
+		rejectCount: 1,
+		headers:     http.Header{headerRateLimitReset: []string{"4"}},
+	}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	sleeper := &recordingSleeper{}
+	client := &http.Client{Transport: newTestTransport(srv.Client().Transport, 5, sleeper)}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, []time.Duration{4 * time.Second}, sleeper.recorded(),
+		"a reported window longer than the exponential step wins")
+}
+
+func TestRateLimitTransport_IgnoresResetShorterThanBackoff(t *testing.T) {
+	// The Ory API answers a rejected request on a sub-second bucket with
+	// x-ratelimit-reset: 0. A wait taken from that header alone would spend
+	// every retry inside one window. See issue #327.
+	backend := &rateLimitServer{
+		rejectCount: 2,
+		headers:     http.Header{headerRateLimitReset: []string{"0", "0"}},
+	}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	sleeper := &recordingSleeper{}
+	client := &http.Client{Transport: newTestTransport(srv.Client().Transport, 5, sleeper)}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, []time.Duration{1 * time.Second, 2 * time.Second}, sleeper.recorded(),
+		"the exponential step is the floor, so a reset of 0 does not shorten the wait")
+}
+
+func TestRateLimitTransport_FallsBackToExponentialBackoff(t *testing.T) {
+	backend := &rateLimitServer{rejectCount: 3}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	sleeper := &recordingSleeper{}
+	client := &http.Client{Transport: newTestTransport(srv.Client().Transport, 5, sleeper)}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second}, sleeper.recorded())
+}
+
+func TestRateLimitTransport_StopsWaitingOnCancelledContext(t *testing.T) {
+	backend := &rateLimitServer{rejectCount: 100}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	sleeper := &recordingSleeper{err: context.Canceled, errAt: 1}
+	transport := newTestTransport(srv.Client().Transport, 5, sleeper)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req) //nolint:bodyclose // the canceled wait returns no response to close
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&backend.seen))
+}
+
+func TestRateLimitTransport_ReturnsTransportError(t *testing.T) {
+	sleeper := &recordingSleeper{}
+	wantErr := errors.New("dial failed")
+	transport := newTestTransport(roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, wantErr
+	}), 5, sleeper)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.invalid", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req) //nolint:bodyclose // the failed transport returns no response to close
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Empty(t, sleeper.recorded(), "a network error is not a rate limit")
+}
+
+func TestRateLimitTransport_ThrottlesWhenBudgetIsSpent(t *testing.T) {
+	backend := &rateLimitServer{
+		headers: http.Header{
+			headerRateLimitRemaining: []string{"0", "480"},
+			headerRateLimitReset:     []string{"0", "0"},
+		},
+	}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	sleeper := &recordingSleeper{}
+	client := &http.Client{Transport: newTestTransport(srv.Client().Transport, 5, sleeper)}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, []time.Duration{rateLimitBaseDelay}, sleeper.recorded(),
+		"an empty bucket pauses the worker before it spends a request on a certain 429")
+}
+
+func TestRateLimitTransport_ThrottlePauseIsCapped(t *testing.T) {
+	backend := &rateLimitServer{
+		headers: http.Header{
+			headerRateLimitRemaining: []string{"0"},
+			headerRateLimitReset:     []string{"60"},
+		},
+	}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	sleeper := &recordingSleeper{}
+	client := &http.Client{Transport: newTestTransport(srv.Client().Transport, 5, sleeper)}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, []time.Duration{rateLimitThrottleMaxDelay}, sleeper.recorded(),
+		"a pause protects the next request; it must not stall the apply")
+}
+
+func TestRateLimitTransport_DoesNotThrottleWithBudgetLeft(t *testing.T) {
+	backend := &rateLimitServer{
+		headers: http.Header{
+			headerRateLimitRemaining: []string{"9", "480"},
+			headerRateLimitReset:     []string{"1"},
+		},
+	}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	sleeper := &recordingSleeper{}
+	client := &http.Client{Transport: newTestTransport(srv.Client().Transport, 5, sleeper)}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Empty(t, sleeper.recorded())
+}
+
+func TestRateLimitTransport_JitterStaysInsideItsShare(t *testing.T) {
+	transport := newRateLimitTransport(nil, DefaultMaxRetries)
+	header := http.Header{headerRateLimitReset: []string{"2"}}
+
+	for i := 0; i < 200; i++ {
+		wait := transport.waitFor(header, 0)
+		assert.GreaterOrEqual(t, wait, 2*time.Second, "an additive jitter never shortens the reported window")
+		assert.LessOrEqual(t, wait, 3*time.Second, "the jitter adds at most half the wait")
+	}
+}
+
+func TestRateLimitTransport_JitterSpreadsParallelRetries(t *testing.T) {
+	transport := newRateLimitTransport(nil, DefaultMaxRetries)
+	header := http.Header{headerRateLimitReset: []string{"1"}}
+
+	distinct := map[time.Duration]struct{}{}
+	for i := 0; i < 50; i++ {
+		distinct[transport.waitFor(header, 0)] = struct{}{}
+	}
+	assert.Greater(t, len(distinct), 1, "parallel workers must not wake at the same instant")
+}
+
+func TestRateLimitTransport_WaitForCapsAndFloors(t *testing.T) {
+	transport := newRateLimitTransport(nil, DefaultMaxRetries)
+	transport.randFloat = func() float64 { return 0 }
+
+	tests := []struct {
+		name    string
+		header  http.Header
+		attempt int
+		want    time.Duration
+	}{
+		{
+			name:   "retry after in seconds wins over the reset window",
+			header: http.Header{headerRetryAfter: []string{"7"}, headerRateLimitReset: []string{"2"}},
+			want:   7 * time.Second,
+		},
+		{
+			name:   "longest reset window wins across limit buckets",
+			header: http.Header{headerRateLimitReset: []string{"1", "12", "3"}},
+			want:   12 * time.Second,
+		},
+		{
+			name:   "a reset window longer than the cap is trimmed to 30 s",
+			header: http.Header{headerRateLimitReset: []string{"600"}},
+			want:   rateLimitMaxDelay,
+		},
+		{
+			name:   "a reset of zero leaves the exponential step in place",
+			header: http.Header{headerRateLimitReset: []string{"0"}},
+			want:   rateLimitBaseDelay,
+		},
+		{
+			name:    "a reset shorter than the exponential step does not shorten it",
+			header:  http.Header{headerRateLimitReset: []string{"1"}},
+			attempt: 3,
+			want:    8 * time.Second,
+		},
+		{
+			name:   "an unparsable header falls back to the exponential step",
+			header: http.Header{headerRateLimitReset: []string{"soon"}},
+			want:   rateLimitBaseDelay,
+		},
+		{
+			name:    "the exponential fallback stops at the cap",
+			header:  http.Header{},
+			attempt: 9,
+			want:    rateLimitMaxDelay,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, transport.waitFor(tt.header, tt.attempt))
+		})
+	}
+}
+
+func TestRetryAfterDelay(t *testing.T) {
+	t.Run("http date", func(t *testing.T) {
+		when := time.Now().Add(5 * time.Second).UTC()
+		header := http.Header{headerRetryAfter: []string{when.Format(http.TimeFormat)}}
+
+		delay, ok := retryAfterDelay(header)
+		require.True(t, ok)
+		assert.InDelta(t, (5 * time.Second).Seconds(), delay.Seconds(), 1.5)
+	})
+
+	t.Run("date in the past", func(t *testing.T) {
+		when := time.Now().Add(-1 * time.Minute).UTC()
+		header := http.Header{headerRetryAfter: []string{when.Format(http.TimeFormat)}}
+
+		delay, ok := retryAfterDelay(header)
+		require.True(t, ok)
+		assert.Equal(t, time.Duration(0), delay)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		_, ok := retryAfterDelay(http.Header{})
+		assert.False(t, ok)
+	})
+
+	t.Run("negative seconds", func(t *testing.T) {
+		_, ok := retryAfterDelay(http.Header{headerRetryAfter: []string{"-3"}})
+		assert.False(t, ok)
+	})
+}
+
+func TestLowestRemaining(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []string
+		want   int
+		found  bool
+	}{
+		{name: "single bucket", values: []string{"12"}, want: 12, found: true},
+		{name: "smallest bucket wins", values: []string{"480", "0", "9"}, want: 0, found: true},
+		{name: "unparsable values are skipped", values: []string{"many", "3"}, want: 3, found: true},
+		{name: "no header", values: nil, found: false},
+		{name: "only unparsable values", values: []string{"many"}, found: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := http.Header{}
+			for _, value := range tt.values {
+				header.Add(headerRateLimitRemaining, value)
+			}
+			got, ok := lowestRemaining(header)
+			assert.Equal(t, tt.found, ok)
+			if tt.found {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestOryClientConfig_MaxRetries(t *testing.T) {
+	zero, five := 0, 5
+
+	assert.Equal(t, DefaultMaxRetries, OryClientConfig{}.maxRetries(), "an unset value uses the default")
+	assert.Equal(t, 0, OryClientConfig{MaxRetries: &zero}.maxRetries(), "an explicit zero turns the retry off")
+	assert.Equal(t, 5, OryClientConfig{MaxRetries: &five}.maxRetries())
+}
+
+func TestOryClientConfig_EqualComparesMaxRetries(t *testing.T) {
+	zero, five, unset := 0, 5, (*int)(nil)
+
+	assert.True(t, OryClientConfig{MaxRetries: &five}.Equal(OryClientConfig{MaxRetries: &five}))
+	assert.False(t, OryClientConfig{MaxRetries: &five}.Equal(OryClientConfig{MaxRetries: &zero}))
+	assert.True(t, OryClientConfig{MaxRetries: unset}.Equal(OryClientConfig{}),
+		"an unset value and the default are the same client")
+}
+
+func TestNewOryClient_UsesRateLimitTransport(t *testing.T) {
+	two := 2
+	client, err := NewOryClient(OryClientConfig{
+		WorkspaceAPIKey: testutil.TestWorkspaceAPIKey,
+		ConsoleAPIURL:   DefaultConsoleAPIURL,
+		ProjectAPIKey:   testutil.TestProjectAPIKey,
+		ProjectSlug:     testutil.TestProjectSlug,
+		MaxRetries:      &two,
+	})
+	require.NoError(t, err)
+
+	transport, ok := client.httpClient.Transport.(*rateLimitTransport)
+	require.True(t, ok, "the provider client must retry a rate limit")
+	assert.Equal(t, 2, transport.maxRetries)
+
+	assert.Same(t, client.httpClient, client.consoleClient.GetConfig().HTTPClient,
+		"console SDK calls go through the retrying client")
+	assert.Same(t, client.httpClient, client.projectClient.GetConfig().HTTPClient,
+		"project SDK calls go through the retrying client")
+	assert.Same(t, client.httpClient, client.rawHTTPClient(),
+		"raw console calls go through the retrying client")
+}
+
+func TestOryClient_RawHTTPClientFallsBackToPackageDefault(t *testing.T) {
+	assert.Same(t, consoleHTTPClient, (&OryClient{}).rawHTTPClient())
+}
+
+// tokenBucket models the burst limit the Ory API enforces: a window holds a
+// fixed number of requests, and the window refills when time passes.
+type tokenBucket struct {
+	mu       sync.Mutex
+	tokens   int
+	size     int
+	rejected int
+}
+
+// take spends a token and reports whether one was left.
+func (b *tokenBucket) take() (remaining int, ok bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.tokens == 0 {
+		b.rejected++
+		return 0, false
+	}
+	b.tokens--
+	return b.tokens, true
+}
+
+// refill starts a new window.
+func (b *tokenBucket) refill() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.tokens = b.size
+}
+
+func (b *tokenBucket) rejectedCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.rejected
+}
+
+// TestRateLimitTransport_ParallelWorkersAllSucceed reproduces the shape of the
+// bug in issue #327: many Terraform workers write at once, the API rejects the
+// requests over its budget, and every worker must still finish.
+func TestRateLimitTransport_ParallelWorkersAllSucceed(t *testing.T) {
+	const workers = 20
+
+	bucket := &tokenBucket{tokens: 3, size: 3}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remaining, ok := bucket.take()
+		w.Header().Set(headerRateLimitReset, "1")
+		w.Header().Set(headerRateLimitRemaining, strconv.Itoa(remaining))
+		if !ok {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	sleeper := &recordingSleeper{}
+	transport := newTestTransport(srv.Client().Transport, 10, sleeper)
+	// A wait means the limit window passed, so the bucket starts over. The
+	// stand-in keeps the test instant.
+	transport.sleep = func(ctx context.Context, d time.Duration) error {
+		bucket.refill()
+		return sleeper.sleep(ctx, d)
+	}
+	client := &http.Client{Transport: transport}
+
+	var wg sync.WaitGroup
+	statuses := make([]int, workers)
+	errs := make([]error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL,
+				strings.NewReader(`{"client_name":"tf-bulk"}`))
+			if err != nil {
+				errs[index] = err
+				return
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				errs[index] = err
+				return
+			}
+			statuses[index] = resp.StatusCode
+			_ = resp.Body.Close()
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < workers; i++ {
+		require.NoError(t, errs[i], "worker %d", i)
+		assert.Equal(t, http.StatusOK, statuses[i], "worker %d must finish despite the rate limit", i)
+	}
+	assert.Positive(t, bucket.rejectedCount(), "the test only proves something if the API rejected some requests")
+}
+
+// roundTripperFunc adapts a function to http.RoundTripper.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/internal/client/ratelimit_test.go
+++ b/internal/client/ratelimit_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -535,6 +535,42 @@ func TestLowestRemaining(t *testing.T) {
 	}
 }
 
+func TestRequestRoute(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			// url.URL.Redacted would keep both query values, and the retry
+			// diagnostic has no use for them.
+			name: "the query string is dropped",
+			raw:  "https://slug.projects.oryapis.com/admin/identities?credentials_identifier=alice%40example.com&page_token=abc",
+			want: "https://slug.projects.oryapis.com/admin/identities",
+		},
+		{ //nolint:gosec // G101 false positive - the fake userinfo is the point of this case
+			name: "userinfo is dropped with the rest of the authority",
+			raw:  "https://user:secret@api.console.ory.sh/projects/123",
+			want: "https://api.console.ory.sh/projects/123",
+		},
+		{
+			name: "a plain route is unchanged",
+			raw:  "https://api.console.ory.sh/projects",
+			want: "https://api.console.ory.sh/projects",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := url.Parse(tt.raw)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, requestRoute(parsed))
+		})
+	}
+
+	assert.Empty(t, requestRoute(nil))
+}
+
 func TestOryClientConfig_MaxRetries(t *testing.T) {
 	zero, five := 0, 5
 
@@ -588,7 +624,7 @@ type tokenBucket struct {
 	rejected int
 }
 
-// take spends a token and reports whether one was left.
+// take spends a token and reports how many are left and whether one was there.
 func (b *tokenBucket) take() (remaining int, ok bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -621,9 +657,13 @@ func TestRateLimitTransport_ParallelWorkersAllSucceed(t *testing.T) {
 
 	bucket := &tokenBucket{tokens: 3, size: 3}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		remaining, ok := bucket.take()
+		_, ok := bucket.take()
 		w.Header().Set(headerRateLimitReset, "1")
-		w.Header().Set(headerRateLimitRemaining, strconv.Itoa(remaining))
+		// The response carries no x-ratelimit-remaining on purpose. With it the
+		// proactive throttle would pause before the bucket ever empties, refill
+		// it through the stand-in wait below, and leave this case with no
+		// rejection to retry. TestRateLimitTransport_ThrottlesWhenBudgetIsSpent
+		// covers the throttle instead.
 		if !ok {
 			w.WriteHeader(http.StatusTooManyRequests)
 			return

--- a/internal/provider/max_retries_test.go
+++ b/internal/provider/max_retries_test.go
@@ -1,0 +1,141 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/terraform-provider-ory/internal/client"
+)
+
+func TestResolveMaxRetries(t *testing.T) {
+	tests := []struct {
+		name      string
+		tfValue   types.Int64
+		envValue  string
+		want      *int
+		wantError bool
+	}{
+		{
+			name:    "unset leaves the client default in place",
+			tfValue: types.Int64Null(),
+			want:    nil,
+		},
+		{
+			name:    "the configured value wins",
+			tfValue: types.Int64Value(9),
+			want:    intPtr(9),
+		},
+		{
+			name:    "zero turns the retry off",
+			tfValue: types.Int64Value(0),
+			want:    intPtr(0),
+		},
+		{
+			name:     "the configured value wins over the environment",
+			tfValue:  types.Int64Value(3),
+			envValue: "7",
+			want:     intPtr(3),
+		},
+		{
+			name:     "the environment applies when nothing is configured",
+			tfValue:  types.Int64Null(),
+			envValue: "7",
+			want:     intPtr(7),
+		},
+		{
+			name:     "surrounding whitespace is trimmed",
+			tfValue:  types.Int64Null(),
+			envValue: "  4 ",
+			want:     intPtr(4),
+		},
+		{
+			name:      "a value that is not a number is an error",
+			tfValue:   types.Int64Null(),
+			envValue:  "lots",
+			wantError: true,
+		},
+		{
+			name:      "a negative value is an error",
+			tfValue:   types.Int64Null(),
+			envValue:  "-1",
+			wantError: true,
+		},
+		{
+			name:      "a value above the maximum is an error",
+			tfValue:   types.Int64Null(),
+			envValue:  "9999",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("ORY_MAX_RETRIES", tt.envValue)
+
+			var diags diag.Diagnostics
+			got := resolveMaxRetries(tt.tfValue, &diags)
+
+			assert.Equal(t, tt.wantError, diags.HasError(), "diagnostics: %v", diags)
+			if tt.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, *tt.want, *got)
+		})
+	}
+}
+
+func TestProviderSchema_MaxRetries(t *testing.T) {
+	p := New("test")()
+	resp := &provider.SchemaResponse{}
+	p.Schema(context.Background(), provider.SchemaRequest{}, resp)
+	require.False(t, resp.Diagnostics.HasError(), "schema: %v", resp.Diagnostics)
+
+	attr, ok := resp.Schema.Attributes["max_retries"]
+	require.True(t, ok, "the provider must expose max_retries")
+
+	intAttr, ok := attr.(schema.Int64Attribute)
+	require.True(t, ok)
+	assert.True(t, intAttr.Optional)
+	assert.False(t, intAttr.Required)
+	assert.Len(t, intAttr.Validators, 1, "the value must be bounded")
+	assert.Contains(t, intAttr.MarkdownDescription, "429 Too Many Requests")
+	assert.Contains(t, intAttr.MarkdownDescription, "ORY_MAX_RETRIES")
+}
+
+func TestProviderSchema_MaxRetriesRejectsOutOfRange(t *testing.T) {
+	p := New("test")()
+	resp := &provider.SchemaResponse{}
+	p.Schema(context.Background(), provider.SchemaRequest{}, resp)
+	require.False(t, resp.Diagnostics.HasError())
+
+	intAttr := resp.Schema.Attributes["max_retries"].(schema.Int64Attribute)
+	validate := intAttr.Validators[0]
+
+	for _, tc := range []struct {
+		value     int64
+		wantError bool
+	}{
+		{value: 0},
+		{value: client.DefaultMaxRetries},
+		{value: client.MaxRetriesUpperBound},
+		{value: -1, wantError: true},
+		{value: client.MaxRetriesUpperBound + 1, wantError: true},
+	} {
+		req := validator.Int64Request{ConfigValue: types.Int64Value(tc.value)}
+		res := &validator.Int64Response{}
+		validate.ValidateInt64(context.Background(), req, res)
+		assert.Equal(t, tc.wantError, res.Diagnostics.HasError(), "value %d", tc.value)
+	}
+}
+
+func intPtr(v int) *int { return &v }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -217,12 +217,16 @@ When importing existing resources, ensure you have the appropriate credentials c
 				Description: fmt.Sprintf(
 					"How many times a request that the Ory API rejects with HTTP 429 Too Many Requests is retried before the error reaches Terraform (default: %d, maximum: %d). "+
 						"The provider backs off exponentially, capped at 30 seconds, waits longer when the x-ratelimit-reset header reports a longer window, and adds random jitter so parallel workers do not retry together. "+
-						"Raise it for a very large apply; set it to 0 to disable the retry. Can also be set via the ORY_MAX_RETRIES environment variable.",
+						"At the default the waits come to 61 seconds, which is a floor: the jitter and a longer reported window both raise it. "+
+						"The 429 still reaches Terraform once the retries run out, or when this is set to 0. "+
+						"Raise it for a very large apply. Can also be set via the ORY_MAX_RETRIES environment variable.",
 					client.DefaultMaxRetries, client.MaxRetriesUpperBound),
 				MarkdownDescription: fmt.Sprintf(
 					"How many times a request that the Ory API rejects with `429 Too Many Requests` is retried before the error reaches Terraform (default: `%d`, maximum: `%d`). "+
 						"The provider backs off exponentially, capped at 30 seconds, waits longer when the `x-ratelimit-reset` header reports a longer window, and adds random jitter so parallel workers do not retry together. "+
-						"Raise it for a very large apply; set it to `0` to disable the retry. Can also be set via the `ORY_MAX_RETRIES` environment variable.",
+						"At the default the waits come to 61 seconds, which is a floor: the jitter and a longer reported window both raise it. "+
+						"The `429` still reaches Terraform once the retries run out, or when this is set to `0`. "+
+						"Raise it for a very large apply. Can also be set via the `ORY_MAX_RETRIES` environment variable.",
 					client.DefaultMaxRetries, client.MaxRetriesUpperBound),
 				Optional: true,
 				Validators: []validator.Int64{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,15 +2,19 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/ory/terraform-provider-ory/internal/client"
@@ -81,6 +85,9 @@ type OryProviderModel struct {
 	// Optional: Override API URLs (for testing)
 	ConsoleAPIURL types.String `tfsdk:"console_api_url"`
 	ProjectAPIURL types.String `tfsdk:"project_api_url"`
+
+	// Optional: how many times a rate-limited request is retried
+	MaxRetries types.Int64 `tfsdk:"max_retries"`
 }
 
 // New returns a new provider instance.
@@ -206,6 +213,22 @@ When importing existing resources, ensure you have the appropriate credentials c
 				MarkdownDescription: "Override the project API URL template (default: `https://%s.projects.oryapis.com`).",
 				Optional:            true,
 			},
+			"max_retries": schema.Int64Attribute{
+				Description: fmt.Sprintf(
+					"How many times a request that the Ory API rejects with HTTP 429 Too Many Requests is retried before the error reaches Terraform (default: %d, maximum: %d). "+
+						"The provider backs off exponentially, capped at 30 seconds, waits longer when the x-ratelimit-reset header reports a longer window, and adds random jitter so parallel workers do not retry together. "+
+						"Raise it for a very large apply; set it to 0 to disable the retry. Can also be set via the ORY_MAX_RETRIES environment variable.",
+					client.DefaultMaxRetries, client.MaxRetriesUpperBound),
+				MarkdownDescription: fmt.Sprintf(
+					"How many times a request that the Ory API rejects with `429 Too Many Requests` is retried before the error reaches Terraform (default: `%d`, maximum: `%d`). "+
+						"The provider backs off exponentially, capped at 30 seconds, waits longer when the `x-ratelimit-reset` header reports a longer window, and adds random jitter so parallel workers do not retry together. "+
+						"Raise it for a very large apply; set it to `0` to disable the retry. Can also be set via the `ORY_MAX_RETRIES` environment variable.",
+					client.DefaultMaxRetries, client.MaxRetriesUpperBound),
+				Optional: true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, client.MaxRetriesUpperBound),
+				},
+			},
 		},
 	}
 }
@@ -227,6 +250,7 @@ func (p *OryProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	consoleAPIURL := resolveStringDefault(config.ConsoleAPIURL, "ORY_CONSOLE_API_URL", DefaultConsoleAPIURL)
 	projectAPIURL := resolveStringDefault(config.ProjectAPIURL, "ORY_PROJECT_API_URL", DefaultProjectAPIURL)
 	allowedProjectIDs := resolveAllowedProjectIDs(ctx, config.AllowedProjectIDs, &resp.Diagnostics)
+	maxRetries := resolveMaxRetries(config.MaxRetries, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -274,6 +298,7 @@ For more information: https://www.ory.sh/docs/guides/api-keys`,
 		ProjectAPIURL:     projectAPIURL,
 		UserAgent:         userAgent,
 		AllowedProjectIDs: allowedProjectIDs,
+		MaxRetries:        maxRetries,
 	}
 
 	if p.oryClient == nil || !p.lastConfig.Equal(newConfig) {
@@ -371,6 +396,32 @@ func resolveAllowedProjectIDs(ctx context.Context, tfValue types.List, diags *di
 		return normalizeStringList(strings.Split(v, ","))
 	}
 	return nil
+}
+
+// resolveMaxRetries resolves max_retries with an ORY_MAX_RETRIES environment
+// variable fallback. It returns nil when neither source sets a value, which
+// leaves the client on its default. A pointer to 0 is a real setting that turns
+// the retry off, so the two cases must stay apart.
+func resolveMaxRetries(tfValue types.Int64, diags *diag.Diagnostics) *int {
+	if !tfValue.IsNull() && !tfValue.IsUnknown() {
+		value := int(tfValue.ValueInt64())
+		return &value
+	}
+	raw := strings.TrimSpace(os.Getenv("ORY_MAX_RETRIES"))
+	if raw == "" {
+		return nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < 0 || value > client.MaxRetriesUpperBound {
+		diags.AddError(
+			"Invalid ORY_MAX_RETRIES Value",
+			fmt.Sprintf("ORY_MAX_RETRIES must be a whole number between 0 and %d, got %q. "+
+				"It sets how many times a request rejected with HTTP 429 is retried.",
+				client.MaxRetriesUpperBound, raw),
+		)
+		return nil
+	}
+	return &value
 }
 
 // normalizeStringList trims whitespace from each entry and drops empty strings.

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -172,7 +172,9 @@ The provider retries a rejected request instead of failing the apply. It follows
 
 No configuration is needed. A large apply works at the default parallelism, and `terraform apply -parallelism=1` is no longer a workaround.
 
-Set `max_retries` to change how many times a rejected request is retried. The default is 6, which spends up to 61 seconds waiting and so outlasts a full 60-second rate-limit window. The maximum is 20. Set it to `0` to turn the retry off and let the `429` reach Terraform.
+A `429` still reaches Terraform when the retries run out or when `max_retries` is `0`. The error then names the operation and the number of retries it used.
+
+Set `max_retries` to change how many times a rejected request is retried. The default is 6. Its waits of 1, 2, 4, 8, 16 and 30 seconds come to 61 seconds, so the retry outlasts a full 60-second rate-limit window. That total is a floor: the jitter and a longer window reported by the server both raise it. The maximum is 20. Set it to `0` to turn the retry off.
 
 ```hcl
 provider "ory" {

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -159,6 +159,37 @@ export ORY_ALLOWED_PROJECT_IDS="3fa274fe-910d-4766-b1a4-0c0dd3b41429,7bc1e0c2-..
 
 When `allowed_project_ids` is unset, no restriction is applied.
 
+## Rate limits and retries
+
+The Ory API answers `429 Too Many Requests` when a caller exceeds the request budget for a route. Terraform runs resource operations in parallel, ten at a time by default, so a bulk apply of many `ory_oauth2_client` or `ory_identity` resources can reach that budget.
+
+The provider retries a rejected request instead of failing the apply. It follows [Ory's guidance for 429 responses](https://www.ory.com/docs/guides/rate-limits-new#how-to-handle-429-responses):
+
+1. Back off exponentially, capped at 30 seconds.
+2. Wait longer when the `x-ratelimit-reset` response header reports a longer window.
+3. Add random jitter to every wait, so parallel workers do not retry together.
+4. Pause before the budget runs out, based on the `x-ratelimit-remaining` header.
+
+No configuration is needed. A large apply works at the default parallelism, and `terraform apply -parallelism=1` is no longer a workaround.
+
+Set `max_retries` to change how many times a rejected request is retried. The default is 6, which spends up to 61 seconds waiting and so outlasts a full 60-second rate-limit window. The maximum is 20. Set it to `0` to turn the retry off and let the `429` reach Terraform.
+
+```hcl
+provider "ory" {
+  workspace_api_key = var.ory_workspace_api_key
+  project_id        = var.ory_project_id
+  max_retries       = 8 # for a very large apply
+}
+```
+
+The value can also be supplied as an `ORY_MAX_RETRIES` environment variable:
+
+```bash
+export ORY_MAX_RETRIES=8
+```
+
+To see each wait, run Terraform with `TF_LOG=DEBUG` and look for `Ory API rate limit reached`.
+
 ## Import Requirements
 
 When importing existing resources, ensure you have the appropriate credentials configured **before** running `terraform import`.


### PR DESCRIPTION
## Description

Bulk applies failed with `429 Too Many Requests`. Terraform runs resource operations in parallel, ten at a time by default, so applying or updating a set of `ory_oauth2_client` resources exceeds the request budget for a route. The provider turned the 429 into a hard error and aborted the apply with the resources half-written.

Every call to the Ory API now goes through a rate-limit-aware `http.RoundTripper`, so the generated SDK clients and the raw console requests are both covered without a change at any call site. The wait follows [Ory's guidance for 429 responses](https://www.ory.com/docs/guides/rate-limits-new#how-to-handle-429-responses):

1. Back off exponentially, capped at 30 seconds.
2. Wait longer when the `x-ratelimit-reset` header reports a longer window.
3. Add random jitter to every wait, so parallel workers do not retry together.
4. Pause before the budget runs out, based on the `x-ratelimit-remaining` header.

The exponential step is the floor rather than the fallback. The live API reports `x-ratelimit-reset: 0` on the sub-second buckets it rejects most often, and a wait taken from that header alone lasts a few hundred milliseconds, spends every retry inside one window, and fails the apply anyway. This was measured against the API, not assumed.

Other notes:

- The transport replaces `retryWithBackoff`. That helper covered 6 of 74 client methods and would otherwise stack a second retry loop on top of the new one.
- Each attempt sends its own copy of the request, so a POST or PATCH body is replayed in full. A request whose body cannot be replayed is returned with its 429 intact rather than resent empty.
- `consoleHTTPClient` traded its overall 30 second timeout for a per-attempt response-header timeout. An overall timeout would also cover the waits between retries and cut a legitimate backoff short.
- `DeleteProjectAPIKey` keeps its own loop for 5xx errors and no longer retries a 429 itself.

A new `max_retries` provider argument raises or lowers the retry count. The default is 6, which spends up to 61 seconds waiting and so outlasts a full 60-second rate-limit window. The maximum is 20, the value can also come from `ORY_MAX_RETRIES`, and `0` turns the retry off.

## Related Issues

Fixes #327

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

**Unit tests.** `internal/client/ratelimit_test.go` covers the retry until success, the exhausted retry returning the API response, `max_retries = 0`, body replay across attempts, the refusal to retry a body that cannot be replayed, the untouched caller request, the reported window winning over the exponential step, a reset of `0` leaving the exponential step in place, the 30 second cap, jitter bounds and spread, context cancellation, a network error not counting as a rate limit, the proactive pause and its cap, header parsing across repeated limit buckets, and 20 parallel workers all finishing through a token-bucket server. `internal/provider/max_retries_test.go` covers `max_retries` resolution, the `ORY_MAX_RETRIES` fallback, and the bounds validator.

**Acceptance tests.** All green against the shared test project:

```
ok  github.com/ory/terraform-provider-ory/internal/resources/oauth2client    57.0s
ok  github.com/ory/terraform-provider-ory/internal/resources/identity        18.0s
ok  github.com/ory/terraform-provider-ory/internal/resources/projectconfig  177.6s
ok  github.com/ory/terraform-provider-ory/internal/resources/identityschema  24.9s
ok  github.com/ory/terraform-provider-ory/internal/resources/action          70.4s
```

188 passed, 2 skipped for missing plan entitlements.

**Manual testing.** Against a throwaway Ory project, since deleted.

## Screenshots/Output

Reproduction with the current provider. 30 `ory_oauth2_client` resources, `-parallelism=10`:

```
Error: Error Creating OAuth2 Client
  with ory_oauth2_client.bulk[18],
  Could not create OAuth2 client: 429 Too Many Requests
```

25 of 30 reached the state file and the apply aborted.

Same workload raised to `-parallelism=100`, before and after, with an equal rest between the two runs:

```
BEFORE  exit=1  elapsed=1s   created=0   errors=100
AFTER   exit=1  elapsed=88s  created=14  errors=86
```

The retry ladder measured against the live API, from `TF_LOG=DEBUG` on one request:

```
10:51:36.752  attempt=1     ->  1.2s
10:51:37.973  attempt=2     ->  2.3s
10:51:40.265  attempt=3     ->  4.6s
10:51:44.834  attempt=4     ->  9.2s
10:51:54.043  attempt=5     -> 22.1s
10:52:16.161  attempt=6
```

Full lifecycle over 20 clients at the default parallelism, with the fixed provider:

```
1. CREATE 20 clients at parallelism 10   exit=0 created=20 errors=0
2. READ: plan must report no drift       plan exit=0
3. UPDATE: change the scope on all 20    exit=0 changed=20 errors=0
4. READ after update                     plan exit=0
5. IMPORT one client back into state     import exit=0, plan exit=0
6. DESTROY all 20                        exit=0 destroyed=20 errors=0
```

One limit is worth recording. Above roughly 75 parallel writes the API answers with an IP-scoped block, `"reason":"Too many API requests from your IP have been registered"`, which outlives the 61 second retry budget. No client-side retry clears that, and Ory documents it as the response to a client that keeps exceeding its limit without backing off. Terraform's default parallelism stays well inside it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic handling for API rate limits, including retries, backoff, jitter, and server-provided reset delays.
  * Added the `max_retries` provider setting, configurable through Terraform or `ORY_MAX_RETRIES`.
  * Added proactive throttling when the remaining API request budget is low.
* **Documentation**
  * Documented rate-limit behavior, retry configuration, defaults, limits, and debugging guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->