### PR TITLE
fix(project-config): treat the OIDC pairwise salt as a write-only sensitive secret

### DIFF
--- a/.claude/skills/import-existing-project/SKILL.md
+++ b/.claude/skills/import-existing-project/SKILL.md
@@ -125,8 +125,9 @@ import block, note it, and hand-write that resource later.
   (values come back masked or absent). Wire them to `variable` blocks marked `sensitive`, or use the
   write-only variants (`client_secret_wo`, `smtp_connection_uri_wo`, ...) with
   `*_wo_version` to keep them out of state entirely.
-  `courier_http_request_config_auth_basic_auth_password` and
-  `courier_http_request_config_auth_api_key_value` behave the same way but have
+  `courier_http_request_config_auth_basic_auth_password`,
+  `courier_http_request_config_auth_api_key_value`, and
+  `oidc_subject_identifiers_pairwise_salt` behave the same way but have
   **no** `_wo` variant, so they must come from a `sensitive` variable.
   `smtp_connection_uri_wo` is the only write-only argument on
   `ory_project_config`.
@@ -151,7 +152,7 @@ import block, note it, and hand-write that resource later.
   | `enable_ax_v2` | `.services.account_experience.config.enabled` |
   | `disable_account_experience_welcome_screen` | no service config at all; only `GET /normalized/projects/{id}` |
   | `selfservice_methods_code_config_max_submissions` | reported under `...code.config.max_submissions`, written to `...code.max_submissions` |
-  | `oidc_subject_identifiers_pairwise_salt` | reported under `oidc.subject_identifiers.pairwise.salt` |
+  | `oidc_subject_identifiers_pairwise_salt` | a redacted secret; write-only in the provider, so re-supply it from your secret store |
   | `courier_http_request_config_body` | a `https://storage.googleapis.com/.../<sha512>.jsonnet` URL, never the payload |
 
   Do **not** copy the `courier_http_request_config_body` URL into config. The
@@ -237,8 +238,9 @@ explicit `{project_id}/...` form in generated files.
   explicitly added to the project, so the plural data source and the console
   `GET /identity-schemas` endpoint see workspace-scoped schemas the revision
   omits.
-- **Secrets never round-trip.** SMTP connection URI, social/SAML client
-  secrets, SCIM client secrets, OAuth2 client secrets, tokenizer template keys:
+- **Secrets never round-trip.** SMTP connection URI, pairwise subject
+  identifier salt, social/SAML client secrets, SCIM client secrets, OAuth2
+  client secrets, tokenizer template keys:
   re-supply via variables or write-only `*_wo` arguments. Until you do, some of
   these show a perpetual diff or import as empty.
 - **`ory_scim_client` imports with an empty secret and a stored mapper URL.**

--- a/docs/resources/project_config.md
+++ b/docs/resources/project_config.md
@@ -18,7 +18,7 @@ This resource supports drift detection — `terraform plan` will detect changes 
 
 ~> **Note:** Only attributes present in your Terraform configuration are tracked for drift. Attributes you have not configured will not appear in plan output, even if they have non-default values in the API.
 
-~> **Not drift-checked:** A few attributes are accepted by the Ory API but never returned by it, so the provider keeps the configured value instead of reporting a change that no apply could settle. Removing one of these outside Terraform is not detected. They are `session_earliest_possible_extend`, `selfservice_methods_webauthn_config_rp_icon`, and `selfservice_methods_captcha_config_byo`. The same applies to secrets the API redacts, such as `smtp_connection_uri` and the courier HTTP auth credentials.
+~> **Not drift-checked:** A few attributes are accepted by the Ory API but never returned by it, so the provider keeps the configured value instead of reporting a change that no apply could settle. Removing one of these outside Terraform is not detected. They are `session_earliest_possible_extend`, `selfservice_methods_webauthn_config_rp_icon`, and `selfservice_methods_captcha_config_byo`. The same applies to secrets the API redacts: `smtp_connection_uri`, the courier HTTP auth credentials, and `oidc_subject_identifiers_pairwise_salt`.
 
 ~> **Empty values:** The Ory API prunes empty values (`""`, `[]`, `{}`, and integer `0`) from the stored configuration: the apply succeeds, but the key never appears in later reads. The provider treats such a missing key as matching an empty configured value, so applying an empty value does not produce a diff on every plan. Drift is still reported whenever your configuration holds a non-empty value. A few attributes substitute a server default instead of storing the empty value — `account_experience_enabled_locales`, `selfservice_methods_passkey_config_rp_origins`, `webauthn_rp_origins` (default origins derived from the project slug), and `selfservice_methods_totp_config_issuer` (defaults to the project name). For those, plan keeps reporting the substituted default as a change, so omit the attribute instead of setting it empty.
 
