### PR TITLE
feat(social-provider): add organization_id for OIDC B2B SSO

### DIFF
--- a/.claude/skills/import-existing-project/SKILL.md
+++ b/.claude/skills/import-existing-project/SKILL.md
@@ -224,6 +224,14 @@ explicit `{project_id}/...` form in generated files.
 - **`ory_social_provider.auto_link`** is write-only in the API; an import will
   not populate it. Re-add it to config manually where used (enterprise
   feature).
+- **B2B SSO providers come back as `ory_social_provider` with an
+  `organization_id`.** An OIDC provider scoped to an organization lives in the
+  same `...methods.oidc.config.providers[]` array as a plain social provider, so
+  the inventory finds both. Import the matching `ory_organization` as well and
+  replace the generated literal UUID with a reference
+  (`organization_id = ory_organization.<name>.id`) so Terraform orders the
+  create and the destroy correctly. Dropping the attribute clears the link and
+  leaves the organization with no SSO provider (issue #339).
 - **Organizations require a B2B plan; event streams require an enterprise
   plan.** On other plans those endpoints return empty lists or
   `feature_not_available` errors — skip the resources.

--- a/docs/resources/social_provider.md
+++ b/docs/resources/social_provider.md
@@ -237,6 +237,25 @@ resource "ory_social_provider" "enterprise_sso" {
   aal2_amr_values = ["mfa", "otp", "hwk"]
 }
 
+# OIDC provider scoped to an organization (B2B SSO). Ory offers this provider
+# only to users of the organization, and routes users to it by the domain of the
+# email address they enter on the login screen.
+resource "ory_organization" "acme" {
+  label   = "Acme"
+  domains = ["acme.example.com"]
+}
+
+resource "ory_social_provider" "acme_sso" {
+  provider_id     = "acme-sso"
+  provider_type   = "generic"
+  client_id       = var.acme_client_id
+  client_secret   = var.acme_client_secret
+  issuer_url      = "https://sso.acme.example.com"
+  scope           = ["openid", "profile", "email"]
+  label           = "Acme SSO"
+  organization_id = ory_organization.acme.id
+}
+
 # Generic OIDC Provider with custom claims mapping
 resource "ory_social_provider" "corporate_sso" {
   provider_id   = "corporate-sso"
@@ -323,6 +342,15 @@ variable "apple_private_key" {
   sensitive   = true
 }
 
+variable "acme_client_id" {
+  type = string
+}
+
+variable "acme_client_secret" {
+  type      = string
+  sensitive = true
+}
+
 variable "sso_client_id" {
   type = string
 }
@@ -356,6 +384,36 @@ If not set, the provider uses a default mapper that extracts the email claim.
 ## Label
 
 The `label` attribute sets a human-readable label for the provider. This is displayed on the login button in the default UI (e.g., "Sign in with Corporate SSO"). If not set, the default label for the provider type is used.
+
+## Organization Scoping (B2B SSO)
+
+Set `organization_id` to associate an OIDC provider with a specific organization. Ory then offers the provider only to users of that organization instead of to everyone on the login screen, and the callback URL gains an `/organization/<organization_id>` segment. This is the OIDC counterpart of the same attribute on `ory_saml_provider`, and it is what the Ory Console shows as "via `<organization>` SSO" in the Social Sign-In (OIDC) tab.
+
+```hcl
+resource "ory_organization" "acme" {
+  label   = "Acme"
+  domains = ["acme.example.com"]
+}
+
+resource "ory_social_provider" "acme_sso" {
+  provider_id     = "acme-sso"
+  provider_type   = "generic"
+  client_id       = var.acme_client_id
+  client_secret   = var.acme_client_secret
+  issuer_url      = "https://sso.acme.example.com"
+  scope           = ["openid", "email", "profile"]
+  label           = "Acme SSO"
+  organization_id = ory_organization.acme.id
+}
+```
+
+Give the organization one or more `domains` to let Ory route a user to this provider by the domain of the email address they enter.
+
+~> **Note:** `organization_id` must be the ID of an organization that exists in the same project. The API rejects a value that is not a UUID with `HTTP 400`, and a UUID that matches no organization with `HTTP 500` and a foreign key error. Reference an `ory_organization` resource so Terraform creates the organization first.
+
+Removing `organization_id` from your configuration clears the link and turns the resource back into a normal social sign-in provider that every user can use.
+
+-> **Plan:** B2B SSO requires a plan with B2B or Enterprise features. Check your Ory Network plan before using this attribute.
 
 ## Account Linking Mode
 
@@ -579,6 +637,7 @@ The `provider_id` is the unique identifier you chose when creating the provider.
 - `label` (String) Human-readable label for the provider, displayed on the login button (e.g., "Sign in with Corporate SSO").
 - `mapper_url` (String) Jsonnet mapper URL for claims mapping. Can be a URL or base64-encoded Jsonnet (base64://...). If not set, a default mapper that extracts email from claims will be used.
 - `net_id_token_origin_header` (String) Origin header Ory sends when it exchanges a NetID FedCM token for an ID token. The value must be one of the `origin_uris` registered on the NetID client, for example "https://www.example.com". Set it together with fedcm_config_url on a NetID provider. Leave it unset for every other provider.
+- `organization_id` (String) Organization ID to associate this OIDC provider with (for B2B SSO). Set it to the ID of an existing `ory_organization`. The provider is then only offered to users of that organization, and the callback URL gains an `/organization/<organization_id>` segment. Leave it unset for a normal social sign-in provider that every user can use. Requires a B2B plan.
 - `pkce` (String) PKCE (Proof Key for Code Exchange) behavior for the OAuth2 authorization code flow. "auto" (default) enables PKCE when the upstream provider advertises support via OIDC discovery; "force" always sends PKCE (use only with providers known to support it); "never" disables PKCE.
 - `project_id` (String) Project ID. If not set, uses provider's project_id.
 - `scope` (List of String) OAuth2 scopes to request.

--- a/examples/resources/ory_social_provider/resource.tf
+++ b/examples/resources/ory_social_provider/resource.tf
@@ -149,6 +149,25 @@ resource "ory_social_provider" "enterprise_sso" {
   aal2_amr_values = ["mfa", "otp", "hwk"]
 }
 
+# OIDC provider scoped to an organization (B2B SSO). Ory offers this provider
+# only to users of the organization, and routes users to it by the domain of the
+# email address they enter on the login screen.
+resource "ory_organization" "acme" {
+  label   = "Acme"
+  domains = ["acme.example.com"]
+}
+
+resource "ory_social_provider" "acme_sso" {
+  provider_id     = "acme-sso"
+  provider_type   = "generic"
+  client_id       = var.acme_client_id
+  client_secret   = var.acme_client_secret
+  issuer_url      = "https://sso.acme.example.com"
+  scope           = ["openid", "profile", "email"]
+  label           = "Acme SSO"
+  organization_id = ory_organization.acme.id
+}
+
 # Generic OIDC Provider with custom claims mapping
 resource "ory_social_provider" "corporate_sso" {
   provider_id   = "corporate-sso"
@@ -233,6 +252,15 @@ variable "apple_private_key" {
   description = "Apple private key in PEM format (.p8 file contents)"
   type        = string
   sensitive   = true
+}
+
+variable "acme_client_id" {
+  type = string
+}
+
+variable "acme_client_secret" {
+  type      = string
+  sensitive = true
 }
 
 variable "sso_client_id" {

--- a/internal/resources/socialprovider/provider_config_test.go
+++ b/internal/resources/socialprovider/provider_config_test.go
@@ -74,6 +74,63 @@ func TestBuildProviderConfig_NetIDTokenOriginHeader(t *testing.T) {
 	}
 }
 
+// organization_id links an OIDC provider to a B2B SSO organization. Create and
+// Update replace the whole provider object, so the attribute must survive in the
+// payload when set, and must be absent when the user removes it. The API clears
+// the link whenever the key is missing from the replacement object.
+// Regression test for https://github.com/ory/terraform-provider-ory/issues/339
+func TestBuildProviderConfig_OrganizationID(t *testing.T) {
+	tests := []struct {
+		name        string
+		orgID       types.String
+		wantPresent bool
+		wantValue   string
+	}{
+		{
+			name:        "set",
+			orgID:       types.StringValue("64f12157-10fa-4a9b-899d-997cbc99fce3"),
+			wantPresent: true,
+			wantValue:   "64f12157-10fa-4a9b-899d-997cbc99fce3",
+		},
+		{
+			name:        "null",
+			orgID:       types.StringNull(),
+			wantPresent: false,
+		},
+		{
+			name:        "unknown",
+			orgID:       types.StringUnknown(),
+			wantPresent: false,
+		},
+		{
+			name:        "empty string",
+			orgID:       types.StringValue(""),
+			wantPresent: false,
+		},
+	}
+
+	r := &SocialProviderResource{}
+	ctx := context.Background()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := baseProviderPlan()
+			plan.OrganizationID = tt.orgID
+
+			config := r.buildProviderConfig(ctx, plan,
+				plan.ClientID, types.StringValue("test-client-secret"), types.StringNull())
+
+			got, ok := config["organization_id"]
+			if !tt.wantPresent {
+				assert.False(t, ok, "organization_id must be absent from the payload")
+				return
+			}
+			require.True(t, ok, "organization_id must be sent to the API")
+			assert.Equal(t, tt.wantValue, got)
+		})
+	}
+}
+
 // A NetID provider carries both the FedCM config URL and the origin header, so
 // the payload must keep them side by side.
 func TestBuildProviderConfig_NetIDFedcmPair(t *testing.T) {

--- a/internal/resources/socialprovider/resource.go
+++ b/internal/resources/socialprovider/resource.go
@@ -81,6 +81,7 @@ type SocialProviderResourceModel struct {
 	ApplePrivateKeyWOVersion   types.String `tfsdk:"apple_private_key_wo_version"`
 	AutoLink                   types.Bool   `tfsdk:"auto_link"`
 	Label                      types.String `tfsdk:"label"`
+	OrganizationID             types.String `tfsdk:"organization_id"`
 	AccountLinkingMode         types.String `tfsdk:"account_linking_mode"`
 	BaseRedirectURI            types.String `tfsdk:"base_redirect_uri"`
 	AdditionalIDTokenAudiences types.List   `tfsdk:"additional_id_token_audiences"`
@@ -242,6 +243,10 @@ func (r *SocialProviderResource) Schema(ctx context.Context, req resource.Schema
 			},
 			"label": schema.StringAttribute{
 				Description: "Human-readable label for the provider, displayed on the login button (e.g., \"Sign in with Corporate SSO\").",
+				Optional:    true,
+			},
+			"organization_id": schema.StringAttribute{
+				Description: "Organization ID to associate this OIDC provider with (for B2B SSO). Set it to the ID of an existing `ory_organization`. The provider is then only offered to users of that organization, and the callback URL gains an `/organization/<organization_id>` segment. Leave it unset for a normal social sign-in provider that every user can use. Requires a B2B plan.",
 				Optional:    true,
 			},
 			"account_linking_mode": schema.StringAttribute{
@@ -407,6 +412,9 @@ func (r *SocialProviderResource) ValidateConfig(ctx context.Context, req resourc
 	if !config.NetIDTokenOriginHeader.IsNull() && !config.NetIDTokenOriginHeader.IsUnknown() && config.NetIDTokenOriginHeader.ValueString() == "" {
 		resp.Diagnostics.AddAttributeError(path.Root("net_id_token_origin_header"), "Invalid Attribute Value", "net_id_token_origin_header must not be an empty string.")
 	}
+	if !config.OrganizationID.IsNull() && !config.OrganizationID.IsUnknown() && config.OrganizationID.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(path.Root("organization_id"), "Invalid Attribute Value", "organization_id must not be an empty string.")
+	}
 
 	if providerType == "apple" {
 		// Apple: needs either client_secret OR all three Apple-specific fields
@@ -496,6 +504,18 @@ func (r *SocialProviderResource) buildProviderConfig(ctx context.Context, plan *
 	if !plan.Label.IsNull() && !plan.Label.IsUnknown() {
 		config["label"] = plan.Label.ValueString()
 	}
+
+	// organization_id links the provider to a B2B SSO organization. Send it only
+	// when set: Create and Update replace the whole provider object, so omitting
+	// the key clears the link server-side, which is what removing the attribute
+	// from configuration must do. The API rejects a non-UUID value with HTTP 400,
+	// and an organization that does not exist with HTTP 500 and a foreign key
+	// violation on project_revision_oidc_providers.
+	// See: https://github.com/ory/terraform-provider-ory/issues/339
+	if !plan.OrganizationID.IsNull() && !plan.OrganizationID.IsUnknown() && plan.OrganizationID.ValueString() != "" {
+		config["organization_id"] = plan.OrganizationID.ValueString()
+	}
+
 	if !plan.AccountLinkingMode.IsNull() && !plan.AccountLinkingMode.IsUnknown() {
 		config["account_linking_mode"] = plan.AccountLinkingMode.ValueString()
 	}
@@ -979,6 +999,15 @@ func (r *SocialProviderResource) Read(ctx context.Context, req resource.ReadRequ
 		state.Label = types.StringValue(label)
 	} else {
 		state.Label = types.StringNull()
+	}
+
+	// Read organization_id, which the API does return. It reports the key as JSON
+	// null once the link is cleared, so a failed string assertion also has to null
+	// the state value.
+	if orgID, ok := provider["organization_id"].(string); ok && orgID != "" {
+		state.OrganizationID = types.StringValue(orgID)
+	} else {
+		state.OrganizationID = types.StringNull()
 	}
 
 	// Read account_linking_mode from API (returned on read)

--- a/internal/resources/socialprovider/resource_test.go
+++ b/internal/resources/socialprovider/resource_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -877,6 +878,182 @@ func TestAccSocialProviderResource_mapperURLNoDrift(t *testing.T) {
 				ImportStateId:           "test-google-mapper",
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"client_secret", "mapper_url"},
+			},
+		},
+	})
+}
+
+// oidcProvidersPath is the Console API JSON Patch path holding the OIDC
+// providers array, used to read the API back in organization assertions.
+const oidcProvidersPath = "/services/identity/config/selfservice/methods/oidc/config/providers"
+
+// checkAPIOrganizationID asserts what the API stores for the test provider's
+// organization_id. Terraform state only records what the provider believes it
+// wrote, and the whole point of issue #339 is a link that Terraform reports as
+// present while the API has dropped it, so the assertion has to read the API.
+//
+// Set wantLinked to false to assert the link is absent. When it is true, the
+// expected organization ID is read out of orgResourceName in Terraform state, so
+// the caller does not need to know the generated UUID before the apply.
+func checkAPIOrganizationID(t *testing.T, providerID, orgResourceName string, wantLinked bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		var wantOrgID string
+		if wantLinked {
+			rs, ok := s.RootModule().Resources[orgResourceName]
+			if !ok {
+				return fmt.Errorf("resource not found in state: %s", orgResourceName)
+			}
+			wantOrgID = rs.Primary.ID
+		}
+
+		return acctest.Eventually(func() error {
+			projectID := acctest.GetTestProject(t).ID
+			value, ok, err := acctest.ProjectConfigValue(t, projectID, oidcProvidersPath)
+			if err != nil {
+				return fmt.Errorf("could not read project %s: %w", projectID, err)
+			}
+			if !ok {
+				return fmt.Errorf("%s is absent from project %s", oidcProvidersPath, projectID)
+			}
+			providers, ok := value.([]interface{})
+			if !ok {
+				return fmt.Errorf("%s is %T, want an array", oidcProvidersPath, value)
+			}
+			for _, entry := range providers {
+				provider, ok := entry.(map[string]interface{})
+				if !ok || provider["id"] != providerID {
+					continue
+				}
+				gotOrgID, _ := provider["organization_id"].(string)
+				if gotOrgID != wantOrgID {
+					return fmt.Errorf("provider %q has organization_id %q in the API, want %q",
+						providerID, gotOrgID, wantOrgID)
+				}
+				return nil
+			}
+			return fmt.Errorf("provider %q is absent from %s", providerID, oidcProvidersPath)
+		})
+	}
+}
+
+// checkAPIProviderRemoved asserts the API no longer holds the provider this test
+// created. Destroy leaves Terraform state empty either way, so only a read of
+// the API catches a Delete that patched the wrong index or silently no-opped.
+func checkAPIProviderRemoved(t *testing.T, providerID string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		return acctest.Eventually(func() error {
+			projectID := acctest.GetTestProject(t).ID
+			value, ok, err := acctest.ProjectConfigValue(t, projectID, oidcProvidersPath)
+			if err != nil {
+				// A failed read must be retried, not read as "already deleted".
+				return fmt.Errorf("could not read project %s after destroy: %w", projectID, err)
+			}
+			if !ok {
+				return nil
+			}
+			providers, ok := value.([]interface{})
+			if !ok {
+				return nil
+			}
+			for _, entry := range providers {
+				provider, ok := entry.(map[string]interface{})
+				if ok && provider["id"] == providerID {
+					return fmt.Errorf("provider %q survived destroy in %s", providerID, oidcProvidersPath)
+				}
+			}
+			return nil
+		})
+	}
+}
+
+// TestAccSocialProviderResource_organizationID covers B2B SSO: an OIDC provider
+// scoped to an organization. Issue #339 reported the link missing. Without
+// organization_id in the schema, importing a B2B provider and applying the
+// generated configuration silently dropped the organization, leaving the
+// organization with no SSO provider.
+//
+// Every step reads the API back rather than trusting state, because the failure
+// mode is exactly a state value that no longer matches the API.
+func TestAccSocialProviderResource_organizationID(t *testing.T) {
+	const providerID = "test-oidc-b2b-sso"
+	tmplData := map[string]string{"OrgLabel": "TF Provider B2B SSO Test"}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.AccPreCheck(t)
+			acctest.RequireSocialProviderTests(t)
+			acctest.RequireB2BTests(t)
+			// Organizations need a prod or stage project, not a dev one.
+			if env := os.Getenv("ORY_PROJECT_ENVIRONMENT"); env == "dev" || env == "" {
+				t.Skip("B2B SSO tests require ORY_PROJECT_ENVIRONMENT to be 'prod' or 'stage' (not 'dev')")
+			}
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories(),
+		CheckDestroy:             checkAPIProviderRemoved(t, providerID),
+		Steps: []resource.TestStep{
+			// Create the organization and an OIDC provider scoped to it
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_organization.tf.tmpl", tmplData),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ory_social_provider.test", "id"),
+					resource.TestCheckResourceAttr("ory_social_provider.test", "provider_id", providerID),
+					resource.TestCheckResourceAttrPair(
+						"ory_social_provider.test", "organization_id",
+						"ory_organization.test", "id"),
+					checkAPIOrganizationID(t, providerID, "ory_organization.test", true),
+				),
+			},
+			// Verify no perpetual diff, since the API must echo organization_id back
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/with_organization.tf.tmpl", tmplData),
+				PlanOnly: true,
+			},
+			// Change the label only. Update replaces the whole provider object,
+			// so this is what dropped the organization link before the fix.
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_organization_updated.tf.tmpl", tmplData),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_social_provider.test", "label", "B2B SSO Renamed"),
+					resource.TestCheckResourceAttrPair(
+						"ory_social_provider.test", "organization_id",
+						"ory_organization.test", "id"),
+					checkAPIOrganizationID(t, providerID, "ory_organization.test", true),
+				),
+			},
+			// Verify no perpetual diff after the update
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/with_organization_updated.tf.tmpl", tmplData),
+				PlanOnly: true,
+			},
+			// ImportState must round-trip organization_id, which is the path the
+			// import workflow in issue #339 takes
+			{
+				ResourceName:            "ory_social_provider.test",
+				ImportState:             true,
+				ImportStateId:           providerID,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"client_secret"},
+			},
+			// Remove organization_id from config — the link must be cleared
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_organization_removed.tf.tmpl", tmplData),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("ory_social_provider.test", "organization_id"),
+					checkAPIOrganizationID(t, providerID, "ory_organization.test", false),
+				),
+			},
+			// Verify no diff after removal
+			{
+				Config:   acctest.LoadTestConfig(t, "testdata/with_organization_removed.tf.tmpl", tmplData),
+				PlanOnly: true,
+			},
+			// Re-add the link so destroy has to unwind a linked provider, which
+			// is the ordering the organization foreign key constrains
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/with_organization.tf.tmpl", tmplData),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkAPIOrganizationID(t, providerID, "ory_organization.test", true),
+				),
 			},
 		},
 	})

