### PR TITLE
fix(import-skill): stop the inventory script truncating its own output

### DIFF
--- a/.claude/skills/import-existing-project/scripts/generate-imports.sh
+++ b/.claude/skills/import-existing-project/scripts/generate-imports.sh
@@ -36,27 +36,116 @@ command -v jq >/dev/null || die "jq is required"
 [ -n "${ORY_WORKSPACE_API_KEY:-}" ] || die "ORY_WORKSPACE_API_KEY is required"
 [ -n "${ORY_PROJECT_ID:-}" ] || die "ORY_PROJECT_ID is required"
 
-# GET from the Ory Console API (workspace API key). Dies on API errors.
-console_get() {
-  local path="$1" resp
-  resp=$(curl -sS -H "Authorization: Bearer $ORY_WORKSPACE_API_KEY" "$CONSOLE_URL$path") ||
-    die "GET $path failed (network)"
-  if echo "$resp" | jq -e '.error? // empty' >/dev/null 2>&1; then
-    die "GET $path: $(echo "$resp" | jq -r '.error.message // .error')"
+# Per-run scratch state. This lives in files rather than shell variables because
+# nearly every caller reads a value through $( ) or from inside a `... | while
+# read` pipeline, both of which run in a subshell: a variable assigned in there
+# never reaches the caller. With variables, pagination stops after the first page
+# and the label dedupe never sees anything as taken.
+RUN_DIR=$(mktemp -d)
+HEADERS_FILE="$RUN_DIR/headers"
+ERROR_FILE="$RUN_DIR/error"
+LABELS_FILE="$RUN_DIR/labels"
+: >"$HEADERS_FILE"
+: >"$ERROR_FILE"
+: >"$LABELS_FILE"
+cleanup() { rm -rf "$RUN_DIR"; }
+trap cleanup EXIT
+
+http_error() { cat "$ERROR_FILE"; }
+
+# GET with the given bearer token. Prints the body on 2xx and returns 1 on any
+# other status, so callers decide whether the failure is fatal. curl exits 0 on
+# a 4xx or 5xx, so the status has to be captured explicitly.
+http_get() {
+  local url="$1" token="$2" body status reason
+  : >"$ERROR_FILE"
+  body=$(curl -sS -D "$HEADERS_FILE" -w '\n%{http_code}' \
+    -H "Authorization: Bearer $token" "$url" 2>/dev/null) || {
+    echo "network error" >"$ERROR_FILE"
+    return 1
+  }
+  status="${body##*$'\n'}"
+  body="${body%$'\n'*}"
+  if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+    reason=$(echo "$body" | jq -r '.error.message? // .error? // empty' 2>/dev/null || true)
+    if [ -n "$reason" ]; then
+      echo "HTTP $status: $reason" >"$ERROR_FILE"
+    else
+      echo "HTTP $status" >"$ERROR_FILE"
+    fi
+    return 1
   fi
-  echo "$resp"
+  echo "$body"
+}
+
+# GET from the Ory Console API (workspace API key). Dies on any failure. Use
+# only for requests the whole inventory depends on.
+console_get() {
+  local path="$1"
+  http_get "$CONSOLE_URL$path" "$ORY_WORKSPACE_API_KEY" ||
+    die "GET $path failed ($(http_error))"
+}
+
+# GET from the Ory Console API, tolerating failure. Plan-gated features answer
+# with 403 feature_not_available and environment-gated ones with 400 or 403, so
+# a hard failure here would abort the run on a project that simply does not have
+# custom domains, event streams, or organizations.
+console_get_optional() {
+  local path="$1" body
+  if body=$(http_get "$CONSOLE_URL$path" "$ORY_WORKSPACE_API_KEY"); then
+    echo "$body"
+    return 0
+  fi
+  log "WARN: GET $path unavailable ($(http_error)); skipping this section"
+  return 1
 }
 
 # GET from the project admin API (project API key). Prints nothing on error so
 # optional sections can degrade gracefully.
 admin_get() {
-  local path="$1" resp
-  resp=$(curl -sS -H "Authorization: Bearer $ORY_PROJECT_API_KEY" "$ADMIN_URL$path") || return 1
-  if echo "$resp" | jq -e '.error? // empty' >/dev/null 2>&1; then
-    log "WARN: GET $path: $(echo "$resp" | jq -r '.error.message // .error')"
-    return 1
+  local path="$1" body
+  if body=$(http_get "$ADMIN_URL$path" "$ORY_PROJECT_API_KEY"); then
+    echo "$body"
+    return 0
   fi
-  echo "$resp"
+  log "WARN: GET $path: $(http_error)"
+  return 1
+}
+
+# Extract the page_token of the "next" relation from the last response's Link
+# header. Ory paginates its admin collections with an opaque cursor, the same way
+# parseLinkNextPageToken does in internal/client/client.go.
+next_page_token() {
+  tr -d '\r' <"$HEADERS_FILE" | grep -i '^link:' |
+    tr ',' '\n' | grep 'rel="next"' |
+    sed -n 's/.*[?&]page_token=\([^&>]*\).*/\1/p' | head -1
+}
+
+# GET every page of an admin collection and print the concatenated JSON array.
+# Bounded so a server that keeps returning a cursor cannot loop forever.
+admin_get_all() {
+  local path="$1" sep="?" page all token
+  case "$path" in *\?*) sep="&" ;; esac
+  all="[]"
+  token=""
+  local i
+  for i in $(seq 1 50); do
+    local url="$path"
+    [ -n "$token" ] && url="$path${sep}page_token=$token"
+    page=$(admin_get "$url") || return 1
+    echo "$page" | jq -e 'type == "array"' >/dev/null 2>&1 || {
+      log "WARN: GET $path returned $(echo "$page" | jq -r 'type'), expected an array"
+      return 1
+    }
+    all=$(jq -c -n --argjson a "$all" --argjson b "$page" '$a + $b')
+    [ "$(echo "$page" | jq 'length')" -eq 0 ] && break
+    token=$(next_page_token)
+    [ -z "$token" ] && break
+    if [ "$i" -eq 50 ]; then
+      log "WARN: GET $path stopped after 50 pages; results may be truncated"
+    fi
+  done
+  echo "$all"
 }
 
 # Turn an arbitrary string into a valid Terraform resource label fragment.