@@ -477,6 +477,21 @@ The `smtp_connection_uri` attribute selects the SMTP security mode through the U
 
 For more detail, see the [Ory Kratos SMTP documentation](https://www.ory.com/docs/kratos/emails-sms/sending-emails-smtp).
 
+## Pairwise Subject Identifier Salt
+
+`oidc_subject_identifiers_pairwise_salt` is the secret input to the pairwise subject identifier hash. Set it together with `oidc_subject_identifiers_supported_types`:
+
+```hcl
+resource "ory_project_config" "main" {
+  oidc_subject_identifiers_supported_types = ["public", "pairwise"]
+  oidc_subject_identifiers_pairwise_salt   = var.pairwise_salt
+}
+```
+
+-> **Write-only:** The Ory API treats the salt as a secret and redacts it from project revision responses. The provider therefore treats `oidc_subject_identifiers_pairwise_salt` as write-only: it is sent on create and update but never read back, so the value in your configuration is authoritative. Out-of-band changes to the salt are not detected, and `terraform import` leaves the attribute unset until you add it to your configuration.
+
+~> **Rotation:** Changing the salt changes every pairwise subject identifier the project has issued, so relying parties that store the `sub` claim lose the link to the user. An empty value does not clear the salt: the API keeps the stored one.
+
 ## Verification After Registration / Settings
 
 Three boolean attributes toggle the [`show_verification_ui`](https://www.ory.com/docs/kratos/self-service/flows/user-registration) post-flow hook for each authentication method:
@@ -752,7 +767,7 @@ terraform plan  # verify no changes
 - `oauth2_webfinger_oidc_discovery_userinfo_url` (String) Override the userinfo endpoint URL in OIDC discovery.
 - `oidc_dynamic_client_registration_default_scope` (List of String) Default OAuth2 scopes granted to dynamically registered clients.
 - `oidc_dynamic_client_registration_enabled` (Boolean) Enable OpenID Connect dynamic client registration.
-- `oidc_subject_identifiers_pairwise_salt` (String) Salt for the OIDC pairwise subject identifier algorithm.
+- `oidc_subject_identifiers_pairwise_salt` (String, Sensitive) Salt for the OIDC pairwise subject identifier algorithm. Write-only: the Ory API treats the salt as a secret and redacts it from project revision responses, so the provider sends it on create and update but never reads it back, and out-of-band changes are not detected. Changing the salt changes every pairwise subject identifier the project has issued. An empty value keeps the stored salt.
 - `oidc_subject_identifiers_supported_types` (List of String) Supported OIDC subject identifier types ('public', 'pairwise').
 - `password_check_haveibeenpwned` (Boolean, Deprecated) Check passwords against HaveIBeenPwned.
 - `password_identifier_similarity` (Boolean, Deprecated) Check password similarity to identifier.

--- a/internal/codegen/mappings.yaml
+++ b/internal/codegen/mappings.yaml
@@ -673,12 +673,19 @@ attributes:
     go_field: OIDCSubjectIdentifiersPairwiseSalt
     type: string
     openapi_property: hydra_oidc_subject_identifiers_pairwise_salt
-    # Writes go to the spec's governs path,
-    # "oidc.subject_identifiers.pairwise_salt", but the API reports the value
-    # back under the nested "oidc.subject_identifiers.pairwise.salt". Verified
-    # 2026-08-03 on a throwaway prod project.
-    read_path: /services/oauth2/config/oidc/subject_identifiers/pairwise/salt
-    description: "Salt for the OIDC pairwise subject identifier algorithm."
+    description: "Salt for the OIDC pairwise subject identifier algorithm. Write-only: the Ory API treats the salt as a secret and redacts it from project revision responses, so the provider sends it on create and update but never reads it back, and out-of-band changes are not detected. Changing the salt changes every pairwise subject identifier the project has issued. An empty value keeps the stored salt."
+    sensitive: true
+    # The salt is the only secret input to the pairwise subject identifier
+    # hash, and the API redacts it from project revision responses. Reading it
+    # back would null or blank the configured value and cause a perpetual
+    # diff, so it is write-only: sent on create/update at the spec's
+    # governs path "oidc.subject_identifiers.pairwise_salt", never read into
+    # state. Before the redaction the API reported the value under the nested
+    # "oidc.subject_identifiers.pairwise.salt", which needed read_path; the
+    # write-only read makes that moot. Verified 2026-09-07 on a throwaway prod
+    # project: an unrelated patch and an empty write both keep the stored salt,
+    # and a non-empty write rotates it.
+    write_only: true
 
   - name: oauth2_urls_post_logout_redirect
     go_field: OAuth2UrlsPostLogoutRedirect

--- a/internal/resources/projectconfig/generated_test.go
+++ b/internal/resources/projectconfig/generated_test.go
@@ -527,3 +527,66 @@ func TestGeneratedReadEntries_MissingKeySemantics(t *testing.T) {
 		}
 	})
 }