--- a/internal/resources/socialprovider/testdata/with_organization.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/with_organization.tf.tmpl
@@ -1,0 +1,14 @@
+resource "ory_organization" "test" {
+  label = "[[ .OrgLabel ]]"
+}
+
+resource "ory_social_provider" "test" {
+  provider_id     = "test-oidc-b2b-sso"
+  provider_type   = "generic"
+  client_id       = "test-b2b-client-id"
+  client_secret   = "test-b2b-client-secret"
+  issuer_url      = "https://accounts.google.com"
+  scope           = ["openid", "email"]
+  label           = "B2B SSO"
+  organization_id = ory_organization.test.id
+}

--- a/internal/resources/socialprovider/testdata/with_organization_removed.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/with_organization_removed.tf.tmpl
@@ -1,0 +1,14 @@
+resource "ory_organization" "test" {
+  label = "[[ .OrgLabel ]]"
+}
+
+resource "ory_social_provider" "test" {
+  provider_id   = "test-oidc-b2b-sso"
+  provider_type = "generic"
+  client_id     = "test-b2b-client-id"
+  client_secret = "test-b2b-client-secret"
+  issuer_url    = "https://accounts.google.com"
+  scope         = ["openid", "email"]
+  label         = "B2B SSO Renamed"
+  # organization_id intentionally omitted to test removal
+}

