### PR TITLE
fix(saml-provider): patch method keys individually instead of the whole node

### DIFF
--- a/internal/resources/samlprovider/patches_test.go
+++ b/internal/resources/samlprovider/patches_test.go
@@ -1,0 +1,136 @@
+package samlprovider
+
+import (
+	"testing"
+
+	ory "github.com/ory/client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// samlTestProject wraps a selfservice methods map in an *ory.Project.
+func samlTestProject(methods map[string]interface{}) *ory.Project {
+	return &ory.Project{
+		Services: ory.ProjectServices{
+			Identity: &ory.ProjectServiceIdentity{
+				Config: map[string]interface{}{
+					"selfservice": map[string]interface{}{
+						"methods": methods,
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestSAMLMethodPatches_ExistingNodeTargetsIndividualKeys is the regression for
+// issue #332. When the SAML method node already exists, the patches must target
+// its individual keys. A patch whose path is the method node itself replaces the
+// whole object per RFC 6902, discarding every sibling key Ory keeps under it.
+func TestSAMLMethodPatches_ExistingNodeTargetsIndividualKeys(t *testing.T) {
+	patches := samlMethodPatches(true, false, []interface{}{})
+	require.Len(t, patches, 2)
+
+	for _, p := range patches {
+		assert.NotEqualf(t, samlMethodPath, p.Path,
+			"no patch may target the method node itself, it would discard sibling keys")
+		assert.Equal(t, "add", p.Op, "an add on an existing member replaces just that member")
+	}
+
+	byPath := map[string]interface{}{}
+	for _, p := range patches {
+		byPath[p.Path] = p.Value
+	}
+	assert.Equal(t, false, byPath[samlMethodPath+"/enabled"])
+	assert.Equal(t, []interface{}{}, byPath[samlMethodPath+"/config/providers"])
+}
+
+// TestSAMLMethodPatches_AbsentNodeIsWrittenWholesale verifies the one case where
+// writing the whole node is correct: there is nothing under it to lose yet.
+func TestSAMLMethodPatches_AbsentNodeIsWrittenWholesale(t *testing.T) {
+	provider := map[string]interface{}{"id": "first"}
+	patches := samlMethodPatches(false, true, []interface{}{provider})
+	require.Len(t, patches, 1)
+
+	assert.Equal(t, "add", patches[0].Op)
+	assert.Equal(t, samlMethodPath, patches[0].Path)
+	assert.Equal(t, map[string]interface{}{
+		"enabled": true,
+		"config": map[string]interface{}{
+			"providers": []interface{}{provider},
+		},
+	}, patches[0].Value)
+}
+
+// TestSAMLMethodPatches_FirstProviderEnablesMethod covers the create side of the
+// same defect: a project whose SAML method node exists with an empty providers
+// array, which is the default state, must not have that node overwritten when the
+// first provider is added.
+func TestSAMLMethodPatches_FirstProviderEnablesMethod(t *testing.T) {
+	provider := map[string]interface{}{"id": "first"}
+	patches := samlMethodPatches(true, true, []interface{}{provider})
+	require.Len(t, patches, 2)
+
+	byPath := map[string]interface{}{}
+	for _, p := range patches {
+		require.NotEqual(t, samlMethodPath, p.Path)
+		byPath[p.Path] = p.Value
+	}
+	assert.Equal(t, true, byPath[samlMethodPath+"/enabled"])
+	assert.Equal(t, []interface{}{provider}, byPath[samlMethodPath+"/config/providers"])
+}
+
+// TestExtractSAMLConfigFromProject_DistinguishesAbsentFromEmpty verifies the
+// signal Create branches on. An absent method node and a node holding an empty
+// providers array both yield no providers, but only the first may be written
+// wholesale, so the config map must be nil in one case and non-nil in the other.
+func TestExtractSAMLConfigFromProject_DistinguishesAbsentFromEmpty(t *testing.T) {
+	absent := samlTestProject(map[string]interface{}{})
+	assert.Nil(t, extractSAMLConfigFromProject(absent), "an absent saml node must read as nil")
+	assert.Empty(t, extractProvidersFromProject(absent))
+
+	// The default shape on a real project: the node exists, providers is empty.
+	empty := samlTestProject(map[string]interface{}{
+		"saml": map[string]interface{}{
+			"enabled": false,
+			"config":  map[string]interface{}{"providers": []interface{}{}},
+		},
+	})
+	assert.NotNil(t, extractSAMLConfigFromProject(empty), "an existing saml node must not read as nil")
+	assert.Empty(t, extractProvidersFromProject(empty))
+}
+
+// TestProvidersFromSAMLConfig covers the shapes the API can return.
+func TestProvidersFromSAMLConfig(t *testing.T) {
+	assert.Empty(t, providersFromSAMLConfig(nil))
+	assert.Empty(t, providersFromSAMLConfig(map[string]interface{}{}))
+
+	providers := providersFromSAMLConfig(map[string]interface{}{
+		"providers": []interface{}{
+			map[string]interface{}{"id": "one"},
+			"not-an-object",
+			map[string]interface{}{"id": "two"},
+		},
+	})
+	require.Len(t, providers, 2, "non-object entries are skipped")
+	assert.Equal(t, "one", providers[0]["id"])
+	assert.Equal(t, "two", providers[1]["id"])
+}
+
+// TestCopySAMLConfig verifies the cached config is not shared with callers.
+func TestCopySAMLConfig(t *testing.T) {
+	original := map[string]interface{}{
+		"providers": []interface{}{map[string]interface{}{"id": "one"}},
+	}
+	cp := copySAMLConfig(original)
+	require.NotNil(t, cp)
+
+	providers, _ := cp["providers"].([]interface{})
+	require.Len(t, providers, 1)
+	entry, _ := providers[0].(map[string]interface{})
+	entry["id"] = "mutated"
+
+	assert.Equal(t, "one",
+		original["providers"].([]interface{})[0].(map[string]interface{})["id"],
+		"mutating the copy must not reach the original")
+}

--- a/internal/resources/samlprovider/resource.go
+++ b/internal/resources/samlprovider/resource.go
@@ -201,6 +201,48 @@ func (r *SAMLProviderResource) buildProviderConfig(plan *SAMLProviderResourceMod
 	return config
 }
 
+// samlMethodPath is the config node that holds the whole SAML method
+// configuration: its `enabled` flag and its `config` object.
+const samlMethodPath = "/services/identity/config/selfservice/methods/saml"
+
+// samlMethodPatches returns the patches that set the SAML method's enabled flag
+// and its providers array. Both the first-provider create and the last-provider
+// delete need this.
+//
+// When the method node is absent it is created in one operation, which loses
+// nothing. When it already exists each key is patched on its own. A JSON Patch
+// "add" or "replace" whose path is an object node replaces that whole object
+// (RFC 6902), so writing the node wholesale silently discards every sibling key
+// Ory keeps under it. ory_social_provider had the same defect on the OIDC node,
+// where it discarded `config.base_redirect_uri` and `enable_auto_link_policy`.
+// See https://github.com/ory/terraform-provider-ory/issues/332
+func samlMethodPatches(nodeExists, enabled bool, providers []interface{}) []ory.JsonPatch {
+	if !nodeExists {
+		return []ory.JsonPatch{{
+			Op:   "add",
+			Path: samlMethodPath,
+			Value: map[string]interface{}{
+				"enabled": enabled,
+				"config": map[string]interface{}{
+					"providers": providers,
+				},
+			},
+		}}
+	}
+	return []ory.JsonPatch{
+		{
+			Op:    "add",
+			Path:  samlMethodPath + "/enabled",
+			Value: enabled,
+		},
+		{
+			Op:    "add",
+			Path:  samlMethodPath + "/config/providers",
+			Value: providers,
+		},
+	}
+}
+
 // extractSAMLConfigFromProject navigates to the SAML method config map.
 func extractSAMLConfigFromProject(project *ory.Project) map[string]interface{} {
 	if project.Services.Identity == nil {
@@ -230,7 +272,12 @@ func extractSAMLConfigFromProject(project *ory.Project) map[string]interface{} {
 }
 
 func extractProvidersFromProject(project *ory.Project) []map[string]interface{} {
-	samlConfig := extractSAMLConfigFromProject(project)
+	return providersFromSAMLConfig(extractSAMLConfigFromProject(project))
+}
+
+// providersFromSAMLConfig reads the providers array out of a SAML method config
+// map. A nil map, which means the method node is absent, yields no providers.
+func providersFromSAMLConfig(samlConfig map[string]interface{}) []map[string]interface{} {
 	if samlConfig == nil {
 		return []map[string]interface{}{}
 	}
@@ -247,29 +294,45 @@ func extractProvidersFromProject(project *ory.Project) []map[string]interface{} 
 	return result
 }
 
-// copyProviders returns a deep copy of the provider slice via a JSON
+// copySAMLConfig returns a deep copy of the SAML method config via a JSON
 // round-trip so callers cannot accidentally mutate the cached project state.
-func copyProviders(providers []map[string]interface{}) []map[string]interface{} {
-	b, err := json.Marshal(providers)
+func copySAMLConfig(samlConfig map[string]interface{}) map[string]interface{} {
+	b, err := json.Marshal(samlConfig)
 	if err != nil {
-		return providers
+		return samlConfig
 	}
-	var cp []map[string]interface{}
+	var cp map[string]interface{}
 	if err := json.Unmarshal(b, &cp); err != nil {
-		return providers
+		return samlConfig
 	}
 	return cp
 }
 
 func (r *SAMLProviderResource) getProviders(ctx context.Context, projectID string) ([]map[string]interface{}, error) {
+	samlConfig, err := r.getSAMLConfig(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	return providersFromSAMLConfig(samlConfig), nil
+}
+
+// getSAMLConfig returns the SAML method config map, or nil when the method node
+// is absent from the project config. Callers need that distinction: an absent
+// node can be written wholesale, while an existing one must be patched key by
+// key. See samlMethodPatches.
+func (r *SAMLProviderResource) getSAMLConfig(ctx context.Context, projectID string) (map[string]interface{}, error) {
 	if cached := r.client.GetCachedProject(projectID); cached != nil {
-		return copyProviders(extractProvidersFromProject(cached)), nil
+		samlConfig := extractSAMLConfigFromProject(cached)
+		if samlConfig == nil {
+			return nil, nil
+		}
+		return copySAMLConfig(samlConfig), nil
 	}
 	project, err := r.client.GetProject(ctx, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get project %s: %w", projectID, err)
 	}
-	return extractProvidersFromProject(project), nil
+	return extractSAMLConfigFromProject(project), nil
 }
 
 func (r *SAMLProviderResource) findProviderIndex(providers []map[string]interface{}, providerID string) int {
@@ -299,11 +362,12 @@ func (r *SAMLProviderResource) Create(ctx context.Context, req resource.CreateRe
 	mu.Lock()
 	defer mu.Unlock()
 
-	providers, err := r.getProviders(ctx, projectID)
+	samlConfig, err := r.getSAMLConfig(ctx, projectID)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Getting SAML Providers", err.Error())
 		return
 	}
+	providers := providersFromSAMLConfig(samlConfig)
 
 	var patches []ory.JsonPatch
 	existingIndex := r.findProviderIndex(providers, plan.ProviderID.ValueString())
@@ -313,28 +377,19 @@ func (r *SAMLProviderResource) Create(ctx context.Context, req resource.CreateRe
 		// Replace existing
 		patches = append(patches, ory.JsonPatch{
 			Op:    "replace",
-			Path:  fmt.Sprintf("/services/identity/config/selfservice/methods/saml/config/providers/%d", existingIndex),
+			Path:  fmt.Sprintf("%s/config/providers/%d", samlMethodPath, existingIndex),
 			Value: providerConfig,
 		})
 	case len(providers) == 0:
-		// Initialize the full SAML method configuration when adding the first provider.
-		// Using `add` (not `replace`) mirrors ory_social_provider's first-provider flow
-		// so the JSON Patch semantics are identical whether or not the saml method stub
-		// already exists in the project config.
-		patches = append(patches, ory.JsonPatch{
-			Op:   "add",
-			Path: "/services/identity/config/selfservice/methods/saml",
-			Value: map[string]interface{}{
-				"enabled": true,
-				"config": map[string]interface{}{
-					"providers": []interface{}{providerConfig},
-				},
-			},
-		})
+		// Adding the first provider also enables the method. Patch the two keys
+		// individually when the method node already exists so sibling keys under
+		// it survive; only an absent node is written wholesale.
+		patches = append(patches, samlMethodPatches(samlConfig != nil, true,
+			[]interface{}{providerConfig})...)
 	default:
 		patches = append(patches, ory.JsonPatch{
 			Op:    "add",
-			Path:  "/services/identity/config/selfservice/methods/saml/config/providers/-",
+			Path:  samlMethodPath + "/config/providers/-",
 			Value: providerConfig,
 		})
 	}
@@ -517,7 +572,7 @@ func (r *SAMLProviderResource) Update(ctx context.Context, req resource.UpdateRe
 
 	patches := []ory.JsonPatch{{
 		Op:    "replace",
-		Path:  fmt.Sprintf("/services/identity/config/selfservice/methods/saml/config/providers/%d", index),
+		Path:  fmt.Sprintf("%s/config/providers/%d", samlMethodPath, index),
 		Value: providerConfig,
 	}}
 
@@ -562,24 +617,17 @@ func (r *SAMLProviderResource) Delete(ctx context.Context, req resource.DeleteRe
 
 	var patches []ory.JsonPatch
 
-	// When removing the last provider, reset the SAML method config so we
-	// don't leave an `enabled: true` method with an empty providers array,
-	// which Ory treats as an invalid configuration.
+	// When removing the last provider, disable the method and clear the providers
+	// array so we don't leave an `enabled: true` method with an empty list, which
+	// Ory treats as an invalid configuration. The method node exists here, since
+	// we just found a provider inside it, so both keys are patched individually
+	// and sibling keys under the node survive.
 	if len(providers) == 1 {
-		patches = append(patches, ory.JsonPatch{
-			Op:   "replace",
-			Path: "/services/identity/config/selfservice/methods/saml",
-			Value: map[string]interface{}{
-				"enabled": false,
-				"config": map[string]interface{}{
-					"providers": []interface{}{},
-				},
-			},
-		})
+		patches = append(patches, samlMethodPatches(true, false, []interface{}{})...)
 	} else {
 		patches = append(patches, ory.JsonPatch{
 			Op:   "remove",
-			Path: fmt.Sprintf("/services/identity/config/selfservice/methods/saml/config/providers/%d", index),
+			Path: fmt.Sprintf("%s/config/providers/%d", samlMethodPath, index),
 		})
 	}
 

--- a/internal/resources/samlprovider/resource_test.go
+++ b/internal/resources/samlprovider/resource_test.go
@@ -3,6 +3,7 @@
 package samlprovider_test
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -14,6 +15,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ory/terraform-provider-ory/internal/acctest"
@@ -96,6 +98,113 @@ func TestAccSAMLProviderResource_basic(t *testing.T) {
 				// import starts from a blank state — the API's transformed URL is what
 				// import sees, and that's a legitimate value (also accepted by PATCH).
 				ImportStateVerifyIgnore: []string{"raw_idp_metadata_xml"},
+			},
+		},
+	})
+}
+
+// readSAMLMethodNode returns the selfservice.methods.saml node from the test
+// project, read straight from the API rather than from Terraform state.
+func readSAMLMethodNode(t *testing.T) map[string]interface{} {
+	t.Helper()
+
+	c, err := acctest.GetOryClient()
+	require.NoError(t, err, "could not create client")
+
+	project, err := c.GetProject(context.Background(), acctest.GetTestProject(t).ID)
+	require.NoError(t, err, "could not get project")
+	require.NotNil(t, project.Services.Identity, "project has no identity service")
+
+	selfservice, _ := project.Services.Identity.Config["selfservice"].(map[string]interface{})
+	methods, _ := selfservice["methods"].(map[string]interface{})
+	node, _ := methods["saml"].(map[string]interface{})
+	return node
+}
+
+// samlProviderIDs returns the provider ids stored in the SAML method node.
+func samlProviderIDs(node map[string]interface{}) []string {
+	config, _ := node["config"].(map[string]interface{})
+	providers, _ := config["providers"].([]interface{})
+	ids := make([]string, 0, len(providers))
+	for _, p := range providers {
+		pm, _ := p.(map[string]interface{})
+		if id, ok := pm["id"].(string); ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// TestAccSAMLProviderResource_deleteKeepsSiblingProviders is the regression test
+// for issue #332. Both the first-provider create and the last-provider delete
+// used to write the whole selfservice.methods.saml node, which replaces the
+// object and discards every key not named in the literal (RFC 6902). The same
+// defect on the OIDC node discarded config.base_redirect_uri, see
+// TestAccSocialProviderResource_preservesProjectConfigBaseRedirectURI.
+//
+// Every assertion reads the API directly. Terraform state cannot see a node
+// overwrite, because state only records what the provider believes it wrote.
+func TestAccSAMLProviderResource_deleteKeepsSiblingProviders(t *testing.T) {
+	metadata := buildTestMetadataXML(t)
+	configData := map[string]string{"MetadataXML": metadata}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		// After the last provider goes, the method must be left disabled with an
+		// empty providers array, and the node must still carry both keys.
+		CheckDestroy: func(*terraform.State) error {
+			node := readSAMLMethodNode(t)
+			if node == nil {
+				return fmt.Errorf("the saml method node was removed entirely, it should be left disabled")
+			}
+			if _, ok := node["enabled"]; !ok {
+				return fmt.Errorf("the saml method node lost its enabled key: %v", node)
+			}
+			if enabled, _ := node["enabled"].(bool); enabled {
+				return fmt.Errorf("the saml method is still enabled after the last provider was deleted")
+			}
+			if _, ok := node["config"]; !ok {
+				return fmt.Errorf("the saml method node lost its config key: %v", node)
+			}
+			if ids := samlProviderIDs(node); len(ids) != 0 {
+				return fmt.Errorf("providers remain after destroy: %v", ids)
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			// Two providers. The first create enables the method.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/two_providers.tf.tmpl", configData),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_saml_provider.keep", "provider_id", "test-saml-keep"),
+					resource.TestCheckResourceAttr("ory_saml_provider.remove", "provider_id", "test-saml-remove"),
+					func(*terraform.State) error {
+						node := readSAMLMethodNode(t)
+						if enabled, _ := node["enabled"].(bool); !enabled {
+							return fmt.Errorf("adding the first provider did not enable the saml method: %v", node)
+						}
+						ids := samlProviderIDs(node)
+						if len(ids) != 2 {
+							return fmt.Errorf("expected 2 providers server-side, got %v", ids)
+						}
+						return nil
+					},
+				),
+			},
+			// Remove one of the two. The survivor must still be there.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/one_provider.tf.tmpl", configData),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_saml_provider.keep", "provider_id", "test-saml-keep"),
+					func(*terraform.State) error {
+						ids := samlProviderIDs(readSAMLMethodNode(t))
+						if len(ids) != 1 || ids[0] != "test-saml-keep" {
+							return fmt.Errorf("expected only test-saml-keep server-side, got %v", ids)
+						}
+						return nil
+					},
+				),
 			},
 		},
 	})

--- a/internal/resources/samlprovider/testdata/one_provider.tf.tmpl
+++ b/internal/resources/samlprovider/testdata/one_provider.tf.tmpl
@@ -1,0 +1,5 @@
+resource "ory_saml_provider" "keep" {
+  provider_id          = "test-saml-keep"
+  label                = "Keep"
+  raw_idp_metadata_xml = "[[ .MetadataXML ]]"
+}

--- a/internal/resources/samlprovider/testdata/two_providers.tf.tmpl
+++ b/internal/resources/samlprovider/testdata/two_providers.tf.tmpl
@@ -1,0 +1,13 @@
+resource "ory_saml_provider" "keep" {
+  provider_id          = "test-saml-keep"
+  label                = "Keep"
+  raw_idp_metadata_xml = "[[ .MetadataXML ]]"
+}
+
+resource "ory_saml_provider" "remove" {
+  provider_id          = "test-saml-remove"
+  label                = "Remove"
+  raw_idp_metadata_xml = "[[ .MetadataXML ]]"
+
+  depends_on = [ory_saml_provider.keep]
+}


### PR DESCRIPTION
## Description

`ory_saml_provider` wrote the whole `selfservice.methods.saml` node in two places:
`Create` when adding the first provider, and `Delete` when removing the last one.
A JSON Patch `add` or `replace` whose path is an object node replaces that object,
so every key not named in the literal is discarded (RFC 6902).

`ory_social_provider` had the same defect on the OIDC node. The comment left by
that fix records what it cost: the whole-node write discarded
`config.base_redirect_uri`, which `ory_project_config` can manage, and
`enable_auto_link_policy`.

Both SAML call sites now go through one helper, `samlMethodPatches`, which patches
`enabled` and `config/providers` individually when the method node already exists.
Only an absent node is written in a single operation, where there is nothing to
lose. `Create` also branches on whether the node exists rather than on whether it
holds any providers, because the default state on a real project is an existing
node with an empty `providers` array, which the old code treated as "initialize
from scratch".

### No data is lost today

Read from the live Console API on 2026-08-13:

- `selfservice.methods.saml` holds only `enabled` and `config.providers`.
- `PATCH` with `add` on `.../methods/saml/config/sentinel` returns HTTP 200 and
  the key is pruned, so a synthetic sibling cannot be planted to demonstrate the
  loss.
- `selfservice.methods.oidc` holds `enable_auto_link_policy` and
  `config.base_redirect_uri`, which is why the OIDC version of this was a real
  bug and this one is not yet.

The exposure is latent. The first key Ory adds under that node disappears the next
time a user adds their first or deletes their last SAML provider, with HTTP 200 and
a successful apply. Fixing the patch shape now costs nothing and removes the class.

## Related Issues

Fixes #332

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

No documentation change is needed. The patch shape is internal and no schema,
attribute, or behaviour visible in HCL changes.

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

**Unit tests** in the new `internal/resources/samlprovider/patches_test.go`:

- `TestSAMLMethodPatches_ExistingNodeTargetsIndividualKeys` asserts no patch
  targets the method node itself and that both keys are patched.
- `TestSAMLMethodPatches_AbsentNodeIsWrittenWholesale` pins the one case where
  writing the node in one operation is correct.
- `TestSAMLMethodPatches_FirstProviderEnablesMethod` covers the create side.
- `TestExtractSAMLConfigFromProject_DistinguishesAbsentFromEmpty` pins the signal
  `Create` branches on, since an absent node and a node with an empty providers
  array both yield zero providers but must be patched differently.
- `TestProvidersFromSAMLConfig` and `TestCopySAMLConfig` cover the helpers split
  out of `extractProvidersFromProject` and `copyProviders`.

The unit tests were verified against the pre-fix shape. With `samlMethodPatches`
forced to always write the whole node, both patch-shape tests fail:

```
--- FAIL: TestSAMLMethodPatches_ExistingNodeTargetsIndividualKeys
--- FAIL: TestSAMLMethodPatches_FirstProviderEnablesMethod
```

**Acceptance test** `TestAccSAMLProviderResource_deleteKeepsSiblingProviders`.
`internal/resources/samlprovider` previously had no test that read project state
back from the API, so a node overwrite was invisible: Terraform state only records
what the provider believes it wrote. Every assertion in the new test reads the API
directly.

1. Create two providers, then assert server-side that the method is enabled and
   both providers are stored.
2. Remove one, then assert server-side that only the survivor remains.
3. `CheckDestroy` asserts the node still exists, still carries both `enabled` and
   `config`, is disabled, and holds no providers.

```
TF_ACC=1 go test -tags acceptance ./internal/resources/samlprovider/...
--- PASS: TestAccSAMLProviderResource_basic (11.08s)
--- PASS: TestAccSAMLProviderResource_deleteKeepsSiblingProviders (27.75s)
--- PASS: TestAccSAMLProviderResource_concurrentCreate (22.80s)
ok    github.com/ory/terraform-provider-ory/internal/resources/samlprovider  62.315s
```

**Manual verification** against the staging Console API: the replacement patch
shape, two `add` operations on `.../methods/saml/enabled` and
`.../methods/saml/config/providers`, returns HTTP 200 and leaves the node correct.
After the acceptance run, the test project's `methods/saml` is back to
`{"enabled": false, "config": {"providers": []}}` with no leftover providers, and
`methods/oidc` still holds all four of its keys.

## Screenshots/Output

The patch the provider sent before this change, which replaces the node:

```json
{
  "op": "replace",
  "path": "/services/identity/config/selfservice/methods/saml",
  "value": {"enabled": false, "config": {"providers": []}}
}
```

What it sends now:

```json
[
  {"op": "add", "path": "/services/identity/config/selfservice/methods/saml/enabled", "value": false},
  {"op": "add", "path": "/services/identity/config/selfservice/methods/saml/config/providers", "value": []}
]
```