+
+// TestOIDCSubjectIdentifiersPairwiseSalt_WriteOnly verifies the pairwise
+// subject identifier salt is treated as write-only: it stays in the schema as a
+// sensitive attribute and in the patch table, so create and update still send
+// it, but it never reaches the read tables. The Ory API redacts the salt from
+// project revision responses, and before the redaction it reported the value
+// under the nested oidc.subject_identifiers.pairwise.salt. Neither a missing
+// key nor an empty, masked, or rotated value at that path may overwrite the
+// configured value, otherwise every plan would show a diff no apply can settle.
+func TestOIDCSubjectIdentifiersPairwiseSalt_WriteOnly(t *testing.T) {
+	const configured = "configured-pairwise-salt"
+
+	// 1. The schema keeps the attribute and masks it in plan output.
+	attr, ok := simpleSchemaAttributes()["oidc_subject_identifiers_pairwise_salt"].(schema.StringAttribute)
+	require.True(t, ok, "oidc_subject_identifiers_pairwise_salt must be a generated string attribute")
+	assert.True(t, attr.Sensitive, "oidc_subject_identifiers_pairwise_salt must be sensitive")
+
+	// 2. The patch table still carries the write at the spec's governs path.
+	plan := &ProjectConfigResourceModel{
+		OIDCSubjectIdentifiersPairwiseSalt: types.StringValue(configured),
+	}
+	var patchPath string
+	for _, e := range simpleStringPatchEntries(plan) {
+		if e.Field == &plan.OIDCSubjectIdentifiersPairwiseSalt {
+			patchPath = e.Path
+		}
+	}
+	assert.Equal(t, "/services/oauth2/config/oidc/subject_identifiers/pairwise_salt", patchPath,
+		"oidc_subject_identifiers_pairwise_salt must still be sent on create/update")
+
+	// 3. It must be excluded from the generated read entries entirely.
+	state := &ProjectConfigResourceModel{
+		OIDCSubjectIdentifiersPairwiseSalt: types.StringValue(configured),
+	}
+	for _, e := range oauth2StringReadEntries(state) {
+		assert.NotSame(t, &state.OIDCSubjectIdentifiersPairwiseSalt, e.Field,
+			"oidc_subject_identifiers_pairwise_salt must not appear in read entries, it is write-only")
+	}
+
+	// 4. readSimpleFields must preserve the configured value regardless of what
+	//    the API reports under oidc.subject_identifiers: a missing key, an empty
+	//    or masked value, or a salt rotated out of band.
+	for name, subjectIdentifiers := range map[string]map[string]interface{}{
+		"absent":           {"supported_types": []interface{}{"public", "pairwise"}},
+		"empty":            {"pairwise": map[string]interface{}{"salt": ""}},
+		"masked":           {"pairwise": map[string]interface{}{"salt": "****"}},
+		"rotated":          {"pairwise": map[string]interface{}{"salt": "rotated-out-of-band"}},
+		"no oauth2 config": nil,
+	} {
+		st := &ProjectConfigResourceModel{
+			OIDCSubjectIdentifiersPairwiseSalt: types.StringValue(configured),
+		}
+		project := &ory.Project{Services: ory.ProjectServices{}}
+		if subjectIdentifiers != nil {
+			project.Services.Oauth2 = &ory.ProjectServiceOAuth2{Config: map[string]interface{}{
+				"oidc": map[string]interface{}{"subject_identifiers": subjectIdentifiers},
+			}}
+		}
+		readSimpleFields(context.Background(), project, st)
+		assert.Equal(t, configured, st.OIDCSubjectIdentifiersPairwiseSalt.ValueString(),
+			"configured oidc_subject_identifiers_pairwise_salt must be preserved when the API reports %s", name)
+	}
+}

