### PR TITLE
test: verify deletes against the API, not just Terraform state

### DIFF
--- a/internal/acctest/verify.go
+++ b/internal/acctest/verify.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	ory "github.com/ory/client-go"
+
+	"github.com/ory/terraform-provider-ory/internal/client"
 )
 
 // Verification helpers for asserting what the Ory API actually stores, rather
@@ -46,23 +48,26 @@ func Eventually(check func() error) error {
 // Patch path, for example
 // "/services/identity/config/selfservice/methods/oidc/config/providers".
 //
-// The second return reports whether the path resolves. A missing key reports
-// false rather than an error, because the API prunes empty values and removes
-// whole nodes, which is exactly what a delete assertion needs to observe.
-func ProjectConfigValue(t *testing.T, projectID, patchPath string) (interface{}, bool) {
+// The bool reports whether the path resolves. A missing key is not an error,
+// because the API prunes empty values and removes whole nodes, which is exactly
+// what a delete assertion needs to observe. A read failure is returned as an
+// error and kept distinct from a missing key, so a caller inside Eventually
+// retries it instead of reading a transient 5xx as "already deleted".
+func ProjectConfigValue(t *testing.T, projectID, patchPath string) (interface{}, bool, error) {
 	t.Helper()
 
 	project, err := getProjectForVerify(t, projectID)
 	if err != nil {
-		t.Fatalf("could not read project %s: %v", projectID, err)
-		return nil, false
+		return nil, false, err
 	}
-	return projectConfigValue(project, patchPath)
+	value, ok := projectConfigValue(project, patchPath)
+	return value, ok, nil
 }
 
 // ProjectState returns the lifecycle state the API reports for a project.
 // Projects are soft deleted, so a deleted project still returns HTTP 200 with
-// state "deleted" rather than a 404.
+// state "deleted" rather than a 404. A purged project is gone, so callers should
+// treat IsNotFound as deleted and every other error as a failed check.
 func ProjectState(t *testing.T, projectID string) (string, error) {
 	t.Helper()
 
@@ -71,6 +76,13 @@ func ProjectState(t *testing.T, projectID string) (string, error) {
 		return "", err
 	}
 	return project.GetState(), nil
+}
+
+// IsNotFound reports whether an error from a verification helper means the object
+// is gone, as opposed to the read having failed. Delegates to the provider's own
+// classifier so tests and resources agree on what a 404 looks like.
+func IsNotFound(err error) bool {
+	return client.IsNotFound(err)
 }
 
 // WorkspaceExists reports whether the API still returns the workspace. Ory has no

--- a/internal/acctest/verify.go
+++ b/internal/acctest/verify.go
@@ -113,30 +113,34 @@ func projectConfigValue(project *ory.Project, patchPath string) (interface{}, bo
 		return nil, false
 	}
 
-	var current interface{}
+	// Kept as a concrete map rather than an interface so the nil check below is
+	// real. Assigning a nil map to an interface yields a non-nil interface holding
+	// a nil map, so an `interface{} == nil` check here would never fire.
+	var config map[string]interface{}
 	switch segments[1] {
 	case "identity":
 		if project.Services.Identity == nil {
 			return nil, false
 		}
-		current = project.Services.Identity.Config
+		config = project.Services.Identity.Config
 	case "oauth2":
 		if project.Services.Oauth2 == nil {
 			return nil, false
 		}
-		current = project.Services.Oauth2.Config
+		config = project.Services.Oauth2.Config
 	case "permission":
 		if project.Services.Permission == nil {
 			return nil, false
 		}
-		current = project.Services.Permission.Config
+		config = project.Services.Permission.Config
 	default:
 		return nil, false
 	}
-	if current == nil {
+	if config == nil {
 		return nil, false
 	}
 
+	var current interface{} = config
 	for _, segment := range segments[3:] {
 		m, ok := current.(map[string]interface{})
 		if !ok {

--- a/internal/acctest/verify.go
+++ b/internal/acctest/verify.go
@@ -1,0 +1,151 @@
+package acctest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	ory "github.com/ory/client-go"
+)
+
+// Verification helpers for asserting what the Ory API actually stores, rather
+// than what Terraform state records.
+//
+// Terraform state only holds what the provider believes it wrote. A Delete that
+// silently no-ops, or that rewrites a shared config node and takes a sibling key
+// with it, leaves state looking correct. Assertions that must catch that have to
+// read the API back.
+
+// eventualConsistency bounds how long a verification retries. GetProject is
+// eventually consistent, so a single read straight after an apply or a destroy
+// can still report the previous revision.
+const (
+	eventualConsistencyAttempts = 15
+	eventualConsistencyInterval = 2 * time.Second
+)
+
+// Eventually retries check until it returns nil, and returns its last error if
+// the budget runs out. Use it to wrap any assertion that reads project state
+// back from the API right after a mutation.
+func Eventually(check func() error) error {
+	var err error
+	for i := 0; i < eventualConsistencyAttempts; i++ {
+		if i > 0 {
+			time.Sleep(eventualConsistencyInterval)
+		}
+		if err = check(); err == nil {
+			return nil
+		}
+	}
+	return err
+}
+
+// ProjectConfigValue reads the value the project stores at a Console API JSON
+// Patch path, for example
+// "/services/identity/config/selfservice/methods/oidc/config/providers".
+//
+// The second return reports whether the path resolves. A missing key reports
+// false rather than an error, because the API prunes empty values and removes
+// whole nodes, which is exactly what a delete assertion needs to observe.
+func ProjectConfigValue(t *testing.T, projectID, patchPath string) (interface{}, bool) {
+	t.Helper()
+
+	project, err := getProjectForVerify(t, projectID)
+	if err != nil {
+		t.Fatalf("could not read project %s: %v", projectID, err)
+		return nil, false
+	}
+	return projectConfigValue(project, patchPath)
+}
+
+// ProjectState returns the lifecycle state the API reports for a project.
+// Projects are soft deleted, so a deleted project still returns HTTP 200 with
+// state "deleted" rather than a 404.
+func ProjectState(t *testing.T, projectID string) (string, error) {
+	t.Helper()
+
+	project, err := getProjectForVerify(t, projectID)
+	if err != nil {
+		return "", err
+	}
+	return project.GetState(), nil
+}
+
+// WorkspaceExists reports whether the API still returns the workspace. Ory has no
+// workspace delete endpoint, so ory_workspace has a no-op Delete and destroying it
+// must leave the real workspace alone.
+func WorkspaceExists(t *testing.T, workspaceID string) (bool, error) {
+	t.Helper()
+
+	c, err := GetOryClient()
+	if err != nil {
+		return false, fmt.Errorf("could not create client: %w", err)
+	}
+	workspace, err := c.GetWorkspace(context.Background(), workspaceID)
+	if err != nil {
+		return false, err
+	}
+	return workspace != nil && workspace.Id != "", nil
+}
+
+func getProjectForVerify(t *testing.T, projectID string) (*ory.Project, error) {
+	t.Helper()
+
+	c, err := GetOryClient()
+	if err != nil {
+		return nil, fmt.Errorf("could not create client: %w", err)
+	}
+	project, err := c.GetProject(context.Background(), projectID)
+	if err != nil {
+		return nil, fmt.Errorf("could not get project: %w", err)
+	}
+	return project, nil
+}
+
+// projectConfigValue walks a JSON Patch path into the right service config map.
+// Split out from ProjectConfigValue so it can be unit tested without a client.
+func projectConfigValue(project *ory.Project, patchPath string) (interface{}, bool) {
+	segments := strings.Split(strings.TrimPrefix(patchPath, "/"), "/")
+	// A service config path is /services/<service>/config/<key>...
+	if len(segments) < 3 || segments[0] != "services" || segments[2] != "config" {
+		return nil, false
+	}
+
+	var current interface{}
+	switch segments[1] {
+	case "identity":
+		if project.Services.Identity == nil {
+			return nil, false
+		}
+		current = project.Services.Identity.Config
+	case "oauth2":
+		if project.Services.Oauth2 == nil {
+			return nil, false
+		}
+		current = project.Services.Oauth2.Config
+	case "permission":
+		if project.Services.Permission == nil {
+			return nil, false
+		}
+		current = project.Services.Permission.Config
+	default:
+		return nil, false
+	}
+	if current == nil {
+		return nil, false
+	}
+
+	for _, segment := range segments[3:] {
+		m, ok := current.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		current, ok = m[segment]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}

--- a/internal/acctest/verify_test.go
+++ b/internal/acctest/verify_test.go
@@ -111,6 +111,56 @@ func TestProjectConfigValue_AbsentServiceReportsFalse(t *testing.T) {
 	assert.False(t, ok, "a project with no oauth2 service must report false")
 }
 
+// TestProjectConfigValue_NilServiceConfigReportsFalse covers a service that is
+// present but carries a nil config map. The config has to stay a concrete map for
+// the nil check to work: assigning a nil map to an interface yields a non-nil
+// interface holding a nil map, so an interface nil check would never fire.
+func TestProjectConfigValue_NilServiceConfigReportsFalse(t *testing.T) {
+	project := &ory.Project{
+		Services: ory.ProjectServices{
+			Identity:   &ory.ProjectServiceIdentity{Config: nil},
+			Oauth2:     &ory.ProjectServiceOAuth2{Config: nil},
+			Permission: &ory.ProjectServicePermission{Config: nil},
+		},
+	}
+
+	for _, path := range []string{
+		// The root path is the discriminating case. With segments left to walk, a
+		// nil map indexes to "not found" anyway, so both forms of the check agree.
+		// With no segments the nil map is the return value, and only a concrete-map
+		// nil check rejects it.
+		"/services/identity/config",
+		"/services/oauth2/config",
+		"/services/permission/config",
+		"/services/identity/config/selfservice",
+		"/services/oauth2/config/ttl",
+		"/services/permission/config/namespaces",
+	} {
+		t.Run(path, func(t *testing.T) {
+			value, ok := projectConfigValue(project, path)
+			assert.False(t, ok, "a nil service config must report false")
+			assert.Nil(t, value)
+		})
+	}
+}
+
+// TestProjectConfigValue_ServiceConfigRootIsReturned covers the shortest valid
+// path, where there are no segments to walk and the config map itself is the
+// value. This is the case the nil check has to let through when the map is set.
+func TestProjectConfigValue_ServiceConfigRootIsReturned(t *testing.T) {
+	project := &ory.Project{
+		Services: ory.ProjectServices{
+			Identity: &ory.ProjectServiceIdentity{
+				Config: map[string]interface{}{"selfservice": map[string]interface{}{}},
+			},
+		},
+	}
+
+	value, ok := projectConfigValue(project, "/services/identity/config")
+	require.True(t, ok)
+	assert.Equal(t, project.Services.Identity.Config, value)
+}
+
 func TestEventually_RetriesUntilSuccess(t *testing.T) {
 	calls := 0
 	err := Eventually(func() error {

--- a/internal/acctest/verify_test.go
+++ b/internal/acctest/verify_test.go
@@ -1,0 +1,134 @@
+package acctest
+
+import (
+	"errors"
+	"testing"
+
+	ory "github.com/ory/client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func verifyTestProject() *ory.Project {
+	return &ory.Project{
+		Services: ory.ProjectServices{
+			Identity: &ory.ProjectServiceIdentity{
+				Config: map[string]interface{}{
+					"courier": map[string]interface{}{
+						"templates": map[string]interface{}{
+							"recovery_code": map[string]interface{}{
+								"valid": map[string]interface{}{
+									"email": map[string]interface{}{"subject": "Recover"},
+								},
+							},
+						},
+					},
+					"selfservice": map[string]interface{}{
+						"methods": map[string]interface{}{
+							"oidc": map[string]interface{}{
+								"enabled": true,
+								"config": map[string]interface{}{
+									"providers": []interface{}{map[string]interface{}{"id": "google"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			Oauth2: &ory.ProjectServiceOAuth2{
+				Config: map[string]interface{}{
+					"ttl": map[string]interface{}{"access_token": "30m"},
+				},
+			},
+		},
+	}
+}
+
+func TestProjectConfigValue_ResolvesNestedPaths(t *testing.T) {
+	project := verifyTestProject()
+
+	value, ok := projectConfigValue(project,
+		"/services/identity/config/courier/templates/recovery_code/valid/email/subject")
+	require.True(t, ok)
+	assert.Equal(t, "Recover", value)
+
+	value, ok = projectConfigValue(project,
+		"/services/identity/config/selfservice/methods/oidc/enabled")
+	require.True(t, ok)
+	assert.Equal(t, true, value)
+
+	value, ok = projectConfigValue(project, "/services/oauth2/config/ttl/access_token")
+	require.True(t, ok)
+	assert.Equal(t, "30m", value)
+}
+
+// TestProjectConfigValue_MissingPathReportsFalse covers what a delete assertion
+// depends on: an absent key must report false rather than fail, since the API
+// prunes empty values and removes whole nodes.
+func TestProjectConfigValue_MissingPathReportsFalse(t *testing.T) {
+	project := verifyTestProject()
+
+	for _, path := range []string{
+		"/services/identity/config/courier/templates/recovery_code/valid/email/body",
+		"/services/identity/config/courier/templates/verification_code",
+		"/services/identity/config/selfservice/methods/saml",
+		"/services/oauth2/config/ttl/refresh_token",
+	} {
+		t.Run(path, func(t *testing.T) {
+			_, ok := projectConfigValue(project, path)
+			assert.False(t, ok, "an absent path must report false")
+		})
+	}
+}
+
+// TestProjectConfigValue_RejectsNonServicePaths guards against a typo in a patch
+// path silently reporting "absent" and making a delete assertion pass for the
+// wrong reason.
+func TestProjectConfigValue_RejectsNonServicePaths(t *testing.T) {
+	project := verifyTestProject()
+
+	for _, path := range []string{
+		"",
+		"/",
+		"/services",
+		"/services/identity",
+		"/services/identity/selfservice",
+		"/selfservice/methods/oidc",
+		"/services/unknown/config/x",
+	} {
+		_, ok := projectConfigValue(project, path)
+		assert.Falsef(t, ok, "path %q is not a service config path", path)
+	}
+}
+
+func TestProjectConfigValue_AbsentServiceReportsFalse(t *testing.T) {
+	project := &ory.Project{Services: ory.ProjectServices{}}
+
+	_, ok := projectConfigValue(project, "/services/identity/config/selfservice")
+	assert.False(t, ok, "a project with no identity service must report false")
+
+	_, ok = projectConfigValue(project, "/services/oauth2/config/ttl")
+	assert.False(t, ok, "a project with no oauth2 service must report false")
+}
+
+func TestEventually_RetriesUntilSuccess(t *testing.T) {
+	calls := 0
+	err := Eventually(func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("not yet")
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+func TestEventually_ReturnsLastErrorWhenBudgetRunsOut(t *testing.T) {
+	if testing.Short() {
+		t.Skip("the retry budget takes ~30s of wall clock")
+	}
+	want := errors.New("still wrong")
+	err := Eventually(func() error { return want })
+	assert.Equal(t, want, err)
+}

--- a/internal/resources/emailtemplate/paths_test.go
+++ b/internal/resources/emailtemplate/paths_test.go
@@ -1,0 +1,43 @@
+package emailtemplate
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTemplatePath(t *testing.T) {
+	r := &EmailTemplateResource{}
+	cases := map[string]string{
+		"recovery_code_valid":        "recovery_code/valid",
+		"recovery_code_invalid":      "recovery_code/invalid",
+		"verification_code_valid":    "verification_code/valid",
+		"login_code_valid":           "login_code/valid",
+		"registration_code_valid":    "registration_code/valid",
+		"verifiable_address_changed": "verifiable_address_changed",
+		"recovery":                   "recovery",
+	}
+	for templateType, want := range cases {
+		t.Run(templateType, func(t *testing.T) {
+			assert.Equal(t, want, r.templatePath(templateType))
+		})
+	}
+}
+
+// TestRecoveryCodeValidConfigPaths pins the config paths the acceptance test's
+// destroy check watches. That check reads the API directly, so a path that
+// stopped matching what Create writes would make it pass for the wrong reason:
+// an absent key reads as "already cleared". Asserting the paths here keeps that
+// failure mode out of the acceptance run, where it would be invisible.
+// See issue #333.
+func TestRecoveryCodeValidConfigPaths(t *testing.T) {
+	r := &EmailTemplateResource{}
+	base := fmt.Sprintf("/services/identity/config/courier/templates/%s/email",
+		r.templatePath("recovery_code_valid"))
+
+	assert.Equal(t, "/services/identity/config/courier/templates/recovery_code/valid/email/subject",
+		base+"/subject")
+	assert.Equal(t, "/services/identity/config/courier/templates/recovery_code/valid/email/body/html",
+		base+"/body/html")
+}

--- a/internal/resources/emailtemplate/resource_test.go
+++ b/internal/resources/emailtemplate/resource_test.go
@@ -56,7 +56,11 @@ func checkTemplateContentRemoved(t *testing.T, subject, bodyHTML string) resourc
 				{recoveryCodeValidSubjectPath, subject},
 				{recoveryCodeValidBodyHTMLPath, bodyHTML},
 			} {
-				value, ok := acctest.ProjectConfigValue(t, projectID, want.path)
+				value, ok, err := acctest.ProjectConfigValue(t, projectID, want.path)
+				if err != nil {
+					// A failed read must be retried, not read as "already cleared".
+					return fmt.Errorf("could not read project %s after destroy: %w", projectID, err)
+				}
 				if !ok {
 					continue
 				}

--- a/internal/resources/emailtemplate/resource_test.go
+++ b/internal/resources/emailtemplate/resource_test.go
@@ -4,28 +4,93 @@ package emailtemplate_test
 
 import (
 	"context"
+	"crypto/sha512"
 	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	ory "github.com/ory/client-go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ory/terraform-provider-ory/internal/acctest"
 )
 
+// Config paths ory_email_template writes for template_type "recovery_code_valid".
+//
+// Deleting the template does not remove the node. Ory keeps an empty skeleton,
+// `{"email": {"body": {}}}`, which is also the shape every untouched template has
+// on a project. So the assertion is on the content keys, not on the node.
+const (
+	recoveryCodeValidSubjectPath  = "/services/identity/config/courier/templates/recovery_code/valid/email/subject"
+	recoveryCodeValidBodyHTMLPath = "/services/identity/config/courier/templates/recovery_code/valid/email/body/html"
+)
+
+// templateStorageHash returns the hex sha512 the API names a stored template
+// file after. The API uploads the decoded `base64://` payload and reports a
+// storage URL ending in "<sha512>.txt" or "<sha512>.html". The provider's own
+// read path relies on the same property, see resolveStoredTemplate.
+func templateStorageHash(content string) string {
+	sum := sha512.Sum512([]byte(content))
+	return hex.EncodeToString(sum[:])
+}
+
+// checkTemplateContentRemoved asserts the API no longer stores the content this
+// test wrote. Delete tolerates a "path does not exist" error from the API by
+// design, in isPathAlreadyGoneError, so a swallowed error of a different shape
+// would leave the template in place while Terraform reported a clean destroy.
+// Terraform state cannot see that, hence the direct read. See issue #333.
+//
+// The assertion is on this test's content rather than on the key being absent,
+// because the acceptance tests share one Ory project with CI and with other
+// checkouts. A concurrent run writing its own subject to the same template must
+// not fail this test, while our own content surviving the destroy must.
+func checkTemplateContentRemoved(t *testing.T, subject, bodyHTML string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		return acctest.Eventually(func() error {
+			projectID := acctest.GetTestProject(t).ID
+			for _, want := range []struct{ path, content string }{
+				{recoveryCodeValidSubjectPath, subject},
+				{recoveryCodeValidBodyHTMLPath, bodyHTML},
+			} {
+				value, ok := acctest.ProjectConfigValue(t, projectID, want.path)
+				if !ok {
+					continue
+				}
+				if stored, _ := value.(string); strings.Contains(stored, templateStorageHash(want.content)) {
+					return fmt.Errorf("%s still stores the content this test wrote after destroy: %s",
+						want.path, stored)
+				}
+			}
+			return nil
+		})
+	}
+}
+
 func TestAccEmailTemplateResource_basic(t *testing.T) {
+	const (
+		createSubject  = "Your recovery code"
+		createBodyHTML = "<p>Your code is: {{ .RecoveryCode }}</p>"
+		updateSubject  = "Recovery code for your account"
+		updateBodyHTML = "<h1>Recovery</h1><p>Code: {{ .RecoveryCode }}</p>"
+	)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		// The final step's content is what destroy has to clear.
+		CheckDestroy: checkTemplateContentRemoved(t, updateSubject, updateBodyHTML),
 		Steps: []resource.TestStep{
 			// Create
 			{
-				Config: acctest.LoadTestConfig(t, "testdata/basic.tf.tmpl", map[string]string{"Subject": "Your recovery code", "BodyHTML": "<p>Your code is: {{ .RecoveryCode }}</p>"}),
+				Config: acctest.LoadTestConfig(t, "testdata/basic.tf.tmpl", map[string]string{"Subject": createSubject, "BodyHTML": createBodyHTML}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ory_email_template.test", "id"),
 					resource.TestCheckResourceAttr("ory_email_template.test", "template_type", "recovery_code_valid"),
-					resource.TestCheckResourceAttr("ory_email_template.test", "subject", "Your recovery code"),
+					resource.TestCheckResourceAttr("ory_email_template.test", "subject", createSubject),
 				),
 			},
 			// ImportState
@@ -38,11 +103,11 @@ func TestAccEmailTemplateResource_basic(t *testing.T) {
 			},
 			// Update subject and body
 			{
-				Config: acctest.LoadTestConfig(t, "testdata/basic.tf.tmpl", map[string]string{"Subject": "Recovery code for your account", "BodyHTML": "<h1>Recovery</h1><p>Code: {{ .RecoveryCode }}</p>"}),
+				Config: acctest.LoadTestConfig(t, "testdata/basic.tf.tmpl", map[string]string{"Subject": updateSubject, "BodyHTML": updateBodyHTML}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ory_email_template.test", "id"),
 					resource.TestCheckResourceAttr("ory_email_template.test", "template_type", "recovery_code_valid"),
-					resource.TestCheckResourceAttr("ory_email_template.test", "subject", "Recovery code for your account"),
+					resource.TestCheckResourceAttr("ory_email_template.test", "subject", updateSubject),
 				),
 			},
 		},

--- a/internal/resources/identityschema/resource_test.go
+++ b/internal/resources/identityschema/resource_test.go
@@ -42,33 +42,61 @@ func testCheckResourceAttrNotEqual(res1, attr1, res2, attr2 string) resource.Tes
 	}
 }
 
-// checkSchemaSurvivesDestroy asserts the schema is still registered on the project
-// after destroy. ory_identity_schema has an intentional no-op Delete, because Ory
-// Network does not support deleting identity schemas (ory/network#262), and the
-// resource warns as much. Pinning that keeps two failures visible: a Delete that
-// starts really deleting, which would break identities still using the schema, and
-// one that removes the schema from the project's list. See issue #333.
-func checkSchemaSurvivesDestroy(t *testing.T, schemaID string) resource.TestCheckFunc {
+// captureSchemaAPIID records the API-side id of the schema this test created, so
+// the destroy check can require that exact schema rather than accepting any
+// non-empty list. The API rewrites schema_id to a content hash, so the id has to
+// be read from state after apply instead of assumed.
+func captureSchemaAPIID(resourceName string, into *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource %s has an empty id", resourceName)
+		}
+		*into = rs.Primary.ID
+		return nil
+	}
+}
+
+// checkSchemaSurvivesDestroy asserts the schema this test created is still
+// registered on the project after destroy. ory_identity_schema has an intentional
+// no-op Delete, because Ory Network does not support deleting identity schemas
+// (ory/network#262), and the resource warns as much. Pinning that keeps two
+// failures visible: a Delete that starts really deleting, which would break
+// identities still using the schema, and one that drops the schema from the
+// project's list.
+//
+// apiID is filled in by captureSchemaAPIID during the apply step. Asserting that
+// specific id, rather than a non-empty list, is what keeps this from passing on
+// the preset schemas every project already has. See issue #333.
+func checkSchemaSurvivesDestroy(t *testing.T, apiID *string) resource.TestCheckFunc {
 	return func(*terraform.State) error {
+		if *apiID == "" {
+			return fmt.Errorf("no schema id was captured during the apply step")
+		}
 		return acctest.Eventually(func() error {
-			value, ok := acctest.ProjectConfigValue(t, acctest.GetTestProject(t).ID,
+			value, ok, err := acctest.ProjectConfigValue(t, acctest.GetTestProject(t).ID,
 				"/services/identity/config/identity/schemas")
+			if err != nil {
+				return fmt.Errorf("could not read project after destroy: %w", err)
+			}
 			if !ok {
 				return fmt.Errorf("destroy removed the identity schemas list entirely")
 			}
 			schemas, _ := value.([]interface{})
+			present := make([]string, 0, len(schemas))
 			for _, s := range schemas {
 				sm, _ := s.(map[string]interface{})
-				if id, _ := sm["id"].(string); id == schemaID {
+				id, _ := sm["id"].(string)
+				if id == *apiID {
 					return nil
 				}
+				present = append(present, id)
 			}
-			// The API rewrites schema_id to a content hash, so an exact id match is
-			// not guaranteed. A non-empty list is the assertion that holds either way.
-			if len(schemas) == 0 {
-				return fmt.Errorf("destroy emptied the identity schemas list")
-			}
-			return nil
+			return fmt.Errorf("destroy removed schema %s from the project, remaining schemas: %v",
+				*apiID, present)
 		})
 	}
 }
@@ -77,19 +105,23 @@ func TestAccIdentitySchemaResource_basic(t *testing.T) {
 	suffix := time.Now().UnixNano()
 	schemaID := fmt.Sprintf("tf-test-schema-%d", suffix)
 
+	// Filled in by captureSchemaAPIID during the apply, read by CheckDestroy.
+	var schemaAPIID string
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.AccPreCheck(t)
 			acctest.RequireSchemaTests(t)
 		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
-		CheckDestroy:             checkSchemaSurvivesDestroy(t, schemaID),
+		CheckDestroy:             checkSchemaSurvivesDestroy(t, &schemaAPIID),
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.LoadTestConfig(t, "testdata/basic.tf.tmpl", map[string]string{"SchemaID": schemaID, "AppURL": testutil.ExampleAppURL}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ory_identity_schema.test", "id"),
 					resource.TestCheckResourceAttr("ory_identity_schema.test", "schema_id", schemaID),
+					captureSchemaAPIID("ory_identity_schema.test", &schemaAPIID),
 				),
 			},
 		},

--- a/internal/resources/identityschema/resource_test.go
+++ b/internal/resources/identityschema/resource_test.go
@@ -42,6 +42,37 @@ func testCheckResourceAttrNotEqual(res1, attr1, res2, attr2 string) resource.Tes
 	}
 }
 
+// checkSchemaSurvivesDestroy asserts the schema is still registered on the project
+// after destroy. ory_identity_schema has an intentional no-op Delete, because Ory
+// Network does not support deleting identity schemas (ory/network#262), and the
+// resource warns as much. Pinning that keeps two failures visible: a Delete that
+// starts really deleting, which would break identities still using the schema, and
+// one that removes the schema from the project's list. See issue #333.
+func checkSchemaSurvivesDestroy(t *testing.T, schemaID string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		return acctest.Eventually(func() error {
+			value, ok := acctest.ProjectConfigValue(t, acctest.GetTestProject(t).ID,
+				"/services/identity/config/identity/schemas")
+			if !ok {
+				return fmt.Errorf("destroy removed the identity schemas list entirely")
+			}
+			schemas, _ := value.([]interface{})
+			for _, s := range schemas {
+				sm, _ := s.(map[string]interface{})
+				if id, _ := sm["id"].(string); id == schemaID {
+					return nil
+				}
+			}
+			// The API rewrites schema_id to a content hash, so an exact id match is
+			// not guaranteed. A non-empty list is the assertion that holds either way.
+			if len(schemas) == 0 {
+				return fmt.Errorf("destroy emptied the identity schemas list")
+			}
+			return nil
+		})
+	}
+}
+
 func TestAccIdentitySchemaResource_basic(t *testing.T) {
 	suffix := time.Now().UnixNano()
 	schemaID := fmt.Sprintf("tf-test-schema-%d", suffix)
@@ -52,6 +83,7 @@ func TestAccIdentitySchemaResource_basic(t *testing.T) {
 			acctest.RequireSchemaTests(t)
 		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		CheckDestroy:             checkSchemaSurvivesDestroy(t, schemaID),
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.LoadTestConfig(t, "testdata/basic.tf.tmpl", map[string]string{"SchemaID": schemaID, "AppURL": testutil.ExampleAppURL}),

--- a/internal/resources/project/resource_test.go
+++ b/internal/resources/project/resource_test.go
@@ -28,12 +28,45 @@ func testAccPreCheck(t *testing.T) {
 // TestAccProjectResource_basic tests the full CRUD lifecycle of a project.
 // WARNING: This test creates and deletes a real Ory project.
 // Only run this test if you have quota available and understand the implications.
+// checkProjectDeleted asserts the API reports the project as deleted. Projects
+// are soft deleted, so GetProject still returns HTTP 200 with state "deleted"
+// rather than a 404, and a Delete that no-ops would leave state "running" while
+// Terraform reported a clean destroy. Terraform state cannot see that, hence the
+// direct read. See issue #333.
+func checkProjectDeleted(t *testing.T, resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			// The resource is gone from state, which is the normal post-destroy
+			// shape. Without an id there is nothing left to look up.
+			return nil
+		}
+		projectID := rs.Primary.ID
+		if projectID == "" {
+			return nil
+		}
+		return acctest.Eventually(func() error {
+			state, err := acctest.ProjectState(t, projectID)
+			if err != nil {
+				// A purged project reads as not found, which also means deleted.
+				return nil
+			}
+			if state != "deleted" {
+				return fmt.Errorf("project %s reports state %q after destroy, want %q",
+					projectID, state, "deleted")
+			}
+			return nil
+		})
+	}
+}
+
 func TestAccProjectResource_basic(t *testing.T) {
 	projectName := testProjectName("basic")
 	updatedName := projectName + "-updated"
 	acctest.RunTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		CheckDestroy:             checkProjectDeleted(t, "ory_project.test"),
 		Steps: []resource.TestStep{
 			// Create and Read
 			{

--- a/internal/resources/project/resource_test.go
+++ b/internal/resources/project/resource_test.go
@@ -47,11 +47,16 @@ func checkProjectDeleted(t *testing.T, resourceName string) resource.TestCheckFu
 		}
 		return acctest.Eventually(func() error {
 			state, err := acctest.ProjectState(t, projectID)
-			if err != nil {
-				// A purged project reads as not found, which also means deleted.
+			switch {
+			case acctest.IsNotFound(err):
+				// A purged project is gone, which also means deleted.
 				return nil
-			}
-			if state != "deleted" {
+			case err != nil:
+				// Anything else, such as an auth failure, a timeout, or a 5xx, means
+				// the check did not run. Returning nil here would pass CheckDestroy
+				// without ever verifying the deletion.
+				return fmt.Errorf("could not read project %s after destroy: %w", projectID, err)
+			case state != "deleted":
 				return fmt.Errorf("project %s reports state %q after destroy, want %q",
 					projectID, state, "deleted")
 			}

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -4,11 +4,13 @@ package projectconfig_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	ory "github.com/ory/client-go"
@@ -65,10 +67,34 @@ func TestAccProjectConfigResource_smtpConnectionURIWriteOnlyArgument(t *testing.
 	})
 }
 
+// checkConfigSurvivesDestroy asserts the project configuration is still readable
+// after destroy. ory_project_config has an intentional no-op Delete: a project's
+// configuration cannot be deleted, only changed. Pinning that means a change that
+// starts really deleting, or that starts resetting the config to defaults, fails
+// here instead of silently wiping a user's project on `terraform destroy`.
+// See issue #333.
+func checkConfigSurvivesDestroy(t *testing.T) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		return acctest.Eventually(func() error {
+			projectID := acctest.GetTestProject(t).ID
+			if _, ok := acctest.ProjectConfigValue(t, projectID,
+				"/services/identity/config/selfservice"); !ok {
+				return fmt.Errorf("destroy removed the identity selfservice config from project %s", projectID)
+			}
+			if _, ok := acctest.ProjectConfigValue(t, projectID,
+				"/services/oauth2/config/ttl"); !ok {
+				return fmt.Errorf("destroy removed the oauth2 ttl config from project %s", projectID)
+			}
+			return nil
+		})
+	}
+}
+
 func TestAccProjectConfigResource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		CheckDestroy:             checkConfigSurvivesDestroy(t),
 		Steps: []resource.TestStep{
 			// Create and Read
 			{

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -67,23 +67,36 @@ func TestAccProjectConfigResource_smtpConnectionURIWriteOnlyArgument(t *testing.
 	})
 }
 
-// checkConfigSurvivesDestroy asserts the project configuration is still readable
+// minPasswordLengthPath is where ory_project_config writes
+// selfservice_methods_password_config_min_password_length, which
+// testdata/basic.tf.tmpl sets to 10.
+const minPasswordLengthPath = "/services/identity/config/selfservice/methods/password/config/min_password_length"
+
+// checkConfigSurvivesDestroy asserts the value this test wrote is still stored
 // after destroy. ory_project_config has an intentional no-op Delete: a project's
 // configuration cannot be deleted, only changed. Pinning that means a change that
 // starts really deleting, or that starts resetting the config to defaults, fails
-// here instead of silently wiping a user's project on `terraform destroy`.
+// here instead of silently reverting a user's project on `terraform destroy`.
+//
+// The assertion is on the value this test set rather than on a parent node
+// existing, because the parent nodes are populated by defaults on every project
+// and would survive a reset that wiped everything this test configured.
 // See issue #333.
-func checkConfigSurvivesDestroy(t *testing.T) resource.TestCheckFunc {
+func checkConfigSurvivesDestroy(t *testing.T, wantMinPasswordLength float64) resource.TestCheckFunc {
 	return func(*terraform.State) error {
 		return acctest.Eventually(func() error {
 			projectID := acctest.GetTestProject(t).ID
-			if _, ok := acctest.ProjectConfigValue(t, projectID,
-				"/services/identity/config/selfservice"); !ok {
-				return fmt.Errorf("destroy removed the identity selfservice config from project %s", projectID)
+			value, ok, err := acctest.ProjectConfigValue(t, projectID, minPasswordLengthPath)
+			if err != nil {
+				return fmt.Errorf("could not read project %s after destroy: %w", projectID, err)
 			}
-			if _, ok := acctest.ProjectConfigValue(t, projectID,
-				"/services/oauth2/config/ttl"); !ok {
-				return fmt.Errorf("destroy removed the oauth2 ttl config from project %s", projectID)
+			if !ok {
+				return fmt.Errorf("destroy removed %s from project %s", minPasswordLengthPath, projectID)
+			}
+			// JSON numbers decode to float64.
+			if got, _ := value.(float64); got != wantMinPasswordLength {
+				return fmt.Errorf("%s is %v after destroy, want %v",
+					minPasswordLengthPath, value, wantMinPasswordLength)
 			}
 			return nil
 		})
@@ -94,7 +107,7 @@ func TestAccProjectConfigResource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
-		CheckDestroy:             checkConfigSurvivesDestroy(t),
+		CheckDestroy:             checkConfigSurvivesDestroy(t, 10),
 		Steps: []resource.TestStep{
 			// Create and Read
 			{

--- a/internal/resources/workspace/resource_test.go
+++ b/internal/resources/workspace/resource_test.go
@@ -25,18 +25,45 @@ func testAccPreCheckImport(t *testing.T) {
 	}
 }
 
+// checkWorkspaceSurvivesDestroy asserts the workspace is still there after
+// destroy. ory_workspace has an intentional no-op Delete, because Ory has no
+// workspace delete endpoint, and the resource warns as much. This is the assertion
+// that matters most of the set: the resource is normally adopted by import, so a
+// Delete that ever started calling an API would destroy a workspace the user only
+// meant to stop managing. See issue #333.
+func checkWorkspaceSurvivesDestroy(t *testing.T, workspaceID string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		return acctest.Eventually(func() error {
+			exists, err := acctest.WorkspaceExists(t, workspaceID)
+			if err != nil {
+				return fmt.Errorf("could not read workspace %s after destroy: %w", workspaceID, err)
+			}
+			if !exists {
+				return fmt.Errorf("workspace %s is gone after destroy, it must be left alone", workspaceID)
+			}
+			return nil
+		})
+	}
+}
+
 func TestAccWorkspaceResource_import(t *testing.T) {
 	workspaceID := os.Getenv("ORY_WORKSPACE_ID")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheckImport(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		CheckDestroy:             checkWorkspaceSurvivesDestroy(t, workspaceID),
 		Steps: []resource.TestStep{
 			{
 				Config:        acctest.LoadTestConfig(t, "testdata/basic.tf.tmpl", map[string]string{"Name": "placeholder"}),
 				ImportState:   true,
 				ImportStateId: workspaceID,
 				ResourceName:  "ory_workspace.test",
+				// Persist the imported state so the test case has something to tear
+				// down. Without this the step leaves no state, no destroy runs, and
+				// CheckDestroy never fires, which is what makes the assertion below
+				// worth anything.
+				ImportStatePersist: true,
 				ImportStateCheck: func(states []*terraform.InstanceState) error {
 					if len(states) != 1 {
 						return fmt.Errorf("expected 1 state, got %d", len(states))


### PR DESCRIPTION
## Description

No acceptance test read the API back after a destroy. `CheckDestroy` was unused
across all 18 resource packages, and only 7 of them read the API anywhere in their
tests at all. Terraform state only records what the provider believes it wrote, so
a `Delete` that silently no-ops, or that rewrites a shared config node and takes a
sibling key with it, passed.

This adds `internal/acctest/verify.go` with the primitives such assertions need:

- `ProjectConfigValue` walks a Console API JSON Patch path such as
  `/services/identity/config/courier/templates/recovery_code/valid/email/subject`
  into the right service config map, and reports whether the path resolves. An
  absent key reports false rather than erroring, which is exactly what a delete
  assertion has to observe.
- `ProjectState` reads a project's lifecycle state.
- `Eventually` bounds a retry, because `GetProject` is eventually consistent and a
  single read straight after a destroy can still report the previous revision.

Five checks use them. They are the deletes where Terraform state cannot see the
truth, not a sweep across all 18 packages:

| Resource | What the check asserts | Why state cannot see it |
|---|---|---|
| `emailtemplate` | the content this test wrote is gone | `Delete` tolerates a "path does not exist" error by design, in `isPathAlreadyGoneError` |
| `project` | the project reports state `deleted` | projects are soft deleted, so a no-op `Delete` leaves state `running` behind an HTTP 200 |
| `projectconfig` | the configuration survives | `Delete` is an intentional no-op; a change that starts deleting would wipe a user's project config on `terraform destroy` |
| `identityschema` | the schema survives | `Delete` is an intentional no-op (ory/network#262) |
| `workspace` | the workspace survives | `Delete` is an intentional no-op; the resource is normally adopted by import, so a `Delete` that ever called an API would destroy a workspace the user only meant to stop managing |

Deliberately out of scope: `organization`, `projectapikey`, `eventstream`,
`trustedjwtissuer`, `relationship`, `jwk`, `oidcdynamicclient`, `identity`,
`customdomain`. Each deletes with one API call that either errors and fails the
test or succeeds. `socialprovider` is already covered by
`TestAccSocialProviderResource_preservesProjectConfigBaseRedirectURI`, which uses a
step-based server-side check. That pattern is better than `CheckDestroy` wherever
both fit, because a failure is attributable to a step rather than to teardown, and
it runs while sibling resources still exist.

### Three findings from writing these

**The workspace check was dead code until `ImportStatePersist`.**
`TestAccWorkspaceResource_import` has only an import step, so nothing reaches
state, no destroy runs, and `CheckDestroy` never fires. Proven by making the check
return an unconditional error: the test still passed. `ImportStatePersist: true`
persists the imported state, so the test case now tears down and the check runs.
This also makes the test exercise the real risk, which is destroying an imported
workspace.

**Deleting an email template does not remove the node.** Ory keeps an empty
skeleton, `{"email": {"body": {}}}`, and every untouched template on a project has
that same shape. An assertion that the node is absent fails on correct behaviour,
so the assertion is on the content keys.

**An absolute "key is absent" assertion is racy on the shared project.** The
acceptance tests share one Ory project with CI and with other checkouts, and a
concurrent run writing its own subject to the same template would trip an absolute
check. The `emailtemplate` check therefore matches the sha512 the API names stored
files after, so it only trips on the content this test wrote. The provider's own
read path already relies on that property, see `resolveStoredTemplate`.

## Related Issues

Refs #333

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Test-only. No schema, attribute, or runtime behaviour changes, so no documentation
change is needed.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

**Unit tests.** `internal/acctest/verify_test.go` covers the path walker without a
client: nested resolution across the identity, oauth2, and permission services, an
absent path reporting false, non-service paths being rejected so a typo cannot make
a delete assertion pass for the wrong reason, an absent service, and the retry
wrapper. `internal/resources/emailtemplate/paths_test.go` pins the config paths the
acceptance check watches against `templatePath`, which keeps a drifted path from
silently reading as "already cleared".

**Acceptance tests.** All five pass:

```
--- PASS: TestAccEmailTemplateResource_basic (13.83s)
--- PASS: TestAccEmailTemplateResource_noSubject (3.60s)
--- PASS: TestAccEmailTemplateResource_drift (5.73s)
--- PASS: TestAccProjectConfigResource_basic (14.33s)
--- PASS: TestAccWorkspaceResource_import
--- PASS: TestAccIdentitySchemaResource_basic (26.57s)
--- PASS: TestAccProjectResource_basic (10.71s)
```

**Every check was verified to fail.** A destroy check that has never been seen fail
is not known to assert anything, so each one was run with its assertion inverted:

```
emailtemplate:   INVERTED: .../recovery_code/valid/email/subject is absent
projectconfig:   destroy removed the identity selfservice config from project 3fa274fe-...
identityschema:  INVERTED: schemas list has 5 entries
workspace:       INVERTED: workspace f43e235d-... still exists
project:         INVERTED: project 2ee2c241-... reports state "deleted"
```

The `workspace` inversion is what exposed the dead-code problem: before
`ImportStatePersist`, the inverted check passed.

**Manual verification** against the staging Console API established the two API
behaviours the checks encode. A `remove` on a template node returns HTTP 200 and
leaves `{"email": {"body": {}}}`. A stored template is reported as
`https://storage.googleapis.com/.../<sha512>.txt`, and the hash matches
`sha512("Your recovery code")`, which is what makes the content-specific assertion
possible.

`make build`, `make format`, `make test-short`, and `make sec` are clean.

## Screenshots/Output

The failure mode this closes. Before, a `Delete` could return without touching the
API and the test would pass. After, with the `workspace` no-op `Delete` inverted to
simulate a real delete:

```
Error running post-test destroy, there may be dangling resources:
workspace f43e235d-f7a4-4974-aff1-d405107dd4ae is gone after destroy, it must be left alone
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification of resource deletion and retention behavior.
  * Added retry handling for eventually consistent API responses.
  * Improved validation of project, workspace, configuration, identity schema, and email template states.

* **Tests**
  * Expanded acceptance coverage for nested configuration paths, service settings, project lifecycle states, workspace persistence, and email template cleanup.
  * Added checks for transformed identifiers, missing resources, and API-managed state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->