--- a/internal/resources/socialprovider/testdata/with_organization_updated.tf.tmpl
+++ b/internal/resources/socialprovider/testdata/with_organization_updated.tf.tmpl
@@ -1,0 +1,16 @@
+resource "ory_organization" "test" {
+  label = "[[ .OrgLabel ]]"
+}
+
+# Only the label changes. The organization link must survive the update, which
+# replaces the whole provider object server-side.
+resource "ory_social_provider" "test" {
+  provider_id     = "test-oidc-b2b-sso"
+  provider_type   = "generic"
+  client_id       = "test-b2b-client-id"
+  client_secret   = "test-b2b-client-secret"
+  issuer_url      = "https://accounts.google.com"
+  scope           = ["openid", "email"]
+  label           = "B2B SSO Renamed"
+  organization_id = ory_organization.test.id
+}

--- a/internal/resources/socialprovider/validate_config_test.go
+++ b/internal/resources/socialprovider/validate_config_test.go
@@ -45,6 +45,7 @@ func buildTestConfig(t *testing.T, model SocialProviderResourceModel) resource.V
 		"apple_private_key_wo_version":  tfStringValue(model.ApplePrivateKeyWOVersion),
 		"auto_link":                     tfBoolValue(model.AutoLink),
 		"label":                         tfStringValue(model.Label),