--- a/internal/resources/projectconfig/read_gen.go
+++ b/internal/resources/projectconfig/read_gen.go
@@ -651,7 +651,6 @@ func oauth2StringReadEntries(state *ProjectConfigResourceModel) []StringReadEntr
 		{&state.OAuth2GrantRefreshTokenRotationGracePeriod, nil, []string{"oauth2", "grant", "refresh_token", "rotation_grace_period"}, false, false, false},
 		{&state.OAuth2RefreshTokenHook, nil, []string{"oauth2", "refresh_token_hook"}, false, false, false},
 		{&state.OAuth2TokenHook, nil, []string{"oauth2", "token_hook", "url"}, false, false, false},
-		{&state.OIDCSubjectIdentifiersPairwiseSalt, nil, []string{"oidc", "subject_identifiers", "pairwise", "salt"}, false, false, false},
 		{&state.OAuth2UrlsPostLogoutRedirect, nil, []string{"urls", "post_logout_redirect"}, false, false, false},
 		{&state.OAuth2UrlsRegistration, nil, []string{"urls", "registration"}, false, false, false},
 		{&state.OAuth2WebfingerOIDCDiscoveryAuthURL, nil, []string{"webfinger", "oidc_discovery", "auth_url"}, false, false, false},

--- a/internal/resources/projectconfig/read_simple_fields_test.go
+++ b/internal/resources/projectconfig/read_simple_fields_test.go
@@ -184,15 +184,17 @@ func TestReadSimpleFields_PreservesPreserveOnMissingFieldsWhenAPIOmitsKey(t *tes
 	}
 }
 
