### PR TITLE
chore(deps): bump go directive to 1.26.6 for stdlib security fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ory/terraform-provider-ory
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.19.0


### PR DESCRIPTION
## Description

Bumps the `go` directive in `go.mod` from `1.26.5` to `1.26.6`.

The `Security` workflow has been red on `main` since 2026-08-19. `govulncheck` reports 5 Go standard library vulnerabilities that are all reachable from existing code and all fixed in go1.26.6:

| Advisory | Package | Reached through |
|---|---|---|
| GO-2026-6218 | `net/url` | Console API request building |
| GO-2026-6090 | `crypto/tls` | every outbound HTTPS call |
| GO-2026-6088 | `encoding/xml` | `TrustOAuth2JwtGrantIssuer` |
| GO-2026-5972 | `encoding/asn1` | `providerserver.Serve` |
| GO-2026-5026 | `net/http` | `FetchSafeHTTPS`, rate limit transport |

None of them can be avoided in code. Every CI job installs Go with `go-version-file: go.mod`, so the `go` directive is the single source of truth for the toolchain across build, security scan, and release. No workflow changes are needed.

This is the same fix as #291, which bumped `1.26.4` to `1.26.5` for GO-2026-5856.

## Related Issues

No issue. The failure is visible on the `Security` workflow runs for `main`. This unblocks #340, which cannot pass the `Go Vulnerability Check` on its own.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [ ] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

No test is added. The change is a toolchain pin, and `make sec-vuln` is the check that proves it.

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [ ] Acceptance tests
- [x] Manual testing

Ran locally against the bumped toolchain, which `GOTOOLCHAIN=auto` downloaded:

- `make sec-vuln` reports `No vulnerabilities found` and `Your code is affected by 0 vulnerabilities`, down from 5.
- `make build` compiles on go1.26.6.
- `make format` makes no changes beyond the bump and reports 0 lint issues.
- `make test-short` passes across all 17 packages.
- `make sec-gosec` reports 0 issues.

Acceptance tests were not run. The change touches no provider logic, and running them would take the shared test project's lock away from other work for no added signal.

## Screenshots/Output

Before, on `main`:

```
Your code is affected by 5 vulnerabilities from the Go standard library.
```

After:

```
=== Symbol Results ===

No vulnerabilities found.

Your code is affected by 0 vulnerabilities.
```

The residual "1 vulnerability in packages you import and 3 vulnerabilities in modules you require" line is unchanged by this PR and is not reported as reachable, so it does not fail the check.