+		"organization_id":               tfStringValue(model.OrganizationID),
 		"account_linking_mode":          tfStringValue(model.AccountLinkingMode),
 		"base_redirect_uri":             tfStringValue(model.BaseRedirectURI),
 		"additional_id_token_audiences": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
@@ -81,6 +82,7 @@ func buildTestConfig(t *testing.T, model SocialProviderResourceModel) resource.V
 			"apple_private_key_wo_version":  tftypes.String,
 			"auto_link":                     tftypes.Bool,
 			"label":                         tftypes.String,
+			"organization_id":               tftypes.String,
 			"account_linking_mode":          tftypes.String,
 			"base_redirect_uri":             tftypes.String,
 			"additional_id_token_audiences": tftypes.List{ElementType: tftypes.String},
@@ -255,6 +257,42 @@ func TestValidateConfig_NetIDTokenOriginHeader_Passes(t *testing.T) {
 	r.ValidateConfig(ctx, req, &resp)
 
 	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for a valid net_id_token_origin_header: %v", resp.Diagnostics.Errors())
+}
+
+// An empty organization_id would be sent as "" and rejected by the API with
+// HTTP 400, so reject it during validation instead.
+func TestValidateConfig_EmptyOrganizationID_Fails(t *testing.T) {
+	r := &SocialProviderResource{}
+	ctx := context.Background()
+
+	req := buildTestConfig(t, SocialProviderResourceModel{
+		ProviderID:     types.StringValue("acme-sso"),
+		ProviderType:   types.StringValue("generic"),
+		ClientID:       types.StringValue("my-client-id"),
+		ClientSecret:   types.StringValue("my-secret"),
+		OrganizationID: types.StringValue(""), // empty string must fail
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.True(t, resp.Diagnostics.HasError(), "expected error for empty organization_id")
+}
+
+func TestValidateConfig_OrganizationID_Passes(t *testing.T) {
+	r := &SocialProviderResource{}
+	ctx := context.Background()
+
+	req := buildTestConfig(t, SocialProviderResourceModel{
+		ProviderID:     types.StringValue("acme-sso"),
+		ProviderType:   types.StringValue("generic"),
+		ClientID:       types.StringValue("my-client-id"),
+		ClientSecret:   types.StringValue("my-secret"),
+		OrganizationID: types.StringValue("64f12157-10fa-4a9b-899d-997cbc99fce3"),
+	})
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "expected no errors for a valid organization_id: %v", resp.Diagnostics.Errors())
 }
 
 func TestValidateConfig_WriteOnlyClientSecret_Passes(t *testing.T) {

--- a/templates/resources/social_provider.md.tmpl
+++ b/templates/resources/social_provider.md.tmpl
@@ -102,6 +102,36 @@ If not set, the provider uses a default mapper that extracts the email claim.
 
 The `label` attribute sets a human-readable label for the provider. This is displayed on the login button in the default UI (e.g., "Sign in with Corporate SSO"). If not set, the default label for the provider type is used.
 
+## Organization Scoping (B2B SSO)
+
+Set `organization_id` to associate an OIDC provider with a specific organization. Ory then offers the provider only to users of that organization instead of to everyone on the login screen, and the callback URL gains an `/organization/<organization_id>` segment. This is the OIDC counterpart of the same attribute on `ory_saml_provider`, and it is what the Ory Console shows as "via `<organization>` SSO" in the Social Sign-In (OIDC) tab.
+
+```hcl
+resource "ory_organization" "acme" {
+  label   = "Acme"
+  domains = ["acme.example.com"]
+}
+
+resource "ory_social_provider" "acme_sso" {
+  provider_id     = "acme-sso"
+  provider_type   = "generic"
+  client_id       = var.acme_client_id
+  client_secret   = var.acme_client_secret
+  issuer_url      = "https://sso.acme.example.com"
+  scope           = ["openid", "email", "profile"]
+  label           = "Acme SSO"
+  organization_id = ory_organization.acme.id
+}
+```
+
+Give the organization one or more `domains` to let Ory route a user to this provider by the domain of the email address they enter.
+
+~> **Note:** `organization_id` must be the ID of an organization that exists in the same project. The API rejects a value that is not a UUID with `HTTP 400`, and a UUID that matches no organization with `HTTP 500` and a foreign key error. Reference an `ory_organization` resource so Terraform creates the organization first.
+
+Removing `organization_id` from your configuration clears the link and turns the resource back into a normal social sign-in provider that every user can use.
+
+-> **Plan:** B2B SSO requires a plan with B2B or Enterprise features. Check your Ory Network plan before using this attribute.
+
 ## Account Linking Mode
 
 The `account_linking_mode` attribute controls how accounts are linked when a user signs in with this provider and a matching identity already exists:


### PR DESCRIPTION
## Description

Adds an `organization_id` attribute to `ory_social_provider` so OIDC providers used for B2B SSO can be managed in Terraform, matching the attribute that `ory_saml_provider` already has.

The Ory API stores an `organization_id` on every OIDC provider entry, but the resource had no such attribute. A B2B SSO provider created in the Console therefore imported as a plain social provider, and applying the generated configuration dropped the organization link. The organization was left with no SSO provider.

Three changes make the link manageable:

- `buildProviderConfig` sends `organization_id` when it is set. Create and Update replace the whole provider object, so the attribute has to be in the payload for the link to survive an apply.
- `Read` populates `organization_id`, so import round-trips the link and an out-of-band change shows up as drift.
- `ValidateConfig` rejects an empty string, which the API would otherwise reject with `HTTP 400` at apply time.

Removing the attribute from configuration clears the link server-side, because the API drops the key when the replaced provider object omits it. No separate remove patch is needed.

## Related Issues

Fixes #339

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

**API contract verified first, against the staging Console API.** The key round-trips at `/services/identity/config/selfservice/methods/oidc/config/providers/{i}/organization_id`. A non-UUID value is rejected with `HTTP 400` (`uuid: incorrect UUID length`). A UUID matching no organization is rejected with `HTTP 500` and a foreign key violation on `project_revision_oidc_providers_organization_fkey`. Omitting the key on a whole-object replace clears the link and the API then reports the key as `null`, which is why `Read` has to null state on a failed string assertion.

**Unit tests.** `TestBuildProviderConfig_OrganizationID` covers set, null, unknown, and empty-string. `TestValidateConfig_EmptyOrganizationID_Fails` and `TestValidateConfig_OrganizationID_Passes` cover validation.

**Acceptance test.** `TestAccSocialProviderResource_organizationID` runs 8 steps over an `ory_organization` and a linked provider: create, plan-only, label-only update, plan-only, import, removal, plan-only, and re-link. Every assertion reads the API back through `acctest.ProjectConfigValue` rather than trusting Terraform state, because the failure mode is state that no longer matches the API. `CheckDestroy` verifies the provider is gone from the providers array.

The test reproduces the issue. With the payload write removed, step 1 fails with the reported symptom:

```
Step 1/8 error: Check failed: Check 4/4 error: provider "test-oidc-b2b-sso"
has organization_id "" in the API, want "4817ef0d-4e7b-4008-ada0-3fd7a6ab293f"
```

With the fix in place the whole social provider acceptance suite passes:

```
ok  github.com/ory/terraform-provider-ory/internal/resources/socialprovider  161.091s
```

**Manual test of the reporter's workflow.** Created an organization and a linked OIDC provider through the API to stand in for a Console-created B2B SSO provider, then ran the import flow with the Terraform CLI:

1. `terraform plan -generate-config-out` now emits `organization_id = "09347c50-ca4c-4ba0-9c39-691e2dd7d2bb"`. Before this change the line was absent, which is what broke the link.
2. `terraform apply` imported the provider and the API still reported the organization.
3. `terraform plan` reported `No changes`.
4. A label-only update kept the link.
5. `terraform destroy` removed the provider and left the sibling `base_redirect_uri` key on the OIDC config node intact.

Every test object was cleaned up afterwards and the shared test project was returned to its original state.

## Screenshots/Output

`make build`, `make format` (0 lint issues), `make test-short` (17 packages, no failures), `make sec-gosec` (0 issues), and `make sec-gitleaks` (no leaks) all pass.

`make sec-vuln` fails, but the failure predates this branch: `go.mod` is untouched, the 5 findings are Go standard library vulnerabilities fixed in `encoding/asn1` and `net/http` at go1.26.6 against the pinned go1.26.5, and the `Security` workflow is already red on `main`. Fixing it needs a `go` directive bump, which belongs in its own PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Social login providers can now be scoped to a specific organization for B2B SSO.
  * Organization-linked providers support domain-based routing and organization-specific login flows.
  * Removing the organization association returns the provider to a standard configuration.
* **Documentation**
  * Added configuration examples, validation details, callback URL behavior, plan requirements, and import guidance for organization-scoped providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->