-// The pairwise salt is written to oidc.subject_identifiers.pairwise_salt but
-// reported back under the nested oidc.subject_identifiers.pairwise.salt, so the
-// read table uses read_path. Reading the write path instead would null a value
-// the API did return and produce a diff on every plan.
-func TestReadSimpleFields_ReadsPairwiseSaltFromReportedPath(t *testing.T) {
-	const salt = "reported-pairwise-salt"
+// The pairwise salt is a write-only secret: the API redacts it from project
+// revision responses, so the read tables omit it. Before the redaction the API
+// reported the salt under the nested oidc.subject_identifiers.pairwise.salt and
+// the read table followed it there with read_path. A value at that path must
+// not overwrite the configured salt any more, otherwise a redacted or rotated
+// response would show a diff on every plan.
+func TestReadSimpleFields_PreservesPairwiseSaltReportedAtLegacyPath(t *testing.T) {
+	const configured = "configured-pairwise-salt"
 
 	state := &ProjectConfigResourceModel{
-		OIDCSubjectIdentifiersPairwiseSalt: types.StringValue("stale-salt"),
+		OIDCSubjectIdentifiersPairwiseSalt: types.StringValue(configured),
 	}
 
 	project := &ory.Project{
@@ -200,7 +202,7 @@ func TestReadSimpleFields_ReadsPairwiseSaltFromReportedPath(t *testing.T) {
 			Oauth2: &ory.ProjectServiceOAuth2{Config: map[string]interface{}{
 				"oidc": map[string]interface{}{
 					"subject_identifiers": map[string]interface{}{
-						"pairwise": map[string]interface{}{"salt": salt},
+						"pairwise": map[string]interface{}{"salt": "rotated-out-of-band"},
 					},
 				},
 			}},
@@ -208,8 +210,8 @@ func TestReadSimpleFields_ReadsPairwiseSaltFromReportedPath(t *testing.T) {
 	}
 	readSimpleFields(context.Background(), project, state)
 
-	if got := state.OIDCSubjectIdentifiersPairwiseSalt.ValueString(); got != salt {
-		t.Errorf("pairwise_salt = %q, want the value the API reported at pairwise.salt", got)
+	if got := state.OIDCSubjectIdentifiersPairwiseSalt.ValueString(); got != configured {
+		t.Errorf("pairwise_salt = %q, want the configured value preserved", got)
 	}
 }
 

--- a/internal/resources/projectconfig/resource_test.go
+++ b/internal/resources/projectconfig/resource_test.go
@@ -1333,13 +1333,16 @@ func TestAccProjectConfigResource_emailVerificationHooks(t *testing.T) {
 }
 
 func TestAccProjectConfigResource_oauth2Advanced(t *testing.T) {
-	// The pairwise salt is here to cover its read path. The API accepts the write
-	// at oidc.subject_identifiers.pairwise_salt and reports the value back under
-	// the nested oidc.subject_identifiers.pairwise.salt, so reading the write
-	// path would null a value the API did return. The PlanOnly step is what
-	// catches that.
+	// The pairwise salt is a write-only secret. The API accepts the write at
+	// oidc.subject_identifiers.pairwise_salt and redacts the salt from project
+	// revision responses, so the provider never reads it back and state holds
+	// the configured value. The PlanOnly steps prove that neither the create
+	// nor the rotation leaves a diff, and the import step ignores the attribute
+	// because a redacted secret cannot be imported.
 	const salt = "tf-acc-pairwise-salt"
+	const rotatedSalt = "tf-acc-pairwise-salt-rotated"
 	templateData := map[string]string{"PairwiseSalt": salt}
+	rotatedData := map[string]string{"PairwiseSalt": rotatedSalt}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccPreCheck(t) },
@@ -1355,9 +1358,21 @@ func TestAccProjectConfigResource_oauth2Advanced(t *testing.T) {
 					resource.TestCheckResourceAttr("ory_project_config.test", "oidc_subject_identifiers_pairwise_salt", salt),
 				),
 			},
-			// Verify no perpetual diff, which is the read-path assertion
+			// Verify no perpetual diff: the redacted salt must not null state
 			{
 				Config:             acctest.LoadTestConfig(t, "testdata/oauth2_advanced.tf.tmpl", templateData),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Rotate the salt: update sends the new value and state follows the plan
+			{
+				Config: acctest.LoadTestConfig(t, "testdata/oauth2_advanced.tf.tmpl", rotatedData),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ory_project_config.test", "oidc_subject_identifiers_pairwise_salt", rotatedSalt),
+				),
+			},
+			{
+				Config:             acctest.LoadTestConfig(t, "testdata/oauth2_advanced.tf.tmpl", rotatedData),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},

--- a/internal/resources/projectconfig/schema_gen.go
+++ b/internal/resources/projectconfig/schema_gen.go
@@ -626,8 +626,9 @@ func simpleSchemaAttributes() map[string]schema.Attribute {
 			Optional:    true,
 		},
 		"oidc_subject_identifiers_pairwise_salt": schema.StringAttribute{
-			Description: "Salt for the OIDC pairwise subject identifier algorithm.",
+			Description: "Salt for the OIDC pairwise subject identifier algorithm. Write-only: the Ory API treats the salt as a secret and redacts it from project revision responses, so the provider sends it on create and update but never reads it back, and out-of-band changes are not detected. Changing the salt changes every pairwise subject identifier the project has issued. An empty value keeps the stored salt.",
 			Optional:    true,
+			Sensitive:   true,
 		},
 		"oauth2_urls_post_logout_redirect": schema.StringAttribute{
 			Description: "Default redirect URL after OAuth2 logout.",

--- a/templates/resources/project_config.md.tmpl
+++ b/templates/resources/project_config.md.tmpl
@@ -18,7 +18,7 @@ This resource supports drift detection — `terraform plan` will detect changes 
 
 ~> **Note:** Only attributes present in your Terraform configuration are tracked for drift. Attributes you have not configured will not appear in plan output, even if they have non-default values in the API.
 
-~> **Not drift-checked:** A few attributes are accepted by the Ory API but never returned by it, so the provider keeps the configured value instead of reporting a change that no apply could settle. Removing one of these outside Terraform is not detected. They are `session_earliest_possible_extend`, `selfservice_methods_webauthn_config_rp_icon`, and `selfservice_methods_captcha_config_byo`. The same applies to secrets the API redacts, such as `smtp_connection_uri` and the courier HTTP auth credentials.
+~> **Not drift-checked:** A few attributes are accepted by the Ory API but never returned by it, so the provider keeps the configured value instead of reporting a change that no apply could settle. Removing one of these outside Terraform is not detected. They are `session_earliest_possible_extend`, `selfservice_methods_webauthn_config_rp_icon`, and `selfservice_methods_captcha_config_byo`. The same applies to secrets the API redacts: `smtp_connection_uri`, the courier HTTP auth credentials, and `oidc_subject_identifiers_pairwise_salt`.
 
 ~> **Empty values:** The Ory API prunes empty values (`""`, `[]`, `{}`, and integer `0`) from the stored configuration: the apply succeeds, but the key never appears in later reads. The provider treats such a missing key as matching an empty configured value, so applying an empty value does not produce a diff on every plan. Drift is still reported whenever your configuration holds a non-empty value. A few attributes substitute a server default instead of storing the empty value — `account_experience_enabled_locales`, `selfservice_methods_passkey_config_rp_origins`, `webauthn_rp_origins` (default origins derived from the project slug), and `selfservice_methods_totp_config_issuer` (defaults to the project name). For those, plan keeps reporting the substituted default as a change, so omit the attribute instead of setting it empty.
 
@@ -119,6 +119,21 @@ The `smtp_connection_uri` attribute selects the SMTP security mode through the U
 -> **Write-only:** The Ory API does not return the SMTP connection URI in project-config responses (it contains credentials). The provider therefore treats `smtp_connection_uri` as write-only — it is sent on create and update but never read back, so the value in your configuration is authoritative. As a result, out-of-band changes to the SMTP URI are not detected, and the attribute will not show a diff if the API omits or masks the value.
 
 For more detail, see the [Ory Kratos SMTP documentation](https://www.ory.com/docs/kratos/emails-sms/sending-emails-smtp).
+
+## Pairwise Subject Identifier Salt
+
+`oidc_subject_identifiers_pairwise_salt` is the secret input to the pairwise subject identifier hash. Set it together with `oidc_subject_identifiers_supported_types`:
+
+```hcl
+resource "ory_project_config" "main" {
+  oidc_subject_identifiers_supported_types = ["public", "pairwise"]
+  oidc_subject_identifiers_pairwise_salt   = var.pairwise_salt
+}
+```
+
+-> **Write-only:** The Ory API treats the salt as a secret and redacts it from project revision responses. The provider therefore treats `oidc_subject_identifiers_pairwise_salt` as write-only: it is sent on create and update but never read back, so the value in your configuration is authoritative. Out-of-band changes to the salt are not detected, and `terraform import` leaves the attribute unset until you add it to your configuration.
+
+~> **Rotation:** Changing the salt changes every pairwise subject identifier the project has issued, so relying parties that store the `sub` claim lose the link to the user. An empty value does not clear the salt: the API keeps the stored one.
 
 ## Verification After Registration / Settings
 


### PR DESCRIPTION
## Description

The Ory API now treats `hydra_oidc_subject_identifiers_pairwise_salt` as a secret and redacts it from project revision responses, the same way it handles the SMTP connection URI and the courier HTTP auth secrets. The provider read the salt back from the project document and stored it as a plain attribute, so the plaintext salt showed up in plan output, and the read would null the configured value and show a diff on every plan once the redaction reaches the project document.

This change marks `oidc_subject_identifiers_pairwise_salt` as `sensitive` and `write_only` in `mappings.yaml`, following the pattern from #269 and #285:

- The attribute stays in the schema and in the patch table, so create and update still send it at the spec's governs path.
- The generated read table no longer carries it, and the `read_path` entry is gone with it. State keeps the configured value whatever the API reports.
- Plan output masks the value.
- The docs gain a "Pairwise Subject Identifier Salt" section that explains the write-only behaviour, the import behaviour, and that changing the salt changes every pairwise subject identifier the project has issued. The import skill guidance lists the salt among the secrets that must be re-supplied.

Out-of-band changes to the salt are no longer detected. That is the same trade-off already made for `smtp_connection_uri`, and it is documented.

## Related Issues

No issue filed. Continues the write-only secret handling from #269 and #285.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the existing code style
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation as needed
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linter (`make format`)

## Testing

Describe how you tested these changes:

- [x] Unit tests
- [x] Acceptance tests
- [x] Manual testing

Unit tests: `TestOIDCSubjectIdentifiersPairwiseSalt_WriteOnly` checks that the attribute is sensitive in the schema, still has its patch entry at `/services/oauth2/config/oidc/subject_identifiers/pairwise_salt`, has no read entry, and that `readSimpleFields` keeps the configured value when the API reports the key missing, empty, masked, or rotated. `TestReadSimpleFields_PreservesPairwiseSaltReportedAtLegacyPath` replaces the old read-path test. `make test-short`, `make format`, and `make sec` pass.

Acceptance test: `TestAccProjectConfigResource_oauth2Advanced` now rotates the salt in a second apply and asserts an empty plan after both the create and the rotation. It passes against the staging test project.

Manual testing against the staging Console API on a throwaway production project:

1. Wrote the salt with `PATCH /projects/{id}` at the governs path. `GET /normalized/projects/{id}` reports the salt as an empty string. An unrelated patch and an empty write both keep the stored salt, and a non-empty write rotates it.
2. Ran the built provider through `dev_overrides` with a config that sets `oidc_subject_identifiers_supported_types` and the salt: apply, empty plan, rotate the salt, empty plan, rotate the salt out of band through the API and confirm the plan stays empty, update an unrelated attribute, `terraform import` into a fresh state followed by a plan that only adds the configured attributes, and destroy. The throwaway project was deleted afterwards.

## Screenshots/Output

```
$ terraform apply -auto-approve
  + resource "ory_project_config" "main" {
      + oauth2_grant_jwt_jti_optional            = true
      + oidc_subject_identifiers_pairwise_salt   = (sensitive value)
      + oidc_subject_identifiers_supported_types = [
          + "public",
          + "pairwise",
        ]
    }
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

$ terraform plan -detailed-exitcode
No changes. Your infrastructure matches the configuration.

$ TF_VAR_pairwise_salt=<rotated> terraform apply -auto-approve
  ~ resource "ory_project_config" "main" {
      ~ oidc_subject_identifiers_pairwise_salt   = (sensitive value)
    }
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

$ go test -tags acceptance -run 'TestAccProjectConfigResource_oauth2Advanced$' ./internal/resources/projectconfig/
--- PASS: TestAccProjectConfigResource_oauth2Advanced (9.58s)
ok      github.com/ory/terraform-provider-ory/internal/resources/projectconfig  10.282s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the OIDC pairwise subject identifier salt is a sensitive, write-only value supplied from a secret store.
  * Documented that rotating the salt changes all pairwise subject identifiers, while an empty value preserves the existing salt.

* **Bug Fixes**
  * Prevented redacted or legacy API responses from overwriting the configured salt.
  * Preserved the salt during imports and subsequent configuration reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->