@@ -67,21 +156,54 @@ sanitize() {
 
 short_id() { echo "$1" | cut -c1-8; }
 
+# Terraform addresses must be unique, but sanitize collapses every run of
+# non-alphanumerics to "_", so "google-1" and "google_1" both become "google_1".
+# Record what has been emitted and suffix a counter on a repeat, otherwise
+# Terraform rejects the whole file for duplicate import blocks. The record has to
+# be a file: callers invoke this from inside $( ), so a variable would reset on
+# every call and never report a label as taken.
+unique_label() {
+  local base="$1" candidate="$1" n=2
+  while grep -qxF "$candidate" "$LABELS_FILE"; do
+    candidate="${base}_${n}"
+    n=$((n + 1))
+  done
+  printf '%s\n' "$candidate" >>"$LABELS_FILE"
+  echo "$candidate"
+}
+
+# HCL escaping for an import ID. Action IDs embed arbitrary webhook URLs, so a
+# quote or backslash in one would otherwise produce a broken file.
+hcl_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
 emit() {
-  printf 'import {\n  to = %s\n  id = "%s"\n}\n\n' "$1" "$2"
+  printf 'import {\n  to = %s\n  id = "%s"\n}\n\n' "$1" "$(hcl_escape "$2")"
 }
 
 log "Inventorying project $ORY_PROJECT_ID ..."
 PROJECT_JSON=$(console_get "/projects/$ORY_PROJECT_ID")
-PROJECT_NAME=$(echo "$PROJECT_JSON" | jq -r '.name')
-PROJECT_SLUG=$(echo "$PROJECT_JSON" | jq -r '.slug')
+PROJECT_NAME=$(echo "$PROJECT_JSON" | jq -r '.name // empty')
+PROJECT_SLUG=$(echo "$PROJECT_JSON" | jq -r '.slug // empty')
+PROJECT_STATE=$(echo "$PROJECT_JSON" | jq -r '.state // empty')
 WORKSPACE_ID=$(echo "$PROJECT_JSON" | jq -r '.workspace_id // empty')
+[ -n "$PROJECT_SLUG" ] ||
+  die "project $ORY_PROJECT_ID has no slug; check ORY_PROJECT_ID and ORY_WORKSPACE_API_KEY"
+
+# Projects are soft deleted: GET returns HTTP 200 with state "deleted". Every
+# import block would then fail with "Cannot import non-existent remote object"
+# even though each request succeeded, so stop before emitting any.
+if [ "$PROJECT_STATE" = "deleted" ]; then
+  die "project $ORY_PROJECT_ID is soft deleted (state: deleted); nothing can be imported from it"
+fi
+
 # shellcheck disable=SC2059 # PROJECT_URL_TEMPLATE is intentionally a printf template
 ADMIN_URL=$(printf "$PROJECT_URL_TEMPLATE" "$PROJECT_SLUG")
 
 cat <<EOF
 # Terraform import blocks for Ory Network project:
-#   name: $PROJECT_NAME
+#   name: ${PROJECT_NAME:-<unnamed>}
 #   id:   $ORY_PROJECT_ID
 #   slug: $PROJECT_SLUG
 #
@@ -109,168 +231,315 @@ EOF
 fi
 
 # --- Custom domains -----------------------------------------------------------
-DOMAINS=$(console_get "/projects/$ORY_PROJECT_ID/cname" | jq -c '. // []')
+DOMAINS="[]"
+if RESP=$(console_get_optional "/projects/$ORY_PROJECT_ID/cname"); then
+  DOMAINS=$(echo "$RESP" | jq -c 'if type == "array" then . else [] end')
+fi
 echo "$DOMAINS" | jq -c '.[]' | while read -r row; do
-  id=$(echo "$row" | jq -r '.id')
-  hostname=$(echo "$row" | jq -r '.hostname')
-  emit "ory_custom_domain.$(sanitize "$hostname")" "$ORY_PROJECT_ID/$id"
+  id=$(echo "$row" | jq -r '.id // empty')
+  hostname=$(echo "$row" | jq -r '.hostname // empty')
+  [ -n "$id" ] || continue
+  emit "ory_custom_domain.$(unique_label "$(sanitize "${hostname:-domain}")")" "$ORY_PROJECT_ID/$id"
 done
 log "custom domains: $(echo "$DOMAINS" | jq 'length')"
 
 # --- Event streams ------------------------------------------------------------
-STREAMS=$(console_get "/projects/$ORY_PROJECT_ID/eventstreams" | jq -c '.event_streams // []')
+STREAMS="[]"
+if RESP=$(console_get_optional "/projects/$ORY_PROJECT_ID/eventstreams"); then
+  STREAMS=$(echo "$RESP" | jq -c '.event_streams // [] | if type == "array" then . else [] end')
+fi
 echo "$STREAMS" | jq -c '.[]' | while read -r row; do
-  id=$(echo "$row" | jq -r '.id')
+  id=$(echo "$row" | jq -r '.id // empty')
   type=$(echo "$row" | jq -r '.type // "stream"')
-  emit "ory_event_stream.$(sanitize "$type")_$(short_id "$id")" "$ORY_PROJECT_ID/$id"
+  [ -n "$id" ] || continue
+  emit "ory_event_stream.$(unique_label "$(sanitize "$type")_$(short_id "$id")")" "$ORY_PROJECT_ID/$id"
 done
 log "event streams: $(echo "$STREAMS" | jq 'length')"
 
 # --- Organizations (B2B) --------------------------------------------------------
-ORGS_RESP=$(console_get "/projects/$ORY_PROJECT_ID/organizations")
-if [ "$(echo "$ORGS_RESP" | jq -r '.has_next_page // false')" = "true" ]; then
-  log "WARN: organization list is paginated and only the first page was fetched"
-fi
-ORGS=$(echo "$ORGS_RESP" | jq -c '.organizations // []')
+# Paginated with an explicit next_page_token rather than a Link header.
+ORGS="[]"
+ORG_PAGE_TOKEN=""
+for _ in $(seq 1 50); do
+  ORG_PATH="/projects/$ORY_PROJECT_ID/organizations"
+  [ -n "$ORG_PAGE_TOKEN" ] && ORG_PATH="$ORG_PATH?page_token=$ORG_PAGE_TOKEN"
+  ORGS_RESP=$(console_get_optional "$ORG_PATH") || break
+  ORGS=$(jq -c -n --argjson a "$ORGS" \
+    --argjson b "$(echo "$ORGS_RESP" | jq -c '.organizations // [] | if type == "array" then . else [] end')" \
+    '$a + $b')
+  [ "$(echo "$ORGS_RESP" | jq -r '.has_next_page // false')" = "true" ] || break
+  ORG_PAGE_TOKEN=$(echo "$ORGS_RESP" | jq -r '.next_page_token // empty')
+  [ -n "$ORG_PAGE_TOKEN" ] || break
+done
 echo "$ORGS" | jq -c '.[]' | while read -r row; do
-  id=$(echo "$row" | jq -r '.id')
-  label=$(echo "$row" | jq -r '.label')
-  emit "ory_organization.$(sanitize "$label")_$(short_id "$id")" "$ORY_PROJECT_ID/$id"
+  id=$(echo "$row" | jq -r '.id // empty')
+  label=$(echo "$row" | jq -r '.label // empty')
+  [ -n "$id" ] || continue
+  emit "ory_organization.$(unique_label "$(sanitize "${label:-org}")_$(short_id "$id")")" "$ORY_PROJECT_ID/$id"
 done
 log "organizations: $(echo "$ORGS" | jq 'length')"
 
 # --- Project API keys (comment only: key values are unrecoverable) -------------
-KEYS=$(console_get "/projects/$ORY_PROJECT_ID/tokens" | jq -c '. // []')
+KEYS="[]"
+if RESP=$(console_get_optional "/projects/$ORY_PROJECT_ID/tokens"); then
+  KEYS=$(echo "$RESP" | jq -c 'if type == "array" then . else [] end')
+fi
 if [ "$(echo "$KEYS" | jq 'length')" -gt 0 ]; then
   echo "# Project API keys exist but are not imported by default: the secret value"
   echo "# is only returned at creation time and cannot be recovered by an import."
   echo "# Uncomment to import one anyway (state will hold a null value):"
   echo "$KEYS" | jq -c '.[]' | while read -r row; do
-    id=$(echo "$row" | jq -r '.id')
+    id=$(echo "$row" | jq -r '.id // empty')
     name=$(echo "$row" | jq -r '.name // "key"')
+    [ -n "$id" ] || continue
     printf '# import {\n#   to = ory_project_api_key.%s\n#   id = "%s"\n# }\n' \
-      "$(sanitize "$name")_$(short_id "$id")" "$ORY_PROJECT_ID/$id"
+      "$(unique_label "$(sanitize "$name")_$(short_id "$id")")" "$ORY_PROJECT_ID/$id"
   done
   echo
 fi
 log "project API keys: $(echo "$KEYS" | jq 'length') (commented out)"
 
 # --- Social sign-in providers (from the project revision) ----------------------
-SOCIAL=$(echo "$PROJECT_JSON" | jq -c '[.services.identity.config.selfservice.methods.oidc.config.providers[]?]')
+SOCIAL=$(echo "$PROJECT_JSON" | jq -c '
+  [.services.identity.config.selfservice.methods.oidc.config.providers[]?
+   | select(type == "object")]')
 if [ "$(echo "$SOCIAL" | jq 'length')" -gt 0 ]; then
   echo "# Social provider client secrets are never returned by the API. After"
   echo "# generating config, re-supply each client_secret (or client_secret_wo)."
+  if [ "$(echo "$SOCIAL" | jq '[.[] | select((.organization_id // "") != "")] | length')" -gt 0 ]; then
+    echo "# Providers with an organization_id are B2B SSO providers. Import the"
+    echo "# matching ory_organization too and reference it as"
+    echo "# organization_id = ory_organization.<name>.id so Terraform orders the"
+    echo "# create and the destroy correctly."
+  fi
 fi
 echo "$SOCIAL" | jq -c '.[]' | while read -r row; do
-  id=$(echo "$row" | jq -r '.id')
-  emit "ory_social_provider.$(sanitize "$id")" "$id"
+  id=$(echo "$row" | jq -r '.id // empty')
+  [ -n "$id" ] || continue
+  emit "ory_social_provider.$(unique_label "$(sanitize "$id")")" "$id"
 done
 log "social providers: $(echo "$SOCIAL" | jq 'length')"
 
 # --- SAML providers (from the project revision) ---------------------------------
-SAML=$(echo "$PROJECT_JSON" | jq -c '[.services.identity.config.selfservice.methods.saml.config.providers[]?]')
+SAML=$(echo "$PROJECT_JSON" | jq -c '
+  [.services.identity.config.selfservice.methods.saml.config.providers[]?
+   | select(type == "object")]')
 echo "$SAML" | jq -c '.[]' | while read -r row; do
-  id=$(echo "$row" | jq -r '.id')
-  emit "ory_saml_provider.$(sanitize "$id")" "$id"
+  id=$(echo "$row" | jq -r '.id // empty')
+  [ -n "$id" ] || continue
+  emit "ory_saml_provider.$(unique_label "$(sanitize "$id")")" "$id"
 done
 log "saml providers: $(echo "$SAML" | jq 'length')"
 
 # --- Actions / webhooks (from the project revision) -----------------------------
 # after-timing hooks nested under an auth method: flow:after:<method>:METHOD:url
-# after-timing hooks in a flat array (recovery/verification): auth method
-# placeholder "_" (the provider ignores it for those flows).
+# after-timing hooks in a flat array: auth method placeholder "_". Only valid on
+# a flow that does not scope its hooks by authentication method. For login,
+# registration, and settings the provider resolves "_" to the default "password"
+# and then reads .../after/password/hooks, so a flat hook there is unreachable.
+# Mirrors authMethodsForFlow in internal/resources/action/resource.go.
 # before-timing hooks: flow:before:METHOD:url
-ACTIONS=$(echo "$PROJECT_JSON" | jq -c '
-  .services.identity.config.selfservice.flows // {} | to_entries
+#
+# Every level is type-checked. The "after" node holds scalar siblings of the
+# auth-method objects, such as default_browser_return_url and required_aal, and
+# indexing one of those aborts jq and truncates the whole file.
+# shellcheck disable=SC2016 # jq program: $flow and $timing are jq variables
+ACTIONS_JQ='
+  def hooks_of($flow; $timing; $method):
+    (if type == "array" then . else [] end)
+    | map(select(type == "object" and .hook == "web_hook"
+                 and (.config | type) == "object"
+                 and (.config.url | type) == "string")
+        | {label: ($flow + "_" + $timing + (if $method == "" then "" else "_" + $method end)),
+           id: ($flow + ":" + $timing
+                + (if $timing == "after" then ":" + (if $method == "" then "_" else $method end) else "" end)
+                + ":" + (.config.method // "POST") + ":" + .config.url)});
+  def flat_allowed($flow): ($flow | IN("login", "registration", "settings")) | not;
+  (.services.identity.config.selfservice.flows // {})
+  | (if type == "object" then . else {} end)
+  | to_entries
   | map(.key as $flow
-      | (.value.before.hooks // [] | map(select(.hook == "web_hook")
-          | {label: "\($flow)_before", id: "\($flow):before:\(.config.method // "POST"):\(.config.url)"})),
-        (.value.after // {} | to_entries
-          | map(.key as $m
-              | if .key == "hooks" then
-                  (.value | map(select(.hook == "web_hook")
-                    | {label: "\($flow)_after", id: "\($flow):after:_:\(.config.method // "POST"):\(.config.url)"}))
-                else
-                  (.value.hooks // [] | map(select(.hook == "web_hook")
-                    | {label: "\($flow)_after_\($m)", id: "\($flow):after:\($m):\(.config.method // "POST"):\(.config.url)"}))
-                end)
-          | add // [])
-    )
+      | (if (.value | type) == "object" then .value else {} end) as $cfg
+      | (
+          (if ($cfg.before | type) == "object" then ($cfg.before.hooks | hooks_of($flow; "before"; "")) else [] end)
+          + (
+            (if ($cfg.after | type) == "object" then $cfg.after else {} end)
+            | to_entries
+            | map(.key as $m
+                | if $m == "hooks" then
+                    (if flat_allowed($flow) then (.value | hooks_of($flow; "after"; "")) else [] end)
+                  elif (.value | type) == "object" then
+                    (.value.hooks | hooks_of($flow; "after"; $m))
+                  else
+                    []
+                  end)
+            | add // [])
+        ))
+  | add // []'
+ACTIONS=$(echo "$PROJECT_JSON" | jq -c "$ACTIONS_JQ")
+
+# Flat "after" hooks on a flow that scopes hooks by auth method are unreachable
+# for ory_action. Emitting an import block for one produces "Cannot import
+# non-existent remote object", so report them instead.
+UNREACHABLE=$(echo "$PROJECT_JSON" | jq -c '
+  (.services.identity.config.selfservice.flows // {})
+  | (if type == "object" then . else {} end)
+  | to_entries
+  | map(select(.key | IN("login", "registration", "settings"))
+      | .key as $flow
+      | (if (.value | type) == "object" and (.value.after | type) == "object"
+         then (.value.after.hooks // []) else [] end)
+      | (if type == "array" then . else [] end)
+      | map(select(type == "object" and .hook == "web_hook")
+          | "\($flow): \(.config.url // "?")"))
   | add // []')
+if [ "$(echo "$UNREACHABLE" | jq 'length')" -gt 0 ]; then
+  echo "# WARNING: these webhooks sit in a flat .../<flow>/after/hooks array on a"
+  echo "# flow whose hooks the provider scopes by authentication method. ory_action"
+  echo "# always reads .../<flow>/after/<auth_method>/hooks for these flows, so the"
+  echo "# hooks below cannot be imported. Move each one under an auth method in the"
+  echo "# Ory Console, then re-run this script."
+  echo "$UNREACHABLE" | jq -r '.[] | "#   \(.)"'
+  echo
+  log "WARN: $(echo "$UNREACHABLE" | jq 'length') flat after-hook(s) on an auth-method flow cannot be imported"
+fi
+
 n=0
-echo "$ACTIONS" | jq -c '.[]' | while read -r row; do
+while read -r row; do
+  [ -n "$row" ] || continue
   n=$((n + 1))
   label=$(echo "$row" | jq -r '.label')
   id=$(echo "$row" | jq -r '.id')
-  emit "ory_action.$(sanitize "$label")_$n" "$ORY_PROJECT_ID:$id"
-done
+  emit "ory_action.$(unique_label "$(sanitize "$label")_$n")" "$ORY_PROJECT_ID:$id"
+done < <(echo "$ACTIONS" | jq -c '.[]')
 log "actions (web_hooks): $(echo "$ACTIONS" | jq 'length')"
 
 # --- Email templates (from the project revision) --------------------------------
 # Only templates with actual content (subject or body) are customized; the rest
 # are empty skeletons for the defaults and cannot be imported meaningfully.
-TEMPLATES=$(echo "$PROJECT_JSON" | jq -c '
-  [.services.identity.config.courier.templates // {} | to_entries[]
-   | .key as $base | .value | to_entries[]
+# The subject and body live one level below the validity key, under ".email".
+# ory_email_template accepts a closed set of template types, so an unexpected
+# group in the revision is reported rather than emitted as a doomed import.
+VALID_TEMPLATE_TYPES='["recovery_code_valid","recovery_code_invalid","recovery_valid","recovery_invalid","verification_code_valid","verification_code_invalid","verification_valid","verification_invalid","login_code_valid","login_code_invalid","registration_code_valid","registration_code_invalid"]'
+TEMPLATES_ALL=$(echo "$PROJECT_JSON" | jq -c '
+  [(.services.identity.config.courier.templates // {})
+   | (if type == "object" then . else {} end)
+   | to_entries[]
+   | .key as $base
+   | (if (.value | type) == "object" then .value else {} end)
+   | to_entries[]
    | select(.key == "valid" or .key == "invalid")
-   | .key as $validity | .value.email // {}
-   | select((.subject // "") != "" or (.body.html // "") != "" or (.body.plaintext // "") != "")
+   | .key as $validity
+   | (if (.value | type) == "object" then (.value.email // {}) else {} end)
+   | (if type == "object" then . else {} end)
+   | select(((.subject // "") | tostring) != ""
+            or ((.body.html? // "") | tostring) != ""
+            or ((.body.plaintext? // "") | tostring) != "")
    | "\($base)_\($validity)"]')
+TEMPLATES=$(jq -c -n --argjson all "$TEMPLATES_ALL" --argjson valid "$VALID_TEMPLATE_TYPES" \
+  '[$all[] | select(. as $t | $valid | index($t))]')
+UNKNOWN_TEMPLATES=$(jq -c -n --argjson all "$TEMPLATES_ALL" --argjson valid "$VALID_TEMPLATE_TYPES" \
+  '[$all[] | select(. as $t | $valid | index($t) | not)]')
 echo "$TEMPLATES" | jq -r '.[]' | while read -r type; do
-  emit "ory_email_template.$(sanitize "$type")" "$type"
+  [ -n "$type" ] || continue
+  emit "ory_email_template.$(unique_label "$(sanitize "$type")")" "$type"
 done
+if [ "$(echo "$UNKNOWN_TEMPLATES" | jq 'length')" -gt 0 ]; then
+  echo "# These courier templates hold content but are not among the template types"
+  echo "# ory_email_template accepts, so no import block was emitted for them:"
+  echo "$UNKNOWN_TEMPLATES" | jq -r '.[] | "#   \(.)"'
+  echo
+fi
 log "email templates with custom content: $(echo "$TEMPLATES" | jq 'length')"
 
 # --- Identity schemas: not importable, list them for reference -------------------
-SCHEMAS=$(echo "$PROJECT_JSON" | jq -c '[.services.identity.config.identity.schemas[]?.id | select(startswith("preset://") | not)]')
+# An entry without a string id would abort startswith(), and the project revision
+# lists only schemas explicitly added to the project. The workspace endpoint holds
+# the rest, which is why ory_identity_schemas merges both sources.
+SCHEMAS=$(echo "$PROJECT_JSON" | jq -c '
+  [.services.identity.config.identity.schemas[]?
+   | select(type == "object") | .id
+   | select(type == "string")
+   | select(startswith("preset://") | not)]')
+if WS_SCHEMAS_RESP=$(console_get_optional "/identity-schemas"); then
+  SCHEMAS=$(jq -c -n --argjson a "$SCHEMAS" \
+    --argjson b "$(echo "$WS_SCHEMAS_RESP" | jq -c '
+      [(if type == "array" then . else (.identity_schemas // []) end)[]?
+       | select(type == "object") | (.id // .schema_id)
+       | select(type == "string")
+       | select(startswith("preset://") | not)]')" \
+    '($a + $b) | unique')
+fi
 if [ "$(echo "$SCHEMAS" | jq 'length')" -gt 0 ]; then
   echo "# Identity schemas are immutable and intentionally NOT importable."
   echo "# Existing schemas stay as they are; manage future schemas with new"
   echo "# ory_identity_schema resources, or read these with the ory_identity_schema"
-  echo "# data source:"
+  echo "# and ory_identity_schemas data sources:"
   echo "$SCHEMAS" | jq -r '.[] | "#   schema id: \(.)"'
   echo
 fi
 log "identity schemas (not importable): $(echo "$SCHEMAS" | jq 'length')"
 
 # --- Keto namespaces / relationships ---------------------------------------------
-NAMESPACES=$(echo "$PROJECT_JSON" | jq -c '[.services.permission.config.namespaces[]?.name]')
-if [ "$(echo "$NAMESPACES" | jq 'length')" -gt 0 ]; then
+# namespaces is either an array of {name, id} objects or an object holding a
+# "location" URL that points at a namespace config file. Indexing the object
+# shape as an array aborts jq, so handle both.
+NAMESPACES=$(echo "$PROJECT_JSON" | jq -c '
+  (.services.permission.config.namespaces // [])
+  | if type == "array" then [.[] | select(type == "object") | .name | select(type == "string")]
+    else [] end')
+NAMESPACE_LOCATION=$(echo "$PROJECT_JSON" | jq -r '
+  (.services.permission.config.namespaces // {})
+  | if type == "object" then (.location // empty) else empty end')
+if [ "$(echo "$NAMESPACES" | jq 'length')" -gt 0 ] || [ -n "$NAMESPACE_LOCATION" ]; then
   echo "# Keto namespaces (managed inside ory_project_config, not separate resources):"
-  echo "$NAMESPACES" | jq -r '.[] | "#   \(.)"'
+  if [ -n "$NAMESPACE_LOCATION" ]; then
+    echo "#   configured from a location URL: $NAMESPACE_LOCATION"
+    echo "#   set keto_namespace_configuration in ory_project_config to manage it."
+  else
+    echo "$NAMESPACES" | jq -r '.[] | "#   \(.)"'
+  fi
   echo "# Relationship tuples are data, not configuration; import selectively with an"
   echo "# ory_relationship import block whose id is \"namespace:object#relation@subject\"."
   echo "# List tuples via GET /relation-tuples?namespace=<name> on the project API."
   echo
 fi
-log "keto namespaces: $(echo "$NAMESPACES" | jq 'length')"
+log "keto namespaces: $(echo "$NAMESPACES" | jq 'length')${NAMESPACE_LOCATION:+ (location URL)}"
 
 # --- Project-API-key gated resources ---------------------------------------------
 if [ -n "${ORY_PROJECT_API_KEY:-}" ]; then
   # OAuth2 clients
-  if CLIENTS=$(admin_get "/admin/clients?page_size=500"); then
+  if CLIENTS=$(admin_get_all "/admin/clients?page_size=250"); then
     COUNT=$(echo "$CLIENTS" | jq 'length')
-    [ "$COUNT" = "500" ] && log "WARN: 500 OAuth2 clients returned; results may be truncated (pagination not followed)"
     if [ "$COUNT" -gt 0 ]; then
       echo "# OAuth2 client secrets are only returned at creation time. After"
       echo "# generating config, re-supply client_secret (or client_secret_wo) for"
-      echo "# confidential clients. For clients registered via dynamic client"
-      echo "# registration, use ory_oidc_dynamic_client instead of ory_oauth2_client."
+      echo "# confidential clients."
+      echo "#"
+      echo "# GET /admin/clients returns dynamically registered (RFC 7591) clients"
+      echo "# alongside normal ones and carries no field that distinguishes them, so"
+      echo "# every client below is emitted as ory_oauth2_client. For a client you"
+      echo "# registered through /oauth2/register, change the resource type on the"
+      echo "# 'to' line to ory_oidc_dynamic_client; both take the same {client_id}"
+      echo "# import ID, so nothing else changes."
     fi
     echo "$CLIENTS" | jq -c '.[]' | while read -r row; do
-      id=$(echo "$row" | jq -r '.client_id')
+      id=$(echo "$row" | jq -r '.client_id // empty')
       name=$(echo "$row" | jq -r '.client_name // ""')
-      emit "ory_oauth2_client.$(sanitize "${name:-client}")_$(short_id "$id")" "$id"
+      [ -n "$id" ] || continue
+      emit "ory_oauth2_client.$(unique_label "$(sanitize "${name:-client}")_$(short_id "$id")")" "$id"
     done
     log "oauth2 clients: $COUNT"
   fi
 
-  # Trusted OAuth2 JWT grant issuers
-  if ISSUERS=$(admin_get "/admin/trust/grants/jwt-bearer/issuers"); then
-    echo "$ISSUERS" | jq -c '.[]?' | while read -r row; do
-      id=$(echo "$row" | jq -r '.id')
-      issuer=$(echo "$row" | jq -r '.issuer')
-      emit "ory_trusted_oauth2_jwt_grant_issuer.$(sanitize "$issuer")_$(short_id "$id")" "$id"
+  # Trusted OAuth2 JWT grant issuers. The API defaults to 250 per page, so this
+  # has to follow the cursor or a larger project loses issuers silently.
+  if ISSUERS=$(admin_get_all "/admin/trust/grants/jwt-bearer/issuers?page_size=250"); then
+    echo "$ISSUERS" | jq -c '.[]' | while read -r row; do
+      id=$(echo "$row" | jq -r '.id // empty')
+      issuer=$(echo "$row" | jq -r '.issuer // "issuer"')
+      [ -n "$id" ] || continue
+      emit "ory_trusted_oauth2_jwt_grant_issuer.$(unique_label "$(sanitize "$issuer")_$(short_id "$id")")" "$id"
     done
     log "trusted jwt grant issuers: $(echo "$ISSUERS" | jq 'length')"
   fi
@@ -279,14 +548,16 @@ if [ -n "${ORY_PROJECT_API_KEY:-}" ]; then
   # explicitly. Default hydra.* sets are system-managed; do not import them.
   if [ -n "${ORY_JWKS_SETS:-}" ]; then
     echo "# JWKS imports put PRIVATE keys into the Terraform state. Handle with care."
-    IFS=',' read -r -a SETS <<<"$ORY_JWKS_SETS"
-    for set in "${SETS[@]}"; do
-      set=$(echo "$set" | sed -e 's/^ *//' -e 's/ *$//')
-      [ -z "$set" ] && continue
-      if admin_get "/admin/keys/$set" >/dev/null; then
-        emit "ory_json_web_key_set.$(sanitize "$set")" "$ORY_PROJECT_ID/$set"
+    IFS=',' read -r -a JWKS_SETS <<<"$ORY_JWKS_SETS"
+    for jwks_set in "${JWKS_SETS[@]}"; do
+      jwks_set=$(echo "$jwks_set" | sed -e 's/^ *//' -e 's/ *$//')
+      [ -z "$jwks_set" ] && continue
+      # The set id becomes a path segment, so it has to be percent-encoded.
+      jwks_set_encoded=$(jq -rn --arg s "$jwks_set" '$s | @uri')
+      if admin_get "/admin/keys/$jwks_set_encoded" >/dev/null; then
+        emit "ory_json_web_key_set.$(unique_label "$(sanitize "$jwks_set")")" "$ORY_PROJECT_ID/$jwks_set"
       else
-        log "WARN: JWKS set '$set' not found, skipping"
+        log "WARN: JWKS set '$jwks_set' not found, skipping"
       fi
     done
   else
@@ -295,7 +566,7 @@ if [ -n "${ORY_PROJECT_API_KEY:-}" ]; then
 
   # Identities: data, not configuration. Report the count only (first page).
   if IDENTITIES=$(admin_get "/admin/identities?page_size=250"); then
-    IDENTITY_COUNT=$(echo "$IDENTITIES" | jq 'length')
+    IDENTITY_COUNT=$(echo "$IDENTITIES" | jq 'if type == "array" then length else 0 end')
     SUFFIX=""
     if [ "$IDENTITY_COUNT" -gt 0 ]; then
       [ "$IDENTITY_COUNT" = "250" ] && SUFFIX="+"

--- a/internal/provider/import_skill_script_test.go
+++ b/internal/provider/import_skill_script_test.go
@@ -1,0 +1,306 @@
+package provider
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The inventory script in the import-existing-project skill walks a project
+// revision with jq. Every jq expression that indexes a nested key aborts the
+// whole run when the key holds an unexpected type, and because the script sets
+// `set -euo pipefail`, an abort truncates imports.tf after a partial write. The
+// result looks like a complete inventory and is not one.
+//
+// These tests feed the script's own jq programs the revision shapes that used to
+// crash them. They read the programs out of the script so a future edit cannot
+// pass the test while breaking the script.
+
+const skillScriptRelPath = "../../.claude/skills/import-existing-project/scripts/generate-imports.sh"
+
+func requireJQ(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq is not installed; skipping inventory script jq tests")
+	}
+}
+
+func readSkillScript(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Clean(skillScriptRelPath))
+	require.NoError(t, err, "the import skill inventory script must ship with the provider")
+	return string(b)
+}
+
+// extractSingleQuoted returns the body of a single-quoted shell assignment,
+// for example ACTIONS_JQ='...'. jq programs are stored that way so the shell
+// leaves their $variables alone.
+func extractSingleQuoted(t *testing.T, script, varName string) string {
+	t.Helper()
+	marker := varName + "='"
+	start := strings.Index(script, marker)
+	require.GreaterOrEqual(t, start, 0, "%s is not assigned in the inventory script", varName)
+	rest := script[start+len(marker):]
+	end := strings.Index(rest, "'")
+	require.GreaterOrEqual(t, end, 0, "%s is not terminated", varName)
+	program := rest[:end]
+	require.NotEmpty(t, strings.TrimSpace(program), "%s is empty", varName)
+	return program
+}
+
+// runJQ pipes input through a jq program and returns its compact output. A jq
+// failure is returned as an error so a test can assert the program no longer
+// aborts on a given shape.
+func runJQ(t *testing.T, program, input string) (string, error) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "jq", "-c", program)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// obj is a shorthand for a decoded JSON object.
+type obj = map[string]any
+
+// identityRevision wraps an identity service config the way GET /projects/{id}
+// returns it, and marshals it. Building the JSON instead of writing it by hand
+// keeps a miscounted brace from masquerading as a jq failure.
+func identityRevision(t *testing.T, config obj) string {
+	t.Helper()
+	b, err := json.Marshal(obj{"services": obj{"identity": obj{"config": config}}})
+	require.NoError(t, err)
+	return string(b)
+}
+
+// flowsConfig nests a flows map at the path the provider reads it from.
+func flowsConfig(flows obj) obj {
+	return obj{"selfservice": obj{"flows": flows}}
+}
+
+// hookURL is the webhook target every actions fixture uses. The jq program
+// treats it as an opaque string, so one value covers every case.
+const hookURL = "https://a.test"
+
+func webHook() obj {
+	return obj{"hook": "web_hook", "config": obj{"url": hookURL, "method": "POST"}}
+}
+
+func TestImportSkillActionsJQToleratesUnexpectedShapes(t *testing.T) {
+	requireJQ(t)
+	program := extractSingleQuoted(t, readSkillScript(t), "ACTIONS_JQ")
+
+	tests := []struct {
+		name   string
+		config obj
+		want   string
+	}{
+		{
+			// default_browser_return_url is a real project_config attribute and a
+			// scalar sibling of the auth-method objects under "after". Indexing it
+			// used to abort with `Cannot index string with string ("hooks")`.
+			name: "scalar sibling under after",
+			config: flowsConfig(obj{"login": obj{"after": obj{
+				"default_browser_return_url": "https://x.test",
+				"password":                   obj{"hooks": []any{webHook()}},
+			}}}),
+			want: `[{"label":"login_after_password","id":"login:after:password:POST:https://a.test"}]`,
+		},
+		{
+			// login scopes its after hooks by auth method, so a flat array there is
+			// unreachable for ory_action and must not be emitted at all.
+			name: "flat after hooks on login are dropped",
+			config: flowsConfig(obj{"login": obj{"after": obj{
+				"hooks": []any{webHook()},
+			}}}),
+			want: `[]`,
+		},
+		{
+			// verification does not scope by auth method, so the "_" placeholder is
+			// correct there.
+			name: "flat after hooks on verification keep the placeholder",
+			config: flowsConfig(obj{"verification": obj{"after": obj{
+				"hooks": []any{webHook()},
+			}}}),
+			want: `[{"label":"verification_after","id":"verification:after:_:POST:https://a.test"}]`,
+		},
+		{
+			name: "before hooks",
+			config: flowsConfig(obj{"login": obj{"before": obj{
+				"hooks": []any{webHook()},
+			}}}),
+			want: `[{"label":"login_before","id":"login:before:POST:https://a.test"}]`,
+		},
+		{
+			name:   "flows missing entirely",
+			config: obj{},
+			want:   `[]`,
+		},
+		{
+			name:   "flows is not an object",
+			config: obj{"selfservice": obj{"flows": "nope"}},
+			want:   `[]`,
+		},
+		{
+			name:   "after is not an object",
+			config: flowsConfig(obj{"login": obj{"after": "nope"}}),
+			want:   `[]`,
+		},
+		{
+			name: "hook entry is not an object",
+			config: flowsConfig(obj{"login": obj{"after": obj{
+				"password": obj{"hooks": []any{"nope"}},
+			}}}),
+			want: `[]`,
+		},
+		{
+			// A hook with no config.url would build an import ID ending in "null".
+			name: "hook without a url is skipped",
+			config: flowsConfig(obj{"login": obj{"after": obj{
+				"password": obj{"hooks": []any{obj{"hook": "web_hook", "config": obj{"method": "POST"}}}},
+			}}}),
+			want: `[]`,
+		},
+		{
+			name: "non-webhook hooks are skipped",
+			config: flowsConfig(obj{"settings": obj{"after": obj{
+				"profile": obj{"hooks": []any{obj{"hook": "verify_new_address"}}},
+			}}}),
+			want: `[]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := runJQ(t, program, identityRevision(t, tt.config))
+			require.NoError(t, err, "the actions program must not abort on this shape: %s", got)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// The remaining sections build their jq inline, so these tests assert the
+// property that matters: the script survives a revision holding each shape and
+// still writes a complete file. Running the whole script needs network access,
+// so the check is on the inline programs the script actually contains.
+func TestImportSkillInlineJQToleratesUnexpectedShapes(t *testing.T) {
+	requireJQ(t)
+	script := readSkillScript(t)
+
+	permissionRevision := func(config obj) string {
+		b, err := json.Marshal(obj{"services": obj{"permission": obj{"config": config}}})
+		require.NoError(t, err)
+		return string(b)
+	}
+	methodProviders := func(method string, providers []any) obj {
+		return obj{"selfservice": obj{"methods": obj{method: obj{"config": obj{"providers": providers}}}}}
+	}
+
+	tests := []struct {
+		name string
+		// needle is a distinctive fragment of the inline jq, used to prove the
+		// script still contains the guarded form rather than a regressed one.
+		needle string
+		input  string
+	}{
+		{
+			// namespaces is either an array of {name, id} or an object holding a
+			// "location" URL. Indexing the object shape as an array aborted jq.
+			name:   "keto namespaces as a location object",
+			needle: `if type == "array" then [.[] | select(type == "object") | .name | select(type == "string")]`,
+			input:  permissionRevision(obj{"namespaces": obj{"location": "base64://abc"}}),
+		},
+		{
+			// A schema entry without a string id aborted startswith().
+			name:   "identity schema entry without a string id",
+			needle: `select(startswith("preset://") | not)`,
+			input: identityRevision(t, obj{"identity": obj{"schemas": []any{
+				obj{"url": "https://x"},
+			}}}),
+		},
+		{
+			// A scalar under courier.templates.<base> aborted to_entries.
+			name:   "courier template group as a scalar",
+			needle: `select(.key == "valid" or .key == "invalid")`,
+			input:  identityRevision(t, obj{"courier": obj{"templates": obj{"recovery_code": "nope"}}}),
+		},
+		{
+			name:   "oidc providers array holding a scalar",
+			needle: `.services.identity.config.selfservice.methods.oidc.config.providers[]?`,
+			input:  identityRevision(t, methodProviders("oidc", []any{"nope"})),
+		},
+		{
+			name:   "saml providers array holding a scalar",
+			needle: `.services.identity.config.selfservice.methods.saml.config.providers[]?`,
+			input:  identityRevision(t, methodProviders("saml", []any{"nope"})),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Contains(t, script, tt.needle,
+				"the inventory script no longer contains the guarded form this test covers")
+			program := inlineJQContaining(t, script, tt.needle)
+			got, err := runJQ(t, program, tt.input)
+			require.NoError(t, err, "the program must not abort on this shape: %s", got)
+		})
+	}
+}
+
+// inlineJQContaining reconstructs the single-quoted jq program surrounding a
+// needle. The script writes these as jq -c '...' or $(... | jq -c '...'), so the
+// program is delimited by the single quotes on either side of the needle.
+func inlineJQContaining(t *testing.T, script, needle string) string {
+	t.Helper()
+	idx := strings.Index(script, needle)
+	require.GreaterOrEqual(t, idx, 0)
+	start := strings.LastIndex(script[:idx], "'")
+	require.GreaterOrEqual(t, start, 0, "no opening quote before the needle")
+	rest := script[start+1:]
+	end := strings.Index(rest, "'")
+	require.GreaterOrEqual(t, end, 0, "no closing quote after the needle")
+	return rest[:end]
+}
+
+// The script emits Terraform addresses built from user-controlled strings.
+// sanitize collapses every run of non-alphanumerics to "_", so two different
+// provider IDs can land on the same label and Terraform then rejects the file
+// for duplicate import blocks. unique_label has to dedupe across subshells,
+// because every call site invokes it inside a command substitution.
+func TestImportSkillScriptDedupesLabels(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not installed; skipping inventory script helper tests")
+	}
+	scriptPath, err := filepath.Abs(filepath.Clean(skillScriptRelPath))
+	require.NoError(t, err)
+
+	// Source only the helper block, then exercise it the way the script does.
+	harness := `
+set -euo pipefail
+RUN_DIR=$(mktemp -d); LABELS_FILE="$RUN_DIR/labels"; : >"$LABELS_FILE"
+eval "$(sed -n '/^# Turn an arbitrary string into a valid Terraform/,/^emit() {/p' "$1" | sed '$d')"
+printf '%s %s %s %s\n' \
+  "$(unique_label "$(sanitize 'google-1')")" \
+  "$(unique_label "$(sanitize 'google_1')")" \
+  "$(unique_label "$(sanitize 'google 1')")" \
+  "$(unique_label "$(sanitize 'github')")"
+printf '%s %s\n' "$(hcl_escape 'a"b')" "$(hcl_escape 'a\b')"
+rm -rf "$RUN_DIR"
+`
+	cmd := exec.CommandContext(t.Context(), "bash", "-c", harness, "harness", scriptPath)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "helper harness failed: %s", out)
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	require.Len(t, lines, 2, "unexpected harness output: %s", out)
+
+	assert.Equal(t, "google_1 google_1_2 google_1_3 github", lines[0],
+		"colliding labels must be suffixed so Terraform addresses stay unique")
+	assert.Equal(t, `a\"b a\\b`, lines[1],
+		"a quote or backslash in an import ID must be escaped for HCL")
+}


### PR DESCRIPTION
## Description

`generate-imports.sh` could abort partway through and leave a truncated `imports.tf` that looks complete. Five jq expressions index a nested key without checking its type, and the script runs under `set -euo pipefail`, so each one kills the run after part of the file is already on stdout.

The common case needs no unusual project. Any flow with `default_browser_return_url` set, which is the Console default for most projects, aborts the actions block:

```
jq: error: Cannot index string with string ("hooks")
```

That attribute is a scalar sibling of the auth-method objects under `after`, and the old jq indexed every sibling looking for `hooks`.

### Crashes fixed

| Shape | Old behaviour |
|---|---|
| A scalar sibling of the auth-method objects under `after` | `Cannot index string with string ("hooks")` |
| Keto `namespaces` in its `{location: url}` object shape | `Cannot index string with string ("name")` |
| An identity schema entry whose `id` is absent or not a string | `startswith() requires string inputs` |
| A courier template group that is a scalar | `string ("nope") has no keys` |
| An `oidc` or `saml` providers array holding a non-object | indexes a string |

`console_get` treated any JSON error body as fatal, so a plan-gated `403 feature_not_available` on `/cname`, `/eventstreams`, or `/organizations` aborted the run. Those are exactly the endpoints the skill's own text calls plan-gated. They now degrade to a warning. `curl` exits 0 on a 4xx, so the HTTP status is captured explicitly instead of sniffing for an `.error` key, which previously let a non-JSON error body through as data and crashed a downstream jq with no indication of which request failed.

### Wrong output fixed

- **A flat `after.hooks` array was emitted with the `_` auth-method placeholder on any flow.** The provider resolves `_` to the default `password` and then reads `.../after/password/hooks` (`internal/resources/action/resource.go:775-780`), so on `login`, `registration`, and `settings` the import always failed with `Cannot import non-existent remote object`. Those hooks are now reported as unimportable, with the reason, instead of becoming a doomed import block.
- **The label dedupe and the pagination cursor were both inert.** Each lived in a shell variable, but every call site runs inside `$( )` or a `... | while read` pipeline, so the assignment never reached the caller. Colliding labels were never suffixed and collections never paginated past page 1. Both now use files. Trusted JWT grant issuers had no `page_size` at all and silently lost everything past the API's default of 250.

### Also

Refuses to run against a soft-deleted project, because `GET /projects/{id}` returns HTTP 200 with `state = "deleted"` and every emitted block would then fail while each request succeeded. Escapes quotes and backslashes in import IDs, which embed arbitrary webhook URLs. Percent-encodes JWKS set ids used as path segments. Validates email template types against the resource's closed enum of 12. Merges the console identity-schema list, which holds workspace-scoped schemas the project revision omits, the same two sources `ory_identity_schemas` merges. Flags B2B SSO providers so their organization gets imported alongside them.

## Related Issues

No issue. Found while auditing the skill against the ~40 provider commits since it landed in #283. The documentation half of that audit is in a separate PR so this one stays reviewable.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [ ] Acceptance tests
- [x] Manual testing

**Every crash was reproduced before being fixed.** Each row in the table above was confirmed with the old jq against a minimal fixture, and the exact error messages quoted are the ones jq produced.

**New Go tests in `internal/provider/import_skill_script_test.go`.** They read the jq programs and shell helpers out of the script itself, so a future edit cannot pass the test while breaking the script. 21 cases across three tests cover every crash shape, both auth-method placeholder outcomes, the label dedupe across subshells, and HCL escaping. They skip when `jq` or `bash` is absent.

Two of those tests caught bugs in my own first draft: a jq function argument that evaluated `.key` after a pipe rather than against the entry object, and the dedupe helper still being inert because I had kept it in a variable.

**Live run against a real project.** Ran end to end against the staging smoke project. Exit 0, and the output passes `terraform fmt -check` as canonically formatted HCL with no duplicate targets. The script is read-only, so no lock on the shared test project was needed.

`make build`, `make format` (0 lint issues), `make test-short`, and `shellcheck` (clean) all pass.

Acceptance tests were not run. The change touches no provider code, only the skill script and a unit test.

## Screenshots/Output

Before, on a project with a flow-level default redirect URL:

```
jq: error (at <unknown>): Cannot index string with string ("hooks")
```

followed by a partial `imports.tf` and a non-zero exit.

After, on the same project:

```
Inventorying project ... ...
custom domains: 0
event streams: 0
organizations: 9
project API keys: 3 (commented out)
identity schemas (not importable): 10
keto namespaces: 4
identities: 1 (not imported)
Done. Review the emitted blocks, then run: terraform plan -generate-config-out=generated.tf